### PR TITLE
fix: add default empty string for inbound remark attribute

### DIFF
--- a/provider/acc_inbound_test.go
+++ b/provider/acc_inbound_test.go
@@ -683,6 +683,73 @@ resource "threexui_inbound" "listen" {
 	})
 }
 
+// --- Remark omitted (default empty string), then set, then removed ---
+
+func TestAccInboundRemarkDefault(t *testing.T) {
+	configNoRemark := testAccProviderConfig() + `
+resource "threexui_inbound" "noremark" {
+  port     = 25026
+  protocol = "vless"
+  enable   = true
+  vless_settings {
+    decryption = "none"
+  }
+}
+`
+	configWithRemark := testAccProviderConfig() + `
+resource "threexui_inbound" "noremark" {
+  port     = 25026
+  protocol = "vless"
+  remark   = "now-has-remark"
+  enable   = true
+  vless_settings {
+    decryption = "none"
+  }
+}
+`
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		CheckDestroy:             testAccCheckInboundDestroyed,
+		Steps: []resource.TestStep{
+			// Step 1: create without remark — defaults to ""
+			{
+				Config: configNoRemark,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("threexui_inbound.noremark", "id"),
+					resource.TestCheckResourceAttr("threexui_inbound.noremark", "remark", ""),
+				),
+			},
+			// Step 2: idempotency — no diff on re-apply
+			{
+				Config:             configNoRemark,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			// Step 3: set remark
+			{
+				Config: configWithRemark,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("threexui_inbound.noremark", "remark", "now-has-remark"),
+				),
+			},
+			// Step 4: remove remark — back to default ""
+			{
+				Config: configNoRemark,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("threexui_inbound.noremark", "remark", ""),
+				),
+			},
+			// Step 5: idempotency after removing remark
+			{
+				Config:             configNoRemark,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
 // --- Config helpers ---
 
 func testAccInboundUpdateConfig(remark string, port int, enable bool) string {

--- a/provider/resource_inbound.go
+++ b/provider/resource_inbound.go
@@ -113,6 +113,8 @@ func (r *InboundResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 			},
 			"remark": schema.StringAttribute{
 				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString(""),
 				Description: "Remark / display name for the inbound.",
 			},
 			"enable": schema.BoolAttribute{


### PR DESCRIPTION
## Summary
- Add `Computed: true` and `Default: stringdefault.StaticString("")` to the `remark` attribute in `threexui_inbound` resource
- Without this fix, omitting `remark` in config causes `"was null, but now cty.StringVal("")"` error on apply
- Add acceptance test `TestAccInboundRemarkDefault` covering full lifecycle: create without remark → idempotency → set remark → remove remark → idempotency

## Test plan
- [ ] `task test` passes (acceptance tests with Docker)
- [ ] New test `TestAccInboundRemarkDefault` validates all 5 steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)