### PR TITLE
chore: suppress docker pull output in tests

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -13,7 +13,7 @@ tasks:
         sh: which tofu
     cmds:
       - docker compose down -v 2>/dev/null || true
-      - docker compose up --detach --wait
+      - docker compose up --detach --wait --quiet-pull
       - defer: docker compose down
       - >-
         TF_ACC=1


### PR DESCRIPTION
## Summary
- Add `--quiet-pull` flag to `docker compose up` in Taskfile to suppress image pull output during test runs

## Test plan
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)