### PR TITLE
fix: reset CHANGELOG.md so Release Please recreates v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,1 @@
 # Changelog
-
-## [0.3.0](https://github.com/batonogov/terraform-provider-threexui/compare/v0.2.0...v0.3.0) (2026-03-06)
-
-
-### Features
-
-* add 3x-ui v2.8.11 support ([#34](https://github.com/batonogov/terraform-provider-threexui/issues/34)) ([36556eb](https://github.com/batonogov/terraform-provider-threexui/commit/36556eb4e44cb63ec498fd3ac7a58b7a7dfaf41f))
-* add Release Please for automated releases ([#29](https://github.com/batonogov/terraform-provider-threexui/issues/29)) ([02f4880](https://github.com/batonogov/terraform-provider-threexui/commit/02f48801e6204c71d5d584ac039806d746dac52d))
-* switch from OpenTofu to Terraform Registry ([#28](https://github.com/batonogov/terraform-provider-threexui/issues/28)) ([fb26e72](https://github.com/batonogov/terraform-provider-threexui/commit/fb26e72d47deab62b5d8b1346bd5ed5b1320ffaf))


### PR DESCRIPTION
## Summary

- Reset CHANGELOG.md to remove the v0.3.0 entry
- The previous v0.3.0 release had no binaries (GoReleaser never ran)
- Tag and release were deleted, but CHANGELOG still had the 0.3.0 entry, causing Release Please to skip to 0.4.0
- After merge, Release Please will correctly create a new v0.3.0 release PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)