### PR TITLE
test: add acceptance compatibility matrix for bundled 3x-ui versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,3 +92,33 @@ jobs:
 
       - name: Run acceptance tests
         run: task test:acc
+
+  acceptance-matrix:
+    name: Compat (${{ matrix.version }})
+    runs-on: ubuntu-latest
+    needs: [lint]
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["v2.8.9", "v2.8.10", "v2.8.11", "v2.9.0"]
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_wrapper: false
+
+      - name: Install Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+
+      - name: Run compatibility tests
+        env:
+          THREEXUI_VERSION: ${{ matrix.version }}
+        run: task test:acc:compat

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ["v2.8.9", "v2.8.10", "v2.8.11", "v2.9.0"]
+        version: ["v2.8.9", "v2.8.10", "v2.8.11"]
     steps:
       - uses: actions/checkout@v6
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,10 +37,10 @@ provider/              — all provider code
   data_source_*.go     — data sources (inbounds, server_status, settings, xray_config, xray_versions, online_clients)
 examples/              — example TF configs for manual testing
 3x-ui-<version>/      — 3x-ui source snapshots (in .gitignore, for reference/diffing)
-docker-compose.yaml    — 3x-ui v2.9.0 on port 2053 (update image tag when bumping version)
+docker-compose.yaml    — 3x-ui on port 2053 (version via THREEXUI_VERSION env, default v2.9.0)
 Taskfile.yml           — task build / test / fmt
 .github/workflows/
-  ci.yml               — lint, unit tests, acceptance tests (PR + push main)
+  ci.yml               — lint, unit tests, acceptance tests, compatibility matrix (PR + push main)
   docs.yml             — docs/examples validation: terraform fmt, markdownlint, yamllint (PR + push main)
   release-please.yml   — Release Please + GoReleaser (conventional commits → semver tag → build + sign + publish)
 ```
@@ -166,14 +166,15 @@ Unauthenticated requests return 404 (not 401). The client performs auto re-login
 ## Commands
 
 ```bash
-task build       # Build binary
-task test:unit   # Run unit tests (no Docker / Terraform needed)
-task test:acc    # Run acceptance tests (requires Docker)
-task test        # Run unit + acceptance tests
-task fmt         # gofmt
-task vet         # go vet
-task lint        # golangci-lint
-task pre-commit  # Run all pre-commit checks manually (fmt, vet, lint, build)
+task build            # Build binary
+task test:unit        # Run unit tests (no Docker / Terraform needed)
+task test:acc         # Run acceptance tests (requires Docker)
+task test:acc:compat  # Run compatibility subset against THREEXUI_VERSION (default v2.9.0)
+task test             # Run unit + acceptance tests
+task fmt              # gofmt
+task vet              # go vet
+task lint             # golangci-lint
+task pre-commit       # Run all pre-commit checks manually (fmt, vet, lint, build)
 ```
 
 ## Pre-commit Hooks
@@ -199,6 +200,14 @@ docker compose up -d   # Start 3x-ui on localhost:2053
 # Login: admin / admin
 # Docker image defaults to webBasePath = / (NOT /panel/)
 # Do not set THREEXUI_BASE_PATH
+
+# Run compatibility subset against a specific 3x-ui version:
+THREEXUI_VERSION=v2.8.9 task test:acc:compat
+
+# Run all versions locally:
+for v in v2.8.9 v2.8.10 v2.8.11 v2.9.0; do
+  echo "=== Testing $v ===" && THREEXUI_VERSION=$v task test:acc:compat
+done
 ```
 
 Acceptance tests use `terraform-plugin-testing`:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -36,6 +36,28 @@ tasks:
         THREEXUI_PASSWORD=admin
         go test ./provider -run TestAcc -count=1 -timeout 600s -v
 
+  test:acc:compat:
+    desc: Запустить acceptance-тесты совместимости (репрезентативное подмножество)
+    vars:
+      TERRAFORM_PATH:
+        sh: which terraform
+      THREEXUI_VERSION: '{{.THREEXUI_VERSION | default "v2.9.0"}}'
+    cmds:
+      - docker compose down -v 2>/dev/null || true
+      - docker compose up --detach --wait --quiet-pull
+      - defer: docker compose down
+      - >-
+        TF_ACC=1
+        TF_ACC_TERRAFORM_PATH={{.TERRAFORM_PATH}}
+        TF_ACC_PROVIDER_NAMESPACE=batonogov
+        TF_ACC_PROVIDER_HOST=registry.terraform.io
+        THREEXUI_ENDPOINT=http://localhost:2053
+        THREEXUI_USERNAME=admin
+        THREEXUI_PASSWORD=admin
+        go test ./provider
+        -run 'TestAccInboundBasic|TestAccInboundUpdateFields|TestAccInboundTrojan|TestAccInboundShadowsocks|TestAccInboundClientBasic|TestAccInboundClientUpdate|TestAccPanelGeneral|TestAccPanelSubscription|TestAccXrayBasics|TestAccXrayRouting|TestAccXrayOutbounds|TestAccDataSources'
+        -count=1 -timeout 600s -v
+
   fmt:
     desc: Форматировать Go-файлы
     cmds:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -42,7 +42,10 @@ tasks:
       TERRAFORM_PATH:
         sh: which terraform
       THREEXUI_VERSION: '{{.THREEXUI_VERSION | default "v2.9.0"}}'
+      COMPAT_TESTS: >-
+        TestAccInboundBasic$|TestAccInboundUpdateFields$|TestAccInboundTrojan$|TestAccInboundShadowsocks$|TestAccInboundClientBasic$|TestAccInboundClientUpdate$|TestAccXrayBasics$|TestAccXrayRouting$|TestAccXrayOutbounds$|TestAccDataSources$
     cmds:
+      - echo "Running compat tests against 3x-ui {{.THREEXUI_VERSION}}"
       - docker compose down -v 2>/dev/null || true
       - docker compose up --detach --wait --quiet-pull
       - defer: docker compose down
@@ -55,7 +58,7 @@ tasks:
         THREEXUI_USERNAME=admin
         THREEXUI_PASSWORD=admin
         go test ./provider
-        -run 'TestAccInboundBasic|TestAccInboundUpdateFields|TestAccInboundTrojan|TestAccInboundShadowsocks|TestAccInboundClientBasic|TestAccInboundClientUpdate|TestAccPanelGeneral|TestAccPanelSubscription|TestAccXrayBasics|TestAccXrayRouting|TestAccXrayOutbounds|TestAccDataSources'
+        -run '{{.COMPAT_TESTS}}'
         -count=1 -timeout 600s -v
 
   fmt:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   3xui:
-    image: ghcr.io/mhsanaei/3x-ui:v2.9.0
+    image: ghcr.io/mhsanaei/3x-ui:${THREEXUI_VERSION:-v2.9.0}
     ports:
       - "2053:2053" # HTTP panel
     environment:


### PR DESCRIPTION
## Summary
- Parameterized `docker-compose.yaml` via `${THREEXUI_VERSION:-v2.9.0}`
- New CI job `acceptance-matrix` with versions [v2.8.9, v2.8.10, v2.8.11], `fail-fast: false`
- v2.9.0 excluded from matrix (already covered by main `acceptance-tests` job)
- New Taskfile task `test:acc:compat` with representative test subset
- All test names anchored with `$` to prevent regex over-matching
- Excluded 2.9.0-only tests (PanelGeneral, PanelSubscription) from compat subset
- CLAUDE.md updated with local run instructions

Closes #72

## Test plan
- [ ] `THREEXUI_VERSION=v2.8.9 task test:acc:compat` passes locally
- [ ] CI matrix runs all 3 versions independently
- [ ] Existing `acceptance-tests` job unaffected