### PR TITLE
feat: add 3x-ui v2.8.10 support

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   3xui:
-    image: ghcr.io/mhsanaei/3x-ui:v2.8.9
+    image: ghcr.io/mhsanaei/3x-ui:v2.8.10
     ports:
       - "2053:2053" # HTTP panel
     environment:

--- a/docs/resources/panel_general.md
+++ b/docs/resources/panel_general.md
@@ -73,6 +73,10 @@ resource "threexui_panel_general" "settings" {
 - `ldap_default_expiry_days` (Optional, Number) - Default expiry days for LDAP clients. Default is `0`.
 - `ldap_default_limit_ip` (Optional, Number) - Default IP limit for LDAP clients. Default is `0`.
 
+### Xray
+
+- `xray_outbound_test_url` (Optional, String) - URL used for testing outbound connectivity. Default is `https://www.google.com/generate_204`.
+
 ## Attribute Reference
 
 All arguments are also exported as attributes.

--- a/provider/acc_panel_settings_test.go
+++ b/provider/acc_panel_settings_test.go
@@ -51,12 +51,14 @@ resource "threexui_panel_general" "test" {
   web_key_file                   = ""
   web_listen                     = ""
   web_port                       = 2053
+  xray_outbound_test_url         = "https://example.com/generate_204"
 }
 `,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("threexui_panel_general.test", "id", "settings"),
 					resource.TestCheckResourceAttr("threexui_panel_general.test", "page_size", "50"),
 					resource.TestCheckResourceAttr("threexui_panel_general.test", "time_location", "Asia/Tehran"),
+					resource.TestCheckResourceAttr("threexui_panel_general.test", "xray_outbound_test_url", "https://example.com/generate_204"),
 				),
 			},
 			// Update
@@ -98,12 +100,14 @@ resource "threexui_panel_general" "test" {
   web_key_file                   = ""
   web_listen                     = ""
   web_port                       = 2053
+  xray_outbound_test_url         = "https://www.google.com/generate_204"
 }
 `,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("threexui_panel_general.test", "id", "settings"),
 					resource.TestCheckResourceAttr("threexui_panel_general.test", "page_size", "25"),
 					resource.TestCheckResourceAttr("threexui_panel_general.test", "time_location", "Local"),
+					resource.TestCheckResourceAttr("threexui_panel_general.test", "xray_outbound_test_url", "https://www.google.com/generate_204"),
 				),
 			},
 			// ImportState
@@ -153,6 +157,7 @@ resource "threexui_panel_general" "test" {
   web_key_file                   = ""
   web_listen                     = ""
   web_port                       = 2053
+  xray_outbound_test_url         = "https://www.google.com/generate_204"
 }
 `,
 				PlanOnly:           true,
@@ -207,6 +212,7 @@ resource "threexui_panel_general" "ldap" {
   web_key_file                   = ""
   web_listen                     = ""
   web_port                       = 2053
+  xray_outbound_test_url         = "https://www.google.com/generate_204"
 }
 `,
 				Check: resource.ComposeTestCheckFunc(
@@ -255,6 +261,7 @@ resource "threexui_panel_general" "ldap" {
   web_key_file                   = ""
   web_listen                     = ""
   web_port                       = 2053
+  xray_outbound_test_url         = "https://www.google.com/generate_204"
 }
 `,
 				Check: resource.ComposeTestCheckFunc(

--- a/provider/client.go
+++ b/provider/client.go
@@ -366,6 +366,39 @@ func (c *Client) UpdateXrayTemplate(ctx context.Context, settings map[string]any
 	return c.doForm(ctx, http.MethodPost, "panel/xray/update", form, nil)
 }
 
+func (c *Client) GetXrayOutboundTestURL(ctx context.Context) (string, error) {
+	var raw string
+	if err := c.doForm(ctx, http.MethodPost, "panel/xray", url.Values{}, &raw); err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(raw) == "" {
+		return "", nil
+	}
+	var payload struct {
+		OutboundTestURL string `json:"outboundTestUrl"`
+	}
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		return "", err
+	}
+	return payload.OutboundTestURL, nil
+}
+
+func (c *Client) SetXrayOutboundTestURL(ctx context.Context, testURL string) error {
+	// Read current xray template to preserve it.
+	tmpl, err := c.GetXrayTemplate(ctx)
+	if err != nil {
+		return err
+	}
+	payload, err := json.Marshal(tmpl)
+	if err != nil {
+		return err
+	}
+	form := url.Values{}
+	form.Set("xraySetting", string(payload))
+	form.Set("outboundTestUrl", testURL)
+	return c.doForm(ctx, http.MethodPost, "panel/xray/update", form, nil)
+}
+
 func (c *Client) doRequest(ctx context.Context, method, endpoint, contentType string, body []byte, out any) error {
 	resp, err := c.doRequestOnce(ctx, method, endpoint, contentType, body)
 	if err != nil {

--- a/provider/resource_settings_tabs.go
+++ b/provider/resource_settings_tabs.go
@@ -550,6 +550,7 @@ type PanelGeneralModel struct {
 	LDAPDefaultTotalGB          types.Int64  `tfsdk:"ldap_default_total_gb"`
 	LDAPDefaultExpiryDays       types.Int64  `tfsdk:"ldap_default_expiry_days"`
 	LDAPDefaultLimitIP          types.Int64  `tfsdk:"ldap_default_limit_ip"`
+	XrayOutboundTestURL         types.String `tfsdk:"xray_outbound_test_url"`
 }
 
 func panelGeneralSchema() schema.Schema {
@@ -700,6 +701,12 @@ func panelGeneralSchema() schema.Schema {
 			"ldap_default_limit_ip": schema.Int64Attribute{
 				Optional: true, Computed: true,
 				PlanModifiers: []planmodifier.Int64{int64planmodifier.UseStateForUnknown()},
+			},
+			"xray_outbound_test_url": schema.StringAttribute{
+				Optional:      true,
+				Computed:      true,
+				Description:   "URL used for testing outbound connectivity (default: https://www.google.com/generate_204).",
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 		},
 	}
@@ -1009,6 +1016,25 @@ func (r *PanelGeneralResource) Configure(_ context.Context, req resource.Configu
 	r.client = client
 }
 
+func (r *PanelGeneralResource) readPanelGeneralState(ctx context.Context, diags *diag.Diagnostics) *PanelGeneralModel {
+	settings := settingsReadTyped(ctx, diags, r.client)
+	if settings == nil {
+		return nil
+	}
+	state := flattenPanelGeneral(settings)
+
+	// xrayOutboundTestUrl is served via the xray endpoint, not the settings API.
+	testURL, err := r.client.GetXrayOutboundTestURL(ctx)
+	if err != nil {
+		diags.AddError("Failed to get xray outbound test URL", err.Error())
+		return nil
+	}
+	if testURL != "" {
+		state.XrayOutboundTestURL = types.StringValue(testURL)
+	}
+	return state
+}
+
 func (r *PanelGeneralResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan PanelGeneralModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -1021,20 +1047,18 @@ func (r *PanelGeneralResource) Create(ctx context.Context, req resource.CreateRe
 		return
 	}
 
-	settings := settingsReadTyped(ctx, &resp.Diagnostics, r.client)
-	if settings == nil {
+	state := r.readPanelGeneralState(ctx, &resp.Diagnostics)
+	if state == nil {
 		return
 	}
-	state := flattenPanelGeneral(settings)
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
 
 func (r *PanelGeneralResource) Read(ctx context.Context, _ resource.ReadRequest, resp *resource.ReadResponse) {
-	settings := settingsReadTyped(ctx, &resp.Diagnostics, r.client)
-	if settings == nil {
+	state := r.readPanelGeneralState(ctx, &resp.Diagnostics)
+	if state == nil {
 		return
 	}
-	state := flattenPanelGeneral(settings)
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
 
@@ -1050,11 +1074,10 @@ func (r *PanelGeneralResource) Update(ctx context.Context, req resource.UpdateRe
 		return
 	}
 
-	settings := settingsReadTyped(ctx, &resp.Diagnostics, r.client)
-	if settings == nil {
+	state := r.readPanelGeneralState(ctx, &resp.Diagnostics)
+	if state == nil {
 		return
 	}
-	state := flattenPanelGeneral(settings)
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
 
@@ -1063,19 +1086,15 @@ func (r *PanelGeneralResource) Delete(ctx context.Context, _ resource.DeleteRequ
 }
 
 func (r *PanelGeneralResource) ImportState(ctx context.Context, _ resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	settings := settingsReadTyped(ctx, &resp.Diagnostics, r.client)
-	if settings == nil {
+	state := r.readPanelGeneralState(ctx, &resp.Diagnostics)
+	if state == nil {
 		return
 	}
-	state := flattenPanelGeneral(settings)
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
 
 func (r *PanelGeneralResource) applyPanelGeneral(ctx context.Context, plan *PanelGeneralModel, diags *diag.Diagnostics) {
 	desired := expandPanelGeneral(plan)
-	if len(desired) == 0 {
-		return
-	}
 
 	// Warn about web_base_path change.
 	if _, hasBasePath := desired["webBasePath"]; hasBasePath {
@@ -1085,22 +1104,32 @@ func (r *PanelGeneralResource) applyPanelGeneral(ctx context.Context, plan *Pane
 		)
 	}
 
-	existing, err := r.client.GetSettings(ctx)
-	if err != nil {
-		diags.AddError("Failed to get settings", err.Error())
-		return
+	if len(desired) > 0 {
+		existing, err := r.client.GetSettings(ctx)
+		if err != nil {
+			diags.AddError("Failed to get settings", err.Error())
+			return
+		}
+
+		needRestart := panelSettingsNeedRestart(existing, desired)
+		merged := mergeSettings(existing, desired)
+		if err := r.client.UpdateSettings(ctx, merged); err != nil {
+			diags.AddError("Failed to update settings", err.Error())
+			return
+		}
+
+		if needRestart {
+			if err := r.client.RestartPanel(ctx); err != nil {
+				diags.AddError("Failed to restart panel", err.Error())
+				return
+			}
+		}
 	}
 
-	needRestart := panelSettingsNeedRestart(existing, desired)
-	merged := mergeSettings(existing, desired)
-	if err := r.client.UpdateSettings(ctx, merged); err != nil {
-		diags.AddError("Failed to update settings", err.Error())
-		return
-	}
-
-	if needRestart {
-		if err := r.client.RestartPanel(ctx); err != nil {
-			diags.AddError("Failed to restart panel", err.Error())
+	// xrayOutboundTestUrl is managed via xray endpoint, not settings API.
+	if !plan.XrayOutboundTestURL.IsNull() && !plan.XrayOutboundTestURL.IsUnknown() {
+		if err := r.client.SetXrayOutboundTestURL(ctx, plan.XrayOutboundTestURL.ValueString()); err != nil {
+			diags.AddError("Failed to set xray outbound test URL", err.Error())
 			return
 		}
 	}


### PR DESCRIPTION
## Summary
- Update docker-compose to 3x-ui v2.8.10
- Add `xray_outbound_test_url` attribute to `threexui_panel_general` resource (new in v2.8.10)
- Setting is served via xray endpoint (not AllSetting struct), so uses dedicated client methods
- All 46 acceptance tests pass on v2.8.10

## Changes
- `docker-compose.yaml` — v2.8.9 → v2.8.10
- `provider/client.go` — `GetXrayOutboundTestURL` / `SetXrayOutboundTestURL`
- `provider/resource_settings_tabs.go` — model, schema, CRUD for the new attribute
- `provider/acc_panel_settings_test.go` — tests with create, update, import, idempotency
- `docs/resources/panel_general.md` — documentation

## Test plan
- [x] `task build` passes
- [x] `task lint` — 0 issues
- [x] `task test` — 46/46 PASS on 3x-ui v2.8.10
- [x] `xray_outbound_test_url` create with custom value
- [x] `xray_outbound_test_url` update to default
- [x] Import preserves the value
- [x] Idempotency check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)