### PR TITLE
test: improve unit test coverage from 27.6% to 51.9%

### DIFF
--- a/provider/default_settings_test.go
+++ b/provider/default_settings_test.go
@@ -1,0 +1,114 @@
+package provider
+
+import (
+	"testing"
+)
+
+func TestDefaultSettingsForProtocol(t *testing.T) {
+	tests := []struct {
+		protocol string
+		wantNil  bool
+		wantKey  string
+	}{
+		{"vless", false, "decryption"},
+		{"vmess", true, ""},
+		{"trojan", true, ""},
+		{"shadowsocks", true, ""},
+		{"http", true, ""},
+		{"unknown", true, ""},
+		{"", true, ""},
+	}
+	for _, tt := range tests {
+		result, err := defaultSettingsForProtocol(tt.protocol)
+		if err != nil {
+			t.Fatalf("defaultSettingsForProtocol(%q): unexpected error: %v", tt.protocol, err)
+		}
+		if tt.wantNil && result != nil {
+			t.Fatalf("defaultSettingsForProtocol(%q): expected nil, got %v", tt.protocol, result)
+		}
+		if !tt.wantNil && result == nil {
+			t.Fatalf("defaultSettingsForProtocol(%q): expected non-nil", tt.protocol)
+		}
+		if tt.wantKey != "" {
+			if _, ok := result[tt.wantKey]; !ok {
+				t.Fatalf("defaultSettingsForProtocol(%q): missing key %q", tt.protocol, tt.wantKey)
+			}
+		}
+	}
+}
+
+func TestDefaultSettingsForProtocol_VlessFields(t *testing.T) {
+	result, err := defaultSettingsForProtocol("vless")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result["decryption"] != "none" {
+		t.Fatalf("expected decryption=none, got %v", result["decryption"])
+	}
+	if result["encryption"] != "none" {
+		t.Fatalf("expected encryption=none, got %v", result["encryption"])
+	}
+	testseed, ok := result["testseed"].([]any)
+	if !ok || len(testseed) != 4 {
+		t.Fatalf("expected testseed with 4 elements, got %v", result["testseed"])
+	}
+}
+
+func TestProtocolUsesClients(t *testing.T) {
+	tests := []struct {
+		protocol string
+		want     bool
+	}{
+		{"vmess", true},
+		{"vless", true},
+		{"trojan", true},
+		{"shadowsocks", true},
+		{"http", false},
+		{"mixed", false},
+		{"", false},
+		{"wireguard", false},
+	}
+	for _, tt := range tests {
+		got := protocolUsesClients(tt.protocol)
+		if got != tt.want {
+			t.Fatalf("protocolUsesClients(%q) = %v, want %v", tt.protocol, got, tt.want)
+		}
+	}
+}
+
+func TestApplyDefaultInboundSettings_Nil(t *testing.T) {
+	err := applyDefaultInboundSettings(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestApplyDefaultInboundSettings_EmptySettings(t *testing.T) {
+	inbound := &Inbound{Protocol: "vless", Settings: ""}
+	err := applyDefaultInboundSettings(inbound)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if inbound.Settings == "" || inbound.Settings == "{}" {
+		t.Fatalf("expected non-empty settings for vless, got %q", inbound.Settings)
+	}
+}
+
+func TestApplyDefaultInboundSettings_ExistingSettings(t *testing.T) {
+	inbound := &Inbound{Protocol: "vless", Settings: `{"decryption":"none","clients":[]}`}
+	err := applyDefaultInboundSettings(inbound)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestApplyDefaultInboundSettings_HttpProtocol(t *testing.T) {
+	inbound := &Inbound{Protocol: "http", Settings: ""}
+	err := applyDefaultInboundSettings(inbound)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if inbound.Settings != "{}" {
+		t.Fatalf("expected {} for http, got %q", inbound.Settings)
+	}
+}

--- a/provider/inbound_helpers_test.go
+++ b/provider/inbound_helpers_test.go
@@ -1,0 +1,344 @@
+package provider
+
+import (
+	"encoding/json"
+	"regexp"
+	"testing"
+)
+
+func TestPreserveInboundSettings_Nil(t *testing.T) {
+	err := preserveInboundSettings(nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPreserveInboundSettings_NilExisting(t *testing.T) {
+	desired := &Inbound{Settings: `{"decryption":"none"}`}
+	err := preserveInboundSettings(desired, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPreserveInboundSettings_ClientsPreserved(t *testing.T) {
+	existing := &Inbound{Settings: `{"clients":[{"id":"abc","email":"test@test.com"}],"testseed":[1,2,3]}`}
+	desired := &Inbound{Settings: `{"decryption":"none"}`}
+	err := preserveInboundSettings(desired, existing)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var result map[string]any
+	if err := json.Unmarshal([]byte(desired.Settings), &result); err != nil {
+		t.Fatalf("failed to parse: %v", err)
+	}
+	clients, ok := result["clients"].([]any)
+	if !ok || len(clients) != 1 {
+		t.Fatalf("expected clients preserved, got %v", result["clients"])
+	}
+	testseed, ok := result["testseed"].([]any)
+	if !ok || len(testseed) != 3 {
+		t.Fatalf("expected testseed preserved, got %v", result["testseed"])
+	}
+}
+
+func TestPreserveInboundSettings_ClientsNotOverwritten(t *testing.T) {
+	existing := &Inbound{Settings: `{"clients":[{"id":"old"}]}`}
+	desired := &Inbound{Settings: `{"clients":[{"id":"new"}]}`}
+	err := preserveInboundSettings(desired, existing)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var result map[string]any
+	if err := json.Unmarshal([]byte(desired.Settings), &result); err != nil {
+		t.Fatalf("failed to parse: %v", err)
+	}
+	clients := result["clients"].([]any)
+	first := clients[0].(map[string]any)
+	if first["id"] != "new" {
+		t.Fatalf("expected desired clients kept, got %v", first["id"])
+	}
+}
+
+func TestPreserveInboundSettings_InvalidJSON(t *testing.T) {
+	desired := &Inbound{Settings: "{bad"}
+	existing := &Inbound{Settings: `{"clients":[]}`}
+	err := preserveInboundSettings(desired, existing)
+	if err == nil {
+		t.Fatalf("expected error for invalid JSON")
+	}
+}
+
+func TestPreserveInboundSettings_EmptySettings(t *testing.T) {
+	desired := &Inbound{Settings: ""}
+	existing := &Inbound{Settings: `{"clients":[]}`}
+	err := preserveInboundSettings(desired, existing)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPreserveSettingsKey_KeyPresent(t *testing.T) {
+	desired := map[string]any{}
+	existing := map[string]any{"clients": []any{map[string]any{"id": "abc"}}}
+	ok := preserveSettingsKey(desired, existing, "clients")
+	if !ok {
+		t.Fatalf("expected true")
+	}
+	if _, exists := desired["clients"]; !exists {
+		t.Fatalf("expected clients to be set")
+	}
+}
+
+func TestPreserveSettingsKey_KeyAbsentInExisting(t *testing.T) {
+	desired := map[string]any{}
+	existing := map[string]any{}
+	ok := preserveSettingsKey(desired, existing, "clients")
+	if ok {
+		t.Fatalf("expected false when key absent")
+	}
+}
+
+func TestPreserveSettingsKey_DesiredAlreadyHasKey(t *testing.T) {
+	desired := map[string]any{"clients": []any{map[string]any{"id": "new"}}}
+	existing := map[string]any{"clients": []any{map[string]any{"id": "old"}}}
+	ok := preserveSettingsKey(desired, existing, "clients")
+	if ok {
+		t.Fatalf("expected false when desired already has non-empty key")
+	}
+}
+
+func TestPreserveSettingsKey_NilExisting(t *testing.T) {
+	desired := map[string]any{}
+	ok := preserveSettingsKey(desired, nil, "clients")
+	if ok {
+		t.Fatalf("expected false for nil existing")
+	}
+}
+
+func TestPreserveSettingsKey_EmptyListInExisting(t *testing.T) {
+	desired := map[string]any{}
+	existing := map[string]any{"clients": []any{}}
+	ok := preserveSettingsKey(desired, existing, "clients")
+	if ok {
+		t.Fatalf("expected false for empty list")
+	}
+}
+
+func TestEnsureRealityDefaults_Nil(t *testing.T) {
+	ensureRealityDefaults(nil)
+}
+
+func TestEnsureRealityDefaults_HasServerNames(t *testing.T) {
+	reality := map[string]any{
+		"serverNames": []any{"custom.com"},
+		"target":      "other.com:443",
+	}
+	ensureRealityDefaults(reality)
+	names := reality["serverNames"].([]any)
+	if names[0] != "custom.com" {
+		t.Fatalf("expected custom.com preserved")
+	}
+}
+
+func TestEnsureRealityDefaults_DeriveFromTarget(t *testing.T) {
+	reality := map[string]any{
+		"target": "myhost.com:443",
+	}
+	ensureRealityDefaults(reality)
+	names := reality["serverNames"].([]any)
+	if names[0] != "myhost.com" {
+		t.Fatalf("expected myhost.com, got %v", names[0])
+	}
+}
+
+func TestEnsureRealityDefaults_NoTargetNoNames(t *testing.T) {
+	reality := map[string]any{}
+	ensureRealityDefaults(reality)
+	if reality["target"] != "www.apple.com:443" {
+		t.Fatalf("expected default target")
+	}
+	names := reality["serverNames"].([]any)
+	if len(names) != 2 {
+		t.Fatalf("expected 2 default server names")
+	}
+}
+
+func TestHasRealityShortIDs_Nil(t *testing.T) {
+	if hasRealityShortIDs(nil) {
+		t.Fatalf("expected false for nil")
+	}
+}
+
+func TestHasRealityShortIDs_Present(t *testing.T) {
+	reality := map[string]any{"shortIds": []any{"abc"}}
+	if !hasRealityShortIDs(reality) {
+		t.Fatalf("expected true")
+	}
+}
+
+func TestHasRealityShortIDs_Empty(t *testing.T) {
+	reality := map[string]any{"shortIds": []any{}}
+	if hasRealityShortIDs(reality) {
+		t.Fatalf("expected false for empty list")
+	}
+}
+
+func TestHasRealityShortIDs_MissingKey(t *testing.T) {
+	reality := map[string]any{"other": "val"}
+	if hasRealityShortIDs(reality) {
+		t.Fatalf("expected false for missing key")
+	}
+}
+
+func TestHasRealityServerNames_Nil(t *testing.T) {
+	if hasRealityServerNames(nil) {
+		t.Fatalf("expected false for nil")
+	}
+}
+
+func TestHasRealityServerNames_Present(t *testing.T) {
+	reality := map[string]any{"serverNames": []any{"example.com"}}
+	if !hasRealityServerNames(reality) {
+		t.Fatalf("expected true")
+	}
+}
+
+func TestHasRealityServerNames_Empty(t *testing.T) {
+	reality := map[string]any{"serverNames": []any{}}
+	if hasRealityServerNames(reality) {
+		t.Fatalf("expected false for empty")
+	}
+}
+
+func TestHasStringListValues_Nil(t *testing.T) {
+	if hasStringListValues(nil) {
+		t.Fatalf("expected false for nil")
+	}
+}
+
+func TestHasStringListValues_NonEmpty(t *testing.T) {
+	if !hasStringListValues([]any{"abc"}) {
+		t.Fatalf("expected true")
+	}
+}
+
+func TestHasStringListValues_EmptyStrings(t *testing.T) {
+	if hasStringListValues([]any{""}) {
+		t.Fatalf("expected false for empty strings")
+	}
+}
+
+func TestHasStringListValues_WrongType(t *testing.T) {
+	if hasStringListValues("not a list") {
+		t.Fatalf("expected false for wrong type")
+	}
+}
+
+func TestHasStringListValues_StringSlice(t *testing.T) {
+	if !hasStringListValues([]string{"abc"}) {
+		t.Fatalf("expected true for []string")
+	}
+}
+
+func TestHasStringListValues_EmptyStringSlice(t *testing.T) {
+	if hasStringListValues([]string{""}) {
+		t.Fatalf("expected false for empty []string")
+	}
+}
+
+func TestRandomHex_Zero(t *testing.T) {
+	result := randomHex(0)
+	if result != "" {
+		t.Fatalf("expected empty, got %q", result)
+	}
+}
+
+func TestRandomHex_Eight(t *testing.T) {
+	result := randomHex(8)
+	if len(result) != 8 {
+		t.Fatalf("expected length 8, got %d", len(result))
+	}
+	matched, _ := regexp.MatchString("^[0-9a-f]+$", result)
+	if !matched {
+		t.Fatalf("expected hex chars, got %q", result)
+	}
+}
+
+func TestRandomHex_Odd(t *testing.T) {
+	result := randomHex(5)
+	if len(result) != 5 {
+		t.Fatalf("expected length 5, got %d", len(result))
+	}
+	matched, _ := regexp.MatchString("^[0-9a-f]+$", result)
+	if !matched {
+		t.Fatalf("expected hex chars, got %q", result)
+	}
+}
+
+func TestRandomHex_Unique(t *testing.T) {
+	a := randomHex(16)
+	b := randomHex(16)
+	if a == b {
+		t.Fatalf("expected different values")
+	}
+}
+
+func TestIsSubset_MapSubset(t *testing.T) {
+	desired := map[string]any{"a": float64(1)}
+	actual := map[string]any{"a": float64(1), "b": float64(2)}
+	if !isSubset(desired, actual) {
+		t.Fatalf("expected subset")
+	}
+}
+
+func TestIsSubset_MapNotSubset(t *testing.T) {
+	desired := map[string]any{"a": float64(1), "c": float64(3)}
+	actual := map[string]any{"a": float64(1), "b": float64(2)}
+	if isSubset(desired, actual) {
+		t.Fatalf("expected not subset")
+	}
+}
+
+func TestIsSubset_ArraySubset(t *testing.T) {
+	desired := []any{float64(1)}
+	actual := []any{float64(1), float64(2)}
+	if !isSubset(desired, actual) {
+		t.Fatalf("expected subset")
+	}
+}
+
+func TestIsSubset_EmptyArraySubset(t *testing.T) {
+	desired := []any{}
+	actual := []any{float64(1)}
+	if !isSubset(desired, actual) {
+		t.Fatalf("expected empty array is subset")
+	}
+}
+
+func TestIsSubset_Scalars(t *testing.T) {
+	if !isSubset(float64(1), float64(1)) {
+		t.Fatalf("expected equal scalars")
+	}
+	if isSubset(float64(1), float64(2)) {
+		t.Fatalf("expected not equal")
+	}
+}
+
+func TestJsonSubsetDiffSuppress_EmptyNew(t *testing.T) {
+	if !jsonSubsetDiffSuppress("k", `{"a":1}`, "", nil) {
+		t.Fatalf("expected suppress for empty new")
+	}
+}
+
+func TestJsonSubsetDiffSuppress_Subset(t *testing.T) {
+	if !jsonSubsetDiffSuppress("k", `{"a":1,"b":2}`, `{"a":1}`, nil) {
+		t.Fatalf("expected suppress for subset")
+	}
+}
+
+func TestJsonSubsetDiffSuppress_NotSubset(t *testing.T) {
+	if jsonSubsetDiffSuppress("k", `{"a":1}`, `{"a":1,"c":3}`, nil) {
+		t.Fatalf("expected no suppress for non-subset")
+	}
+}

--- a/provider/settings_expand_flatten_test.go
+++ b/provider/settings_expand_flatten_test.go
@@ -1,0 +1,230 @@
+package provider
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestExpandFallbacks_Empty(t *testing.T) {
+	result := expandFallbacks([]any{})
+	if len(result) != 0 {
+		t.Fatalf("expected empty, got %v", result)
+	}
+}
+
+func TestExpandFallbacks_Single(t *testing.T) {
+	input := []any{
+		map[string]any{"name": "fb1", "alpn": "h2", "path": "/ws", "dest": "127.0.0.1:8080", "xver": 1},
+	}
+	result := expandFallbacks(input)
+	if len(result) != 1 {
+		t.Fatalf("expected 1, got %d", len(result))
+	}
+	m, _ := result[0].(map[string]any)
+	if m["name"] != "fb1" {
+		t.Fatalf("unexpected name: %v", m["name"])
+	}
+	if m["xver"] != 1 {
+		t.Fatalf("unexpected xver: %v", m["xver"])
+	}
+}
+
+func TestExpandFallbacks_Multiple(t *testing.T) {
+	input := []any{
+		map[string]any{"dest": "a"},
+		map[string]any{"dest": "b"},
+	}
+	result := expandFallbacks(input)
+	if len(result) != 2 {
+		t.Fatalf("expected 2, got %d", len(result))
+	}
+}
+
+func TestExpandFallbacks_MissingOptional(t *testing.T) {
+	input := []any{
+		map[string]any{"dest": "127.0.0.1:80"},
+	}
+	result := expandFallbacks(input)
+	if len(result) != 1 {
+		t.Fatalf("expected 1, got %d", len(result))
+	}
+	m, _ := result[0].(map[string]any)
+	if _, ok := m["name"]; ok {
+		t.Fatalf("name should not be set")
+	}
+}
+
+func TestFlattenFallbacks_Empty(t *testing.T) {
+	result := flattenFallbacks([]any{})
+	if len(result) != 0 {
+		t.Fatalf("expected empty, got %v", result)
+	}
+}
+
+func TestFlattenFallbacks_Single(t *testing.T) {
+	input := []any{
+		map[string]any{"name": "fb", "alpn": "h2", "path": "/", "dest": "target", "xver": float64(2)},
+	}
+	result := flattenFallbacks(input)
+	if len(result) != 1 {
+		t.Fatalf("expected 1, got %d", len(result))
+	}
+	m, _ := result[0].(map[string]any)
+	if m["name"] != "fb" {
+		t.Fatalf("unexpected name: %v", m["name"])
+	}
+	if m["xver"] != 2 {
+		t.Fatalf("unexpected xver: %v", m["xver"])
+	}
+}
+
+func TestExpandAccounts_Empty(t *testing.T) {
+	result := expandAccounts([]any{})
+	if len(result) != 0 {
+		t.Fatalf("expected empty, got %v", result)
+	}
+}
+
+func TestExpandAccounts_Single(t *testing.T) {
+	input := []any{
+		map[string]any{"user": "admin", "pass": "secret"},
+	}
+	result := expandAccounts(input)
+	if len(result) != 1 {
+		t.Fatalf("expected 1, got %d", len(result))
+	}
+	m, _ := result[0].(map[string]any)
+	if m["user"] != "admin" || m["pass"] != "secret" {
+		t.Fatalf("unexpected: %v", m)
+	}
+}
+
+func TestFlattenAccounts_Empty(t *testing.T) {
+	result := flattenAccounts([]any{})
+	if len(result) != 0 {
+		t.Fatalf("expected empty, got %v", result)
+	}
+}
+
+func TestFlattenAccounts_Single(t *testing.T) {
+	input := []any{
+		map[string]any{"user": "u", "pass": "p"},
+	}
+	result := flattenAccounts(input)
+	if len(result) != 1 {
+		t.Fatalf("expected 1, got %d", len(result))
+	}
+	m, _ := result[0].(map[string]any)
+	if m["user"] != "u" || m["pass"] != "p" {
+		t.Fatalf("unexpected: %v", m)
+	}
+}
+
+func TestExpandPeers_Empty(t *testing.T) {
+	result := expandPeers([]any{})
+	if len(result) != 0 {
+		t.Fatalf("expected empty, got %v", result)
+	}
+}
+
+func TestExpandPeers_Full(t *testing.T) {
+	input := []any{
+		map[string]any{
+			"private_key":    "priv",
+			"public_key":     "pub",
+			"pre_shared_key": "psk",
+			"allowed_ips":    []any{"10.0.0.0/24"},
+			"keep_alive":     30,
+		},
+	}
+	result := expandPeers(input)
+	if len(result) != 1 {
+		t.Fatalf("expected 1, got %d", len(result))
+	}
+	m, _ := result[0].(map[string]any)
+	if m["privateKey"] != "priv" {
+		t.Fatalf("unexpected privateKey: %v", m["privateKey"])
+	}
+	if m["publicKey"] != "pub" {
+		t.Fatalf("unexpected publicKey: %v", m["publicKey"])
+	}
+	if m["keepAlive"] != 30 {
+		t.Fatalf("unexpected keepAlive: %v", m["keepAlive"])
+	}
+}
+
+func TestExpandPeers_Minimal(t *testing.T) {
+	input := []any{
+		map[string]any{"public_key": "pub", "allowed_ips": []any{}},
+	}
+	result := expandPeers(input)
+	if len(result) != 1 {
+		t.Fatalf("expected 1, got %d", len(result))
+	}
+}
+
+func TestFlattenPeers_Empty(t *testing.T) {
+	result := flattenPeers([]any{})
+	if len(result) != 0 {
+		t.Fatalf("expected empty, got %v", result)
+	}
+}
+
+func TestFlattenPeers_Full(t *testing.T) {
+	input := []any{
+		map[string]any{
+			"privateKey":   "priv",
+			"publicKey":    "pub",
+			"preSharedKey": "psk",
+			"allowedIPs":   []any{"10.0.0.0/24"},
+			"keepAlive":    float64(30),
+		},
+	}
+	result := flattenPeers(input)
+	if len(result) != 1 {
+		t.Fatalf("expected 1, got %d", len(result))
+	}
+	m, _ := result[0].(map[string]any)
+	if m["private_key"] != "priv" {
+		t.Fatalf("unexpected private_key: %v", m["private_key"])
+	}
+	if m["keep_alive"] != 30 {
+		t.Fatalf("unexpected keep_alive: %v", m["keep_alive"])
+	}
+}
+
+func TestFlattenStringMap_Normal(t *testing.T) {
+	in := map[string]any{"a": "1", "b": "2"}
+	out := flattenStringMap(in)
+	expected := map[string]string{"a": "1", "b": "2"}
+	if !reflect.DeepEqual(out, expected) {
+		t.Fatalf("unexpected: %v", out)
+	}
+}
+
+func TestFlattenStringMap_MixedTypes(t *testing.T) {
+	in := map[string]any{"a": "str", "b": 42}
+	out := flattenStringMap(in)
+	if out["a"] != "str" {
+		t.Fatalf("expected str for a")
+	}
+	if _, ok := out["b"]; ok {
+		t.Fatalf("non-string should be skipped")
+	}
+}
+
+func TestFlattenIntList_Empty(t *testing.T) {
+	result := flattenIntList([]any{})
+	if len(result) != 0 {
+		t.Fatalf("expected empty, got %v", result)
+	}
+}
+
+func TestFlattenIntList_Float64Values(t *testing.T) {
+	input := []any{float64(1), float64(2), float64(3)}
+	result := flattenIntList(input)
+	expected := []int{1, 2, 3}
+	if !reflect.DeepEqual(result, expected) {
+		t.Fatalf("expected %v, got %v", expected, result)
+	}
+}

--- a/provider/settings_tabs_test.go
+++ b/provider/settings_tabs_test.go
@@ -1,0 +1,266 @@
+package provider
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestPanelSettingsNeedRestart_ChangedKey(t *testing.T) {
+	existing := map[string]any{"webPort": float64(2053)}
+	desired := map[string]any{"webPort": float64(8080)}
+	if !panelSettingsNeedRestart(existing, desired) {
+		t.Fatalf("expected restart needed")
+	}
+}
+
+func TestPanelSettingsNeedRestart_UnchangedKey(t *testing.T) {
+	existing := map[string]any{"webPort": float64(2053)}
+	desired := map[string]any{"webPort": float64(2053)}
+	if panelSettingsNeedRestart(existing, desired) {
+		t.Fatalf("expected no restart")
+	}
+}
+
+func TestPanelSettingsNeedRestart_NonRestartKey(t *testing.T) {
+	existing := map[string]any{"pageSize": float64(25)}
+	desired := map[string]any{"pageSize": float64(50)}
+	if panelSettingsNeedRestart(existing, desired) {
+		t.Fatalf("expected no restart for pageSize")
+	}
+}
+
+func TestPanelSettingsNeedRestart_NewRestartKey(t *testing.T) {
+	existing := map[string]any{}
+	desired := map[string]any{"webBasePath": "/new/"}
+	if !panelSettingsNeedRestart(existing, desired) {
+		t.Fatalf("expected restart for new restart key")
+	}
+}
+
+func TestPanelSettingsNeedRestart_NoRestartKeys(t *testing.T) {
+	existing := map[string]any{"webPort": float64(2053)}
+	desired := map[string]any{"remarkModel": "-ieo"}
+	if panelSettingsNeedRestart(existing, desired) {
+		t.Fatalf("expected no restart")
+	}
+}
+
+func TestSettingsValueEqual_Strings(t *testing.T) {
+	if !settingsValueEqual("abc", "abc") {
+		t.Fatalf("expected equal")
+	}
+	if settingsValueEqual("abc", "def") {
+		t.Fatalf("expected not equal")
+	}
+}
+
+func TestSettingsValueEqual_Bools(t *testing.T) {
+	if !settingsValueEqual(true, true) {
+		t.Fatalf("expected equal")
+	}
+	if settingsValueEqual(true, false) {
+		t.Fatalf("expected not equal")
+	}
+}
+
+func TestSettingsValueEqual_FloatAndInt(t *testing.T) {
+	if !settingsValueEqual(float64(42), int(42)) {
+		t.Fatalf("expected equal")
+	}
+	if !settingsValueEqual(float64(42), int64(42)) {
+		t.Fatalf("expected equal for int64")
+	}
+}
+
+func TestSettingsValueEqual_IntAndFloat(t *testing.T) {
+	if !settingsValueEqual(int(42), float64(42)) {
+		t.Fatalf("expected equal")
+	}
+}
+
+func TestSettingsValueEqual_Nil(t *testing.T) {
+	if !settingsValueEqual(nil, nil) {
+		t.Fatalf("expected nil == nil")
+	}
+	if settingsValueEqual(nil, "x") {
+		t.Fatalf("expected nil != string")
+	}
+}
+
+func TestSettingsValueEqual_DifferentTypes(t *testing.T) {
+	if settingsValueEqual("42", float64(42)) {
+		t.Fatalf("expected not equal for string vs number")
+	}
+}
+
+func TestNumberValueEqual_Float64(t *testing.T) {
+	if !numberValueEqual(3.14, float64(3.14)) {
+		t.Fatalf("expected equal")
+	}
+}
+
+func TestNumberValueEqual_Int(t *testing.T) {
+	if !numberValueEqual(42.0, int(42)) {
+		t.Fatalf("expected equal")
+	}
+}
+
+func TestNumberValueEqual_Int64(t *testing.T) {
+	if !numberValueEqual(100.0, int64(100)) {
+		t.Fatalf("expected equal")
+	}
+}
+
+func TestNumberValueEqual_Uint(t *testing.T) {
+	if !numberValueEqual(10.0, uint(10)) {
+		t.Fatalf("expected equal")
+	}
+}
+
+func TestNumberValueEqual_NonNumeric(t *testing.T) {
+	if numberValueEqual(42.0, "42") {
+		t.Fatalf("expected not equal for string")
+	}
+}
+
+func TestMergeSettings_BothNil(t *testing.T) {
+	result := mergeSettings(nil, nil)
+	if len(result) != 0 {
+		t.Fatalf("expected empty map, got %v", result)
+	}
+}
+
+func TestMergeSettings_NilExisting(t *testing.T) {
+	desired := map[string]any{"a": "1"}
+	result := mergeSettings(nil, desired)
+	if !reflect.DeepEqual(result, desired) {
+		t.Fatalf("expected desired, got %v", result)
+	}
+}
+
+func TestMergeSettings_Overlap(t *testing.T) {
+	existing := map[string]any{"a": "old", "b": "keep"}
+	desired := map[string]any{"a": "new"}
+	result := mergeSettings(existing, desired)
+	if result["a"] != "new" {
+		t.Fatalf("expected override, got %v", result["a"])
+	}
+	if result["b"] != "keep" {
+		t.Fatalf("expected keep, got %v", result["b"])
+	}
+}
+
+func TestMergeSettings_Union(t *testing.T) {
+	existing := map[string]any{"a": "1"}
+	desired := map[string]any{"b": "2"}
+	result := mergeSettings(existing, desired)
+	if result["a"] != "1" || result["b"] != "2" {
+		t.Fatalf("expected union, got %v", result)
+	}
+}
+
+func TestFlattenPanelSettingsFields_Full(t *testing.T) {
+	in := map[string]any{
+		"webListen":   "0.0.0.0",
+		"webPort":     float64(2053),
+		"webBasePath": "/panel/",
+		"pageSize":    float64(25),
+	}
+	out := flattenPanelSettingsFields(in)
+	if out["web_listen"] != "0.0.0.0" {
+		t.Fatalf("unexpected web_listen: %v", out["web_listen"])
+	}
+	if out["web_port"] != 2053 {
+		t.Fatalf("unexpected web_port: %v", out["web_port"])
+	}
+	if out["web_base_path"] != "/panel/" {
+		t.Fatalf("unexpected web_base_path: %v", out["web_base_path"])
+	}
+}
+
+func TestFlattenPanelSettingsFields_Empty(t *testing.T) {
+	out := flattenPanelSettingsFields(map[string]any{})
+	if len(out) != 0 {
+		t.Fatalf("expected empty, got %v", out)
+	}
+}
+
+func TestFlattenAccountSettingsFields_Full(t *testing.T) {
+	in := map[string]any{
+		"twoFactorEnable": true,
+		"twoFactorToken":  "secret",
+	}
+	out := flattenAccountSettingsFields(in)
+	if out["two_factor_enable"] != true {
+		t.Fatalf("unexpected: %v", out)
+	}
+	if out["two_factor_token"] != "secret" {
+		t.Fatalf("unexpected: %v", out)
+	}
+}
+
+func TestFlattenAccountSettingsFields_Empty(t *testing.T) {
+	out := flattenAccountSettingsFields(map[string]any{})
+	if len(out) != 0 {
+		t.Fatalf("expected empty, got %v", out)
+	}
+}
+
+func TestFlattenTelegramSettingsFields_Full(t *testing.T) {
+	in := map[string]any{
+		"tgBotEnable":      true,
+		"tgBotToken":       "tok",
+		"tgBotProxy":       "proxy",
+		"tgBotAPIServer":   "api",
+		"tgBotChatId":      "123",
+		"tgLang":           "en",
+		"tgRunTime":        "@daily",
+		"tgBotBackup":      true,
+		"tgBotLoginNotify": false,
+		"tgCpu":            float64(80),
+	}
+	out := flattenTelegramSettingsFields(in)
+	if out["tg_bot_enable"] != true {
+		t.Fatalf("unexpected tg_bot_enable: %v", out["tg_bot_enable"])
+	}
+	if out["tg_bot_token"] != "tok" {
+		t.Fatalf("unexpected tg_bot_token: %v", out["tg_bot_token"])
+	}
+	if out["tg_cpu"] != 80 {
+		t.Fatalf("unexpected tg_cpu: %v", out["tg_cpu"])
+	}
+}
+
+func TestFlattenTelegramSettingsFields_Empty(t *testing.T) {
+	out := flattenTelegramSettingsFields(map[string]any{})
+	if len(out) != 0 {
+		t.Fatalf("expected empty, got %v", out)
+	}
+}
+
+func TestFlattenSubscriptionSettingsFields_Full(t *testing.T) {
+	in := map[string]any{
+		"subEnable":     true,
+		"subJsonEnable": false,
+		"subTitle":      "My Sub",
+		"subPort":       float64(443),
+		"subEncrypt":    true,
+	}
+	out := flattenSubscriptionSettingsFields(in)
+	if out["sub_enable"] != true {
+		t.Fatalf("unexpected sub_enable: %v", out["sub_enable"])
+	}
+	if out["sub_title"] != "My Sub" {
+		t.Fatalf("unexpected sub_title: %v", out["sub_title"])
+	}
+	if out["sub_port"] != 443 {
+		t.Fatalf("unexpected sub_port: %v", out["sub_port"])
+	}
+}
+
+func TestFlattenSubscriptionSettingsFields_Empty(t *testing.T) {
+	out := flattenSubscriptionSettingsFields(map[string]any{})
+	if len(out) != 0 {
+		t.Fatalf("expected empty, got %v", out)
+	}
+}

--- a/provider/stream_settings_test.go
+++ b/provider/stream_settings_test.go
@@ -1,0 +1,236 @@
+package provider
+
+import (
+	"testing"
+)
+
+func TestExpandRealitySettings_Empty(t *testing.T) {
+	result := expandRealitySettings([]any{})
+	if result != nil {
+		t.Fatalf("expected nil, got %v", result)
+	}
+}
+
+func TestExpandRealitySettings_Full(t *testing.T) {
+	input := []any{
+		map[string]any{
+			"show":           true,
+			"xver":           2,
+			"target":         "example.com:443",
+			"server_names":   []any{"example.com"},
+			"private_key":    "privkey",
+			"min_client_ver": "1.0",
+			"max_client_ver": "2.0",
+			"max_timediff":   60,
+			"short_ids":      []any{"abc123"},
+			"mldsa65_seed":   "seed",
+			"settings":       []any{map[string]any{"public_key": "pubkey", "fingerprint": "chrome"}},
+		},
+	}
+	result := expandRealitySettings(input)
+	if result == nil {
+		t.Fatalf("expected non-nil")
+	}
+	if result["show"] != true {
+		t.Fatalf("unexpected show: %v", result["show"])
+	}
+	if result["target"] != "example.com:443" {
+		t.Fatalf("unexpected target: %v", result["target"])
+	}
+	if result["privateKey"] != "privkey" {
+		t.Fatalf("unexpected privateKey: %v", result["privateKey"])
+	}
+	settings, ok := result["settings"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected settings map")
+	}
+	if settings["publicKey"] != "pubkey" {
+		t.Fatalf("unexpected publicKey: %v", settings["publicKey"])
+	}
+}
+
+func TestExpandRealitySettings_NoTargetDefaults(t *testing.T) {
+	input := []any{
+		map[string]any{},
+	}
+	result := expandRealitySettings(input)
+	if result == nil {
+		t.Fatalf("expected non-nil")
+	}
+	if result["target"] != "www.apple.com:443" {
+		t.Fatalf("expected default target, got %v", result["target"])
+	}
+}
+
+func TestExpandRealitySettings_TargetDerivesServerNames(t *testing.T) {
+	input := []any{
+		map[string]any{
+			"target": "myhost.com:443",
+		},
+	}
+	result := expandRealitySettings(input)
+	if result == nil {
+		t.Fatalf("expected non-nil")
+	}
+	names, ok := result["serverNames"].([]any)
+	if !ok {
+		t.Fatalf("expected serverNames")
+	}
+	if len(names) == 0 {
+		t.Fatalf("expected at least one server name")
+	}
+	if names[0] != "myhost.com" {
+		t.Fatalf("expected myhost.com, got %v", names[0])
+	}
+}
+
+func TestFlattenRealitySettings_Nil(t *testing.T) {
+	result := flattenRealitySettings(nil)
+	if result != nil {
+		t.Fatalf("expected nil, got %v", result)
+	}
+}
+
+func TestFlattenRealitySettings_Empty(t *testing.T) {
+	result := flattenRealitySettings(map[string]any{})
+	if result != nil {
+		t.Fatalf("expected nil, got %v", result)
+	}
+}
+
+func TestFlattenRealitySettings_Full(t *testing.T) {
+	in := map[string]any{
+		"show":         true,
+		"xver":         float64(2),
+		"target":       "example.com:443",
+		"serverNames":  []any{"example.com"},
+		"privateKey":   "pk",
+		"minClientVer": "1.0",
+		"maxClientVer": "2.0",
+		"maxTimediff":  float64(60),
+		"shortIds":     []any{"abc"},
+		"mldsa65Seed":  "seed",
+		"settings":     map[string]any{"publicKey": "pub", "fingerprint": "chrome"},
+	}
+	out := flattenRealitySettings(in)
+	if out == nil {
+		t.Fatalf("expected non-nil")
+	}
+	if out["show"] != true {
+		t.Fatalf("unexpected show: %v", out["show"])
+	}
+	if out["target"] != "example.com:443" {
+		t.Fatalf("unexpected target: %v", out["target"])
+	}
+	if out["private_key"] != "pk" {
+		t.Fatalf("unexpected private_key: %v", out["private_key"])
+	}
+	if out["xver"] != 2 {
+		t.Fatalf("unexpected xver: %v", out["xver"])
+	}
+	settings, ok := out["settings"].([]any)
+	if !ok || len(settings) != 1 {
+		t.Fatalf("expected settings list with 1 element")
+	}
+}
+
+func TestFlattenRealitySettings_Partial(t *testing.T) {
+	in := map[string]any{
+		"target":     "example.com:443",
+		"privateKey": "pk",
+	}
+	out := flattenRealitySettings(in)
+	if out == nil {
+		t.Fatalf("expected non-nil")
+	}
+	if out["target"] != "example.com:443" {
+		t.Fatalf("unexpected target")
+	}
+}
+
+func TestExpandRealityInnerSettings_Empty(t *testing.T) {
+	result := expandRealityInnerSettings([]any{})
+	if result != nil {
+		t.Fatalf("expected nil, got %v", result)
+	}
+}
+
+func TestExpandRealityInnerSettings_Full(t *testing.T) {
+	input := []any{
+		map[string]any{
+			"public_key":     "pub",
+			"fingerprint":    "chrome",
+			"server_name":    "example.com",
+			"spider_x":       "/",
+			"mldsa65_verify": "verify",
+		},
+	}
+	result := expandRealityInnerSettings(input)
+	if result == nil {
+		t.Fatalf("expected non-nil")
+	}
+	if result["publicKey"] != "pub" {
+		t.Fatalf("unexpected publicKey: %v", result["publicKey"])
+	}
+	if result["fingerprint"] != "chrome" {
+		t.Fatalf("unexpected fingerprint: %v", result["fingerprint"])
+	}
+	if result["serverName"] != "example.com" {
+		t.Fatalf("unexpected serverName")
+	}
+	if result["spiderX"] != "/" {
+		t.Fatalf("unexpected spiderX")
+	}
+}
+
+func TestExpandRealityInnerSettings_PublicKeyOnly(t *testing.T) {
+	input := []any{
+		map[string]any{"public_key": "pub"},
+	}
+	result := expandRealityInnerSettings(input)
+	if result == nil {
+		t.Fatalf("expected non-nil")
+	}
+	if result["publicKey"] != "pub" {
+		t.Fatalf("unexpected publicKey")
+	}
+	if _, ok := result["fingerprint"]; ok {
+		t.Fatalf("fingerprint should not be set")
+	}
+}
+
+func TestFlattenRealityInnerSettings_Empty(t *testing.T) {
+	result := flattenRealityInnerSettings(map[string]any{})
+	if result != nil {
+		t.Fatalf("expected nil, got %v", result)
+	}
+}
+
+func TestFlattenRealityInnerSettings_Full(t *testing.T) {
+	in := map[string]any{
+		"publicKey":     "pub",
+		"fingerprint":   "chrome",
+		"serverName":    "example.com",
+		"spiderX":       "/",
+		"mldsa65Verify": "verify",
+	}
+	out := flattenRealityInnerSettings(in)
+	if out == nil {
+		t.Fatalf("expected non-nil")
+	}
+	if out["public_key"] != "pub" {
+		t.Fatalf("unexpected public_key")
+	}
+	if out["fingerprint"] != "chrome" {
+		t.Fatalf("unexpected fingerprint")
+	}
+	if out["server_name"] != "example.com" {
+		t.Fatalf("unexpected server_name")
+	}
+	if out["spider_x"] != "/" {
+		t.Fatalf("unexpected spider_x")
+	}
+	if out["mldsa65_verify"] != "verify" {
+		t.Fatalf("unexpected mldsa65_verify")
+	}
+}

--- a/provider/xray_settings_test.go
+++ b/provider/xray_settings_test.go
@@ -1,0 +1,317 @@
+package provider
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestDeepMergeJSON_Flat(t *testing.T) {
+	dst := map[string]any{"a": "1"}
+	src := map[string]any{"b": "2"}
+	result := deepMergeJSON(dst, src)
+	if result["a"] != "1" || result["b"] != "2" {
+		t.Fatalf("unexpected result: %v", result)
+	}
+}
+
+func TestDeepMergeJSON_Overlap(t *testing.T) {
+	dst := map[string]any{"a": "old"}
+	src := map[string]any{"a": "new"}
+	result := deepMergeJSON(dst, src)
+	if result["a"] != "new" {
+		t.Fatalf("expected overwrite, got %v", result["a"])
+	}
+}
+
+func TestDeepMergeJSON_Nested(t *testing.T) {
+	dst := map[string]any{"a": map[string]any{"x": 1}}
+	src := map[string]any{"a": map[string]any{"y": 2}}
+	result := deepMergeJSON(dst, src)
+	inner, ok := result["a"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected nested map")
+	}
+	if inner["x"] != 1 || inner["y"] != 2 {
+		t.Fatalf("unexpected nested result: %v", inner)
+	}
+}
+
+func TestDeepMergeJSON_NilDst(t *testing.T) {
+	src := map[string]any{"a": "1"}
+	result := deepMergeJSON(nil, src)
+	if result["a"] != "1" {
+		t.Fatalf("unexpected result: %v", result)
+	}
+}
+
+func TestDeepMergeJSON_MapReplacedByScalar(t *testing.T) {
+	dst := map[string]any{"a": map[string]any{"x": 1}}
+	src := map[string]any{"a": "scalar"}
+	result := deepMergeJSON(dst, src)
+	if result["a"] != "scalar" {
+		t.Fatalf("expected scalar, got %v", result["a"])
+	}
+}
+
+func TestSetJSONPath_SingleLevel(t *testing.T) {
+	root := map[string]any{}
+	setJSONPath(root, []string{"key"}, "val")
+	if root["key"] != "val" {
+		t.Fatalf("unexpected: %v", root)
+	}
+}
+
+func TestSetJSONPath_MultiLevel(t *testing.T) {
+	root := map[string]any{}
+	setJSONPath(root, []string{"a", "b", "c"}, 42)
+	a, _ := root["a"].(map[string]any)
+	b, _ := a["b"].(map[string]any)
+	if b["c"] != 42 {
+		t.Fatalf("unexpected: %v", root)
+	}
+}
+
+func TestSetJSONPath_CreateIntermediates(t *testing.T) {
+	root := map[string]any{"x": "keep"}
+	setJSONPath(root, []string{"a", "b"}, "new")
+	if root["x"] != "keep" {
+		t.Fatalf("existing key lost")
+	}
+	a, _ := root["a"].(map[string]any)
+	if a["b"] != "new" {
+		t.Fatalf("unexpected: %v", root)
+	}
+}
+
+func TestSetJSONPath_Overwrite(t *testing.T) {
+	root := map[string]any{"a": "old"}
+	setJSONPath(root, []string{"a"}, "new")
+	if root["a"] != "new" {
+		t.Fatalf("expected overwrite")
+	}
+}
+
+func TestGetJSONPath_Existing(t *testing.T) {
+	root := map[string]any{"a": map[string]any{"b": "val"}}
+	got := getJSONPath(root, []string{"a", "b"})
+	if got != "val" {
+		t.Fatalf("expected val, got %v", got)
+	}
+}
+
+func TestGetJSONPath_Missing(t *testing.T) {
+	root := map[string]any{"a": "val"}
+	got := getJSONPath(root, []string{"b"})
+	if got != nil {
+		t.Fatalf("expected nil, got %v", got)
+	}
+}
+
+func TestGetJSONPath_NonMapIntermediate(t *testing.T) {
+	root := map[string]any{"a": "string"}
+	got := getJSONPath(root, []string{"a", "b"})
+	if got != nil {
+		t.Fatalf("expected nil, got %v", got)
+	}
+}
+
+func TestCloneJSONMap_Nil(t *testing.T) {
+	result := cloneJSONMap(nil)
+	if result == nil || len(result) != 0 {
+		t.Fatalf("expected empty map, got %v", result)
+	}
+}
+
+func TestCloneJSONMap_Independence(t *testing.T) {
+	original := map[string]any{"a": "1", "b": "2"}
+	clone := cloneJSONMap(original)
+	clone["a"] = "changed"
+	if original["a"] != "1" {
+		t.Fatalf("clone modified original")
+	}
+}
+
+func TestNormalizeJSONString_Valid(t *testing.T) {
+	result := normalizeJSONString(`{ "b": 1, "a": 2 }`)
+	if result != `{"a":2,"b":1}` {
+		t.Fatalf("unexpected: %q", result)
+	}
+}
+
+func TestNormalizeJSONString_Invalid(t *testing.T) {
+	result := normalizeJSONString("{bad")
+	if result != "{bad" {
+		t.Fatalf("expected raw string back, got %q", result)
+	}
+}
+
+func TestNormalizeJSONString_Empty(t *testing.T) {
+	result := normalizeJSONString("")
+	if result != "" {
+		t.Fatalf("expected empty, got %q", result)
+	}
+}
+
+func TestJsonEqualDiffSuppress_EqualFormatting(t *testing.T) {
+	if !jsonEqualDiffSuppress("k", `{"a":1}`, `{ "a": 1 }`, nil) {
+		t.Fatalf("expected equal")
+	}
+}
+
+func TestJsonEqualDiffSuppress_DifferentValues(t *testing.T) {
+	if jsonEqualDiffSuppress("k", `{"a":1}`, `{"a":2}`, nil) {
+		t.Fatalf("expected not equal")
+	}
+}
+
+func TestJsonEqualDiffSuppress_BothEmpty(t *testing.T) {
+	if !jsonEqualDiffSuppress("k", "", "", nil) {
+		t.Fatalf("expected equal for empty")
+	}
+}
+
+func TestJsonEqualDiffSuppress_OneEmpty(t *testing.T) {
+	if jsonEqualDiffSuppress("k", `{"a":1}`, "", nil) {
+		t.Fatalf("expected not equal when one empty")
+	}
+}
+
+func TestJsonEqualDiffSuppress_InvalidJSON(t *testing.T) {
+	if jsonEqualDiffSuppress("k", "{bad", `{"a":1}`, nil) {
+		t.Fatalf("expected false for invalid JSON")
+	}
+}
+
+func TestDeepEqualJSON_EqualMaps(t *testing.T) {
+	a := map[string]any{"x": float64(1)}
+	b := map[string]any{"x": float64(1)}
+	if !deepEqualJSON(a, b) {
+		t.Fatalf("expected equal")
+	}
+}
+
+func TestDeepEqualJSON_DifferentMaps(t *testing.T) {
+	a := map[string]any{"x": float64(1)}
+	b := map[string]any{"x": float64(2)}
+	if deepEqualJSON(a, b) {
+		t.Fatalf("expected not equal")
+	}
+}
+
+func TestDeepEqualJSON_Arrays(t *testing.T) {
+	a := []any{float64(1), float64(2)}
+	b := []any{float64(1), float64(2)}
+	if !deepEqualJSON(a, b) {
+		t.Fatalf("expected equal")
+	}
+}
+
+func TestDeepEqualJSON_DifferentTypes(t *testing.T) {
+	if deepEqualJSON("string", float64(1)) {
+		t.Fatalf("expected not equal for different types")
+	}
+}
+
+func TestExtractXraySection_MergeRoot(t *testing.T) {
+	current := map[string]any{
+		"log":       map[string]any{"level": "debug"},
+		"policy":    map[string]any{},
+		"routing":   map[string]any{"rules": []any{}},
+		"outbounds": []any{},
+		"dns":       map[string]any{"servers": []any{}},
+	}
+	result := extractXraySection(current, xraySectionBasics)
+	m, ok := result.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map")
+	}
+	if _, ok := m["log"]; !ok {
+		t.Fatalf("missing log")
+	}
+	if _, ok := m["dns"]; ok {
+		t.Fatalf("dns should not be in basics")
+	}
+}
+
+func TestExtractXraySection_SetPath(t *testing.T) {
+	current := map[string]any{"dns": map[string]any{"servers": []any{"8.8.8.8"}}}
+	result := extractXraySection(current, xraySectionDNS)
+	m, ok := result.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map")
+	}
+	if _, ok := m["servers"]; !ok {
+		t.Fatalf("missing servers")
+	}
+}
+
+func TestExtractXraySection_ReplaceAll(t *testing.T) {
+	current := map[string]any{"a": "1", "b": "2"}
+	result := extractXraySection(current, xraySectionAdvanced)
+	m, ok := result.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map")
+	}
+	if !reflect.DeepEqual(m, current) {
+		t.Fatalf("expected full config")
+	}
+}
+
+func TestApplyXraySection_MergeRoot(t *testing.T) {
+	current := map[string]any{"log": map[string]any{"level": "info"}}
+	desired := map[string]any{"log": map[string]any{"level": "debug"}}
+	result, err := applyXraySection(current, desired, xraySectionBasics)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	log, _ := result["log"].(map[string]any)
+	if log["level"] != "debug" {
+		t.Fatalf("expected debug, got %v", log["level"])
+	}
+}
+
+func TestApplyXraySection_SetPath(t *testing.T) {
+	current := map[string]any{}
+	desired := map[string]any{"servers": []any{"8.8.8.8"}}
+	result, err := applyXraySection(current, desired, xraySectionDNS)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	dns, ok := result["dns"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected dns key")
+	}
+	if _, ok := dns["servers"]; !ok {
+		t.Fatalf("missing servers in dns")
+	}
+}
+
+func TestApplyXraySection_ReplaceAll(t *testing.T) {
+	current := map[string]any{"old": "data"}
+	desired := map[string]any{"new": "data"}
+	result, err := applyXraySection(current, desired, xraySectionAdvanced)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := result["old"]; ok {
+		t.Fatalf("old data should be gone")
+	}
+	if result["new"] != "data" {
+		t.Fatalf("expected new data")
+	}
+}
+
+func TestApplyXraySection_MergeRoot_NotObject(t *testing.T) {
+	_, err := applyXraySection(map[string]any{}, "string", xraySectionBasics)
+	if err == nil {
+		t.Fatalf("expected error for non-object")
+	}
+}
+
+func TestApplyXraySection_SetPath_EmptyPath(t *testing.T) {
+	section := xraySection{id: "test", mode: xraySectionSetPath, path: []string{}}
+	_, err := applyXraySection(map[string]any{}, map[string]any{}, section)
+	if err == nil {
+		t.Fatalf("expected error for empty path")
+	}
+}


### PR DESCRIPTION
## Summary
- Add 6 new unit test files (~115 test cases) covering pure functions that don't require a running 3x-ui server
- Coverage increased from **27.6%** to **51.9%**
- Tested modules: `default_settings`, `resource_xray_settings`, `resource_settings_tabs`/`settings_helpers`, `settings` (expand/flatten), `stream_settings`, `resource_inbound` (helpers)

## Test plan
- [x] All new tests pass: `go test ./provider/... -count=1 -v`
- [x] Coverage verified: `go tool cover -func=coverage.out | tail -1` → 51.9%
- [x] Build passes: `task build`
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)