### PR TITLE
docs: simplify README, add badges and license

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # Terraform Provider for 3x-ui
 
-A provider for managing [3x-ui](https://github.com/MHSanaei/3x-ui) panel inbounds, clients, settings, and Xray configuration via its HTTP API.
+[![CI](https://github.com/batonogov/terraform-provider-3x-ui/actions/workflows/ci.yml/badge.svg)](https://github.com/batonogov/terraform-provider-3x-ui/actions/workflows/ci.yml)
+[![Terraform Registry](https://img.shields.io/badge/terraform-registry-blueviolet)](https://registry.terraform.io/providers/batonogov/threexui/latest)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-## Installation
+A Terraform provider for managing [3x-ui](https://github.com/MHSanaei/3x-ui) panel inbounds, clients, settings, and Xray configuration via its HTTP API.
+
+## Quick Start
 
 ```hcl
 terraform {
@@ -12,31 +16,16 @@ terraform {
     }
   }
 }
-```
 
-## Provider Configuration
-
-```hcl
 provider "threexui" {
-  endpoint            = "http://localhost:2053"
-  username            = "admin"
-  password            = "admin"
-  # base_path           = "/"           # optional, matches webBasePath in 3x-ui
-  # insecure_skip_verify = true          # for self-signed HTTPS
-  # request_timeout      = "30s"
+  endpoint = "http://localhost:2053"
+  username = "admin"
+  password = "admin"
 }
-```
 
-## Resources
-
-### `threexui_inbound`
-
-Manages an inbound proxy. Supports protocols: `vless`, `vmess`, `trojan`, `shadowsocks`, `http`, `socks`, `mixed`, `wireguard`, `dokodemo-door`.
-
-```hcl
-resource "threexui_inbound" "example" {
-  remark   = "Example Inbound"
-  port     = 8443
+resource "threexui_inbound" "vless" {
+  remark   = "VLESS Reality"
+  port     = 443
   protocol = "vless"
 
   vless_settings {
@@ -57,62 +46,38 @@ resource "threexui_inbound" "example" {
     dest_override = ["http", "tls", "quic", "fakedns"]
   }
 }
-```
 
-Key attributes:
-- `remark` - Inbound label.
-- `port` - Listen port.
-- `protocol` - Protocol type.
-- Per-protocol settings block (`vless_settings`, `shadowsocks_settings`, `http_settings`, etc.).
-- `stream_settings` - Transport/security settings block (tcp, ws, grpc, httpupgrade, xhttp, kcp).
-- `sniffing` - Sniffing settings block.
-
-Note: Clients are managed exclusively via `threexui_inbound_client`.
-
-### `threexui_inbound_client`
-
-Manages a client within an existing inbound.
-
-```hcl
 resource "threexui_inbound_client" "client_a" {
-  inbound_id = threexui_inbound.example.id
+  inbound_id = threexui_inbound.vless.id
   email      = "client-a@example.com"
   enable     = true
   flow       = "xtls-rprx-vision"
 }
 ```
 
-Key attributes:
-- `inbound_id` - Inbound ID.
-- `email` - Client identifier (required).
-- `enable` - Whether the client is enabled.
-- `flow` - Flow for VLESS (`xtls-rprx-vision`, etc.).
-- `expiry_time` - Expiry as Unix timestamp in milliseconds.
-- `limit_ip` - IP limit.
-- `total_gb` - Traffic limit.
+## Documentation
 
-### Panel Settings
+Full documentation is available on the [Terraform Registry](https://registry.terraform.io/providers/batonogov/threexui/latest/docs).
+
+### Resources
 
 | Resource | Description |
 |---|---|
-| `threexui_panel_general` | General panel settings (web server, LDAP, display preferences) |
-| `threexui_panel_security` | Security settings (two-factor authentication) |
-| `threexui_panel_user` | Admin username and password |
+| `threexui_inbound` | Inbound proxy (vless, vmess, trojan, shadowsocks, http, socks, mixed, wireguard, dokodemo-door) |
+| `threexui_inbound_client` | Client within an inbound |
+| `threexui_panel_general` | General panel settings |
+| `threexui_panel_security` | Security settings (2FA) |
+| `threexui_panel_user` | Admin credentials |
 | `threexui_panel_telegram` | Telegram bot integration |
 | `threexui_panel_subscription` | Subscription service settings |
-
-### Xray Configuration
-
-| Resource | Description |
-|---|---|
 | `threexui_xray_basics` | Basic Xray config (log, policy, api, stats) |
 | `threexui_xray_dns` | DNS servers and hosts |
-| `threexui_xray_routing` | Routing rules and domain strategy |
+| `threexui_xray_routing` | Routing rules |
 | `threexui_xray_balancers` | Load balancers |
 | `threexui_xray_reverse` | Reverse proxy (bridges, portals) |
-| `threexui_xray_outbounds` | Outbound connections (per-protocol settings) |
+| `threexui_xray_outbounds` | Outbound connections |
 
-## Data Sources
+### Data Sources
 
 | Data Source | Description |
 |---|---|
@@ -121,16 +86,7 @@ Key attributes:
 | `threexui_settings` | All panel settings (JSON) |
 | `threexui_xray_config` | Current Xray template (JSON) |
 | `threexui_xray_versions` | Available Xray versions (list of strings) |
-
-## Import
-
-```bash
-# inbound
-terraform import threexui_inbound.example 123
-
-# inbound client: <inbound_id>:<client_id>
-terraform import threexui_inbound_client.client_a 123:client-id
-```
+| `threexui_online_clients` | Currently online client emails |
 
 ## Development
 
@@ -142,22 +98,7 @@ terraform import threexui_inbound_client.client_a 123:client-id
 - [pre-commit](https://pre-commit.com/) - git hooks framework
 - Docker - for local 3x-ui environment
 
-### Installing pre-commit hooks
-
-```bash
-# Install pre-commit
-pip install pre-commit
-# or via brew on macOS
-brew install pre-commit
-
-# Install git hooks
-pre-commit install
-
-# Run checks manually on all files
-pre-commit run --all-files
-```
-
-### Development commands
+### Commands
 
 ```bash
 task build        # Build the provider
@@ -167,18 +108,6 @@ task lint         # Run golangci-lint
 task pre-commit   # Run all checks manually (fmt, vet, lint, build)
 task test         # Run acceptance tests (starts docker compose)
 ```
-
-### Pre-commit checks
-
-On every commit the following checks run automatically:
-- **gofmt** - code formatting
-- **go vet** - static analysis
-- **golangci-lint** - linter
-- **go build** - compilation check
-- YAML/JSON file checks
-- Trailing whitespace check
-
-If checks fail, the commit is rejected. Fix the errors and try again.
 
 ### Local environment
 
@@ -191,3 +120,7 @@ docker compose up -d
 # Stop
 docker compose down
 ```
+
+## License
+
+[MIT](LICENSE)


### PR DESCRIPTION
## Summary

- Remove detailed usage instructions and attribute descriptions that duplicate Terraform Registry docs
- Add CI, Terraform Registry, and License badges
- Add quick start example (provider + inbound + client)
- Add License section
- Add missing `threexui_online_clients` data source to the table

## Test plan

- [ ] Verify badges render correctly on GitHub
- [ ] Verify links to Terraform Registry and LICENSE work

Generated with [Claude Code](https://claude.com/claude-code)