### PR TITLE
docs: clarify 2FA support contract

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,7 +126,7 @@ Unauthenticated requests return 404 (not 401). The client performs auto re-login
 - `settingsApplyTyped` / `settingsReadTyped` — shared CRUD logic (expand model → API → flatten → model)
 - Delete only clears TF state, does **not** reset settings in the API
 - Subscription resource performs double apply (workaround for 3x-ui bug: sub_json_enable not saved on first apply together with sub_enable)
-- Enabling 2FA blocks the provider (login does not support 2FA code) — Warning added
+- Enabling 2FA — Warning added (partial support: TOTP code sent on initial login, but auto re-login fails when code expires)
 - Changing `web_base_path` requires updating `base_path` in provider config — Warning added
 - `panelSettingsNeedRestart` — keys: webListen, webDomain, webPort, webBasePath, webCertFile, webKeyFile, sessionMaxAge
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,7 +48,7 @@ resource "threexui_inbound" "vless" {
 
 The provider authenticates to the 3x-ui panel using username and password. These can be provided directly in the provider configuration or via environment variables.
 
--> **Note:** The provider does not currently support two-factor authentication codes during login. Enabling 2FA on the panel will prevent the provider from authenticating.
+-> **Note:** The provider has **partial** 2FA support. You can supply a TOTP code via the `two_factor_code` attribute, and it will be sent with the initial login request. However, TOTP codes expire every 30 seconds. Because the provider performs automatic re-login when the session expires (on HTTP 401/404), subsequent logins will fail once the original code is no longer valid. For short-lived operations (a single `terraform apply`) this may work, but long-running or repeated runs will require a fresh code each time.
 
 ## Argument Reference
 
@@ -56,6 +56,6 @@ The provider authenticates to the 3x-ui panel using username and password. These
 - `base_path` (Optional, String) - Base path configured in 3x-ui (`webBasePath`). Default is `/`.
 - `username` (Optional, String) - 3x-ui username. Default is `admin`.
 - `password` (Optional, String, Sensitive) - 3x-ui password. Default is `admin`.
-- `two_factor_code` (Optional, String, Sensitive) - Optional 2FA code for login.
+- `two_factor_code` (Optional, String, Sensitive) - TOTP code for 2FA login. Used for the initial authentication request. See the note above about re-login limitations.
 - `insecure_skip_verify` (Optional, Boolean) - Skip TLS certificate verification (useful for self-signed certs). Default is `false`.
 - `request_timeout` (Optional, String) - HTTP request timeout (e.g. `30s`, `1m`). Default is `30s`.

--- a/docs/resources/panel_security.md
+++ b/docs/resources/panel_security.md
@@ -11,7 +11,7 @@ Manages the security settings of the 3x-ui panel, specifically two-factor authen
 
 This is a singleton resource -- only one instance should exist per provider. Deleting this resource only removes it from Terraform state; it does not reset the settings.
 
-~> **Warning:** Enabling `two_factor_enable` will block the provider from authenticating to the panel, as the provider does not support 2FA codes during login.
+~> **Warning:** If you enable 2FA, you **must** also set `two_factor_code` in the provider configuration. The code is sent with the initial login request, but TOTP codes expire every 30 seconds. Automatic re-login (triggered when the session expires) will fail once the original code is no longer valid. Short-lived operations like a single `terraform apply` may succeed, but long-running or repeated runs require a fresh code each time.
 
 ## Example Usage
 

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -61,7 +61,7 @@ func (p *ThreeXUIProvider) Schema(_ context.Context, _ provider.SchemaRequest, r
 			"two_factor_code": schema.StringAttribute{
 				Optional:    true,
 				Sensitive:   true,
-				Description: "Optional 2FA code for login.",
+				Description: "TOTP code for 2FA login. Sent with the initial authentication request; automatic re-login will fail once the code expires.",
 			},
 			"insecure_skip_verify": schema.BoolAttribute{
 				Optional:    true,

--- a/provider/resource_settings_tabs.go
+++ b/provider/resource_settings_tabs.go
@@ -1251,8 +1251,8 @@ func (r *PanelSecurityResource) ImportState(ctx context.Context, _ resource.Impo
 func (r *PanelSecurityResource) warnIfTwoFactor(plan *PanelSecurityModel, diags *diag.Diagnostics) {
 	if !plan.TwoFactorEnable.IsNull() && !plan.TwoFactorEnable.IsUnknown() && plan.TwoFactorEnable.ValueBool() {
 		diags.AddWarning(
-			"Enabling 2FA will block provider authentication",
-			"The provider does not support two-factor authentication codes during login. Enabling 2FA will prevent the provider from connecting to the panel. You will need to disable 2FA via the API or UI to restore provider access.",
+			"2FA enabled — automatic re-login will not work",
+			"The provider can send a TOTP code with the initial login (via the two_factor_code provider attribute), but TOTP codes expire every 30 seconds. Automatic re-login on session expiry will fail once the code is no longer valid. Ensure you supply a fresh two_factor_code for each run, or disable 2FA to allow unattended operation.",
 		)
 	}
 }


### PR DESCRIPTION
## Summary
- Clarifies that 2FA support is **partial**: TOTP code is sent with initial login, but automatic re-login fails once the code expires
- Aligns `docs/index.md`, `docs/resources/panel_security.md`, runtime warning, and schema description with this contract
- Updates CLAUDE.md to reflect the corrected 2FA description

Closes #50

## Test plan
- [x] `task build` passes
- [x] `task test:unit` — all 169 tests pass
- [x] Pre-commit hooks pass