### PR TITLE
fix: remove email fallback in getClientIDFromModel

### DIFF
--- a/provider/acc_inbound_client_test.go
+++ b/provider/acc_inbound_client_test.go
@@ -275,6 +275,95 @@ resource "threexui_inbound_client" "remove1" {
 	})
 }
 
+// --- Client without client_id: UUID auto-generated, delete+recreate works ---
+
+func TestAccInboundClientAutoUUID(t *testing.T) {
+	config := testAccProviderConfig() + `
+resource "threexui_inbound" "autouuid_host" {
+  port     = 25107
+  protocol = "vless"
+  remark   = "acc-autouuid-host"
+  enable   = true
+  vless_settings {
+    decryption = "none"
+  }
+}
+
+resource "threexui_inbound_client" "autouuid" {
+  inbound_id = threexui_inbound.autouuid_host.id
+  email      = "autouuid@test.com"
+  enable     = true
+  flow       = "xtls-rprx-vision"
+}
+`
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		CheckDestroy:             testAccCheckInboundClientDestroyed,
+		Steps: []resource.TestStep{
+			// Step 1: create without client_id — UUID auto-generated
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("threexui_inbound_client.autouuid", "id"),
+					resource.TestCheckResourceAttrSet("threexui_inbound_client.autouuid", "client_id"),
+					resource.TestCheckResourceAttr("threexui_inbound_client.autouuid", "email", "autouuid@test.com"),
+				),
+			},
+			// Step 2: idempotency
+			{
+				Config:             config,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+// --- Client with explicit client_id ---
+
+func TestAccInboundClientExplicitID(t *testing.T) {
+	config := testAccProviderConfig() + `
+resource "threexui_inbound" "explicitid_host" {
+  port     = 25108
+  protocol = "vless"
+  remark   = "acc-explicitid-host"
+  enable   = true
+  vless_settings {
+    decryption = "none"
+  }
+}
+
+resource "threexui_inbound_client" "explicitid" {
+  inbound_id = threexui_inbound.explicitid_host.id
+  client_id  = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+  email      = "explicitid@test.com"
+  enable     = true
+  flow       = "xtls-rprx-vision"
+}
+`
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		CheckDestroy:             testAccCheckInboundClientDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("threexui_inbound_client.explicitid", "client_id", "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"),
+					resource.TestCheckResourceAttr("threexui_inbound_client.explicitid", "email", "explicitid@test.com"),
+				),
+			},
+			// Idempotency
+			{
+				Config:             config,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
 // --- Config helpers ---
 
 func testAccInboundClientUpdateConfig(email string, enable bool, limitIP int, comment string) string {

--- a/provider/inbound_client_resource_test.go
+++ b/provider/inbound_client_resource_test.go
@@ -1,6 +1,10 @@
 package provider
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
 
 func TestFindClientByID(t *testing.T) {
 	clients := []map[string]any{
@@ -34,4 +38,50 @@ func TestSplitInboundClientID(t *testing.T) {
 	if _, _, err := splitInboundClientID("bad"); err == nil {
 		t.Fatalf("expected error")
 	}
+}
+
+func TestGetClientIDFromModel(t *testing.T) {
+	t.Run("explicit client_id wins", func(t *testing.T) {
+		m := &InboundClientResourceModel{
+			ClientID: types.StringValue("my-uuid"),
+			Email:    types.StringValue("user@test.com"),
+		}
+		got := getClientIDFromModel(m, map[string]any{"email": "user@test.com"})
+		if got != "my-uuid" {
+			t.Fatalf("expected my-uuid, got %q", got)
+		}
+	})
+
+	t.Run("password fallback", func(t *testing.T) {
+		m := &InboundClientResourceModel{
+			ClientID: types.StringUnknown(),
+			Email:    types.StringValue("user@test.com"),
+		}
+		got := getClientIDFromModel(m, map[string]any{"password": "trojan-pass", "email": "user@test.com"})
+		if got != "trojan-pass" {
+			t.Fatalf("expected trojan-pass, got %q", got)
+		}
+	})
+
+	t.Run("no fallback to email", func(t *testing.T) {
+		m := &InboundClientResourceModel{
+			ClientID: types.StringUnknown(),
+			Email:    types.StringValue("user@test.com"),
+		}
+		got := getClientIDFromModel(m, map[string]any{"email": "user@test.com"})
+		if got != "" {
+			t.Fatalf("expected empty string (UUID will be generated), got %q", got)
+		}
+	})
+
+	t.Run("null client_id returns empty", func(t *testing.T) {
+		m := &InboundClientResourceModel{
+			ClientID: types.StringNull(),
+			Email:    types.StringValue("user@test.com"),
+		}
+		got := getClientIDFromModel(m, map[string]any{"email": "user@test.com"})
+		if got != "" {
+			t.Fatalf("expected empty string, got %q", got)
+		}
+	})
 }

--- a/provider/resource_inbound_client.go
+++ b/provider/resource_inbound_client.go
@@ -417,9 +417,6 @@ func getClientIDFromModel(m *InboundClientResourceModel, client map[string]any) 
 	if v := stringValue(client["password"]); v != "" {
 		return v
 	}
-	if v := stringValue(client["email"]); v != "" {
-		return v
-	}
 	return ""
 }
 


### PR DESCRIPTION
## Summary
- Remove email fallback in `getClientIDFromModel` — when `client_id` is not set, a UUID is now always generated instead of using email as the JSON `id`
- Previously, email-as-id caused 3x-ui to not clean up `client_traffics` on deletion, leading to "Duplicate email" errors on recreate
- Add unit tests for `getClientIDFromModel` (explicit id, password fallback, no email fallback, null)
- Add acceptance tests: `TestAccInboundClientAutoUUID` (auto UUID + idempotency), `TestAccInboundClientExplicitID` (explicit UUID + idempotency)

## Test plan
- [ ] `task test` passes (acceptance tests with Docker)
- [ ] Unit test `TestGetClientIDFromModel` covers all branches
- [ ] `TestAccInboundClientAutoUUID` — client without `client_id` gets a UUID
- [ ] `TestAccInboundClientExplicitID` — client with explicit `client_id` preserves it

🤖 Generated with [Claude Code](https://claude.com/claude-code)