### PR TITLE
fix: handle last client deletion in inbound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.4.2](https://github.com/batonogov/terraform-provider-threexui/compare/v0.4.1...v0.4.2) (2026-03-06)
+
+
+### Bug Fixes
+
+* remove email fallback in getClientIDFromModel ([#46](https://github.com/batonogov/terraform-provider-threexui/issues/46)) ([d496d93](https://github.com/batonogov/terraform-provider-threexui/commit/d496d9368bf30611b67bc284f0d9faafffcacc46))
+
 ## [0.4.1](https://github.com/batonogov/terraform-provider-threexui/compare/v0.4.0...v0.4.1) (2026-03-06)
 
 

--- a/provider/acc_inbound_client_test.go
+++ b/provider/acc_inbound_client_test.go
@@ -364,6 +364,86 @@ resource "threexui_inbound_client" "explicitid" {
 	})
 }
 
+// --- Last client replaced with placeholder on delete ---
+
+func TestAccInboundClientDeleteLastPlaceholder(t *testing.T) {
+	// Step 1: create inbound with a single client.
+	step1Config := testAccProviderConfig() + `
+resource "threexui_inbound" "last_client_host" {
+  port     = 25109
+  protocol = "vless"
+  remark   = "acc-last-client"
+  enable   = true
+  vless_settings {
+    decryption = "none"
+  }
+}
+
+resource "threexui_inbound_client" "only" {
+  inbound_id = threexui_inbound.last_client_host.id
+  email      = "only@test.com"
+  enable     = true
+  flow       = "xtls-rprx-vision"
+}
+`
+	// Step 2: remove the client from config, keeping the inbound.
+	// The last client should be replaced with a disabled placeholder.
+	step2Config := testAccProviderConfig() + `
+resource "threexui_inbound" "last_client_host" {
+  port     = 25109
+  protocol = "vless"
+  remark   = "acc-last-client"
+  enable   = true
+  vless_settings {
+    decryption = "none"
+  }
+}
+`
+	// Step 3: re-add a client with the same email — must succeed because
+	// the placeholder freed the original email.
+	step3Config := testAccProviderConfig() + `
+resource "threexui_inbound" "last_client_host" {
+  port     = 25109
+  protocol = "vless"
+  remark   = "acc-last-client"
+  enable   = true
+  vless_settings {
+    decryption = "none"
+  }
+}
+
+resource "threexui_inbound_client" "reused" {
+  inbound_id = threexui_inbound.last_client_host.id
+  email      = "only@test.com"
+  enable     = true
+  flow       = "xtls-rprx-vision"
+}
+`
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		CheckDestroy:             testAccCheckInboundClientDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: step1Config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("threexui_inbound_client.only", "id"),
+					resource.TestCheckResourceAttr("threexui_inbound_client.only", "email", "only@test.com"),
+				),
+			},
+			{
+				Config: step2Config,
+			},
+			{
+				Config: step3Config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("threexui_inbound_client.reused", "email", "only@test.com"),
+				),
+			},
+		},
+	})
+}
+
 // --- Config helpers ---
 
 func testAccInboundClientUpdateConfig(email string, enable bool, limitIP int, comment string) string {

--- a/provider/inbound_client_api_test.go
+++ b/provider/inbound_client_api_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -67,5 +68,21 @@ func TestClientDeleteInboundClient(t *testing.T) {
 	}
 	if gotPath != "/panel/api/inbounds/9/delClient/cid" {
 		t.Fatalf("unexpected path: %s", gotPath)
+	}
+}
+
+func TestClientDeleteInboundClientLastClient(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(failResponse("Something went wrong (no client remained in Inbound)"))
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv.URL)
+	err := client.DeleteInboundClient(context.Background(), 9, "cid")
+	if err == nil {
+		t.Fatal("expected error when deleting last client")
+	}
+	if !strings.Contains(err.Error(), "no client remained in Inbound") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/provider/resource_inbound_client.go
+++ b/provider/resource_inbound_client.go
@@ -279,16 +279,54 @@ func (r *InboundClientResource) Delete(ctx context.Context, req resource.DeleteR
 	inboundClientMu.Lock()
 	defer inboundClientMu.Unlock()
 
+	// Check if inbound still exists. If it was already deleted (e.g. during
+	// terraform destroy), silently remove the client from state — it was
+	// destroyed together with the inbound.
+	inbound, err := r.client.GetInbound(ctx, inboundID)
+	if err != nil {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	if err := ensureInboundClientsKey(ctx, r.client, inboundID); err != nil {
 		resp.Diagnostics.AddError("Failed to ensure clients key", err.Error())
 		return
 	}
 
-	if err := r.client.DeleteInboundClient(ctx, inboundID, clientID); err != nil {
-		if strings.Contains(err.Error(), "no client remained in Inbound") {
-			resp.State.RemoveResource(ctx)
+	// 3x-ui does not allow deleting the last client in an inbound.
+	// If this is the last client, replace it with a disabled placeholder
+	// (random email, enable=false) to free the original email and satisfy
+	// the 3x-ui invariant. The placeholder is cleaned up when the inbound
+	// itself is deleted.
+	settings, parseErr := parseInboundSettings(inbound.Settings)
+	if parseErr == nil && len(settings.Clients) <= 1 {
+		placeholderID, genErr := newUUID()
+		if genErr != nil {
+			resp.Diagnostics.AddError("Failed to generate placeholder UUID", genErr.Error())
 			return
 		}
+		placeholderEmail := fmt.Sprintf("_deleted_%s", placeholderID[:8])
+		placeholder := map[string]any{
+			"email":  placeholderEmail,
+			"enable": false,
+		}
+		switch inbound.Protocol {
+		case "trojan":
+			placeholder["password"] = placeholderID
+		case "shadowsocks":
+			placeholder["email"] = placeholderEmail
+		default:
+			placeholder["id"] = placeholderID
+		}
+		if updateErr := r.client.UpdateInboundClient(ctx, inboundID, clientID, placeholder); updateErr != nil {
+			resp.Diagnostics.AddError("Failed to replace last client with placeholder", updateErr.Error())
+			return
+		}
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if err := r.client.DeleteInboundClient(ctx, inboundID, clientID); err != nil {
 		resp.Diagnostics.AddError("Failed to delete inbound client", err.Error())
 		return
 	}


### PR DESCRIPTION
## Summary

- When deleting the last client in an inbound, the provider now replaces it with a disabled placeholder (random UUID + email, `enable=false`) instead of silently removing from state while the client remains in 3x-ui
- This prevents "Duplicate email" errors on subsequent applies
- If the inbound was already deleted (e.g. `terraform destroy`), the client is silently removed from state
- Supports all protocols: vless/vmess (id), trojan (password), shadowsocks (email)

Matches 3x-ui behavior: the UI hides the delete button for the last client (`isRemovable`), the API returns "no client remained in Inbound"

## Test plan

- [x] Unit test: `TestClientDeleteInboundClientLastClient` — API error propagation
- [x] Acceptance test: `TestAccInboundClientDeleteLastPlaceholder` — full cycle: create single client → remove from config → re-add with same email
- [x] All 49 existing acceptance tests pass (including trojan, vmess, shadowsocks)
- [x] `terraform destroy` works correctly (inbound deletion cleans up placeholder)

🤖 Generated with [Claude Code](https://claude.com/claude-code)