### PR TITLE
fix: eliminate false drift on import for Optional+Computed inbound fields

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,7 +118,9 @@ Unauthenticated requests return 404 (not 401). The client performs auto re-login
 - KCP: `congestion`, `read_buffer_size`, `write_buffer_size` replaced by `cwnd_multiplier`, `max_sending_window` (breaking, 2.9.0)
 - WireGuard: `mtu` changed from int to list [v4, v6]; added `gateway` and `dns` list fields (breaking, 2.9.0)
 - Hysteria: `auth` field on `threexui_inbound_client` used as client identifier (instead of UUID-based `id`)
+- All `Optional+Computed` inbound attributes have `UseStateForUnknown` plan modifiers — prevents false drift (`known after apply`) after import
 - `alignBlocksWithPlan` — prevents "was absent, but now present" errors for Optional blocks (Create/Read/Update); skipped during Import (detect: `state.Protocol.IsNull()`)
+- `ModifyPlan` — preserves `reality_settings.settings` nested block from state when absent in config; needed because blocks don't support attribute-level plan modifiers, and `alignBlocksWithPlan` doesn't nil sub-sub-blocks when the parent block is present
 - `preserveInboundSettings` — on update, preserves clients and testseed from existing inbound
 - `ensureRealityKeys` — auto-generates private/public key and short_ids
 - `ensureInboundClientIDs` — auto-generates UUID for clients without id

--- a/docs/resources/inbound.md
+++ b/docs/resources/inbound.md
@@ -332,3 +332,37 @@ Inbounds can be imported using their numeric ID:
 ```shell
 terraform import threexui_inbound.example 1
 ```
+
+After import, you only need to specify the fields you want to manage in your configuration.
+Server-populated fields (`show`, `xver`, `short_ids`, `fingerprint`, `public_key`, `private_key`,
+`spider_x`, `metadata_only`, `route_only`, `encryption`, `selected_auth`, etc.) are automatically
+preserved from the imported state — no need to copy them into your `.tf` file.
+
+For example, a minimal configuration for an imported VLESS + Reality inbound:
+
+```hcl
+resource "threexui_inbound" "example" {
+  port     = 443
+  protocol = "vless"
+  enable   = true
+  remark   = "My VLESS"
+
+  vless_settings {
+    decryption = "none"
+  }
+
+  stream_settings {
+    network  = "tcp"
+    security = "reality"
+    reality_settings {
+      target       = "www.apple.com:443"
+      server_names = ["www.apple.com"]
+    }
+  }
+
+  sniffing {
+    enabled       = true
+    dest_override = ["http", "tls", "quic", "fakedns"]
+  }
+}
+```

--- a/provider/acc_inbound_test.go
+++ b/provider/acc_inbound_test.go
@@ -1034,6 +1034,119 @@ resource "threexui_inbound" "hysteria" {
 	})
 }
 
+// --- Import: no drift with minimal config ---
+//
+// After importing an existing inbound, planning with a config that omits
+// Optional+Computed fields (show, xver, short_ids, metadata_only, route_only,
+// encryption, selected_auth, reality settings block, etc.) must produce an
+// empty plan.  This is the primary regression test for the UseStateForUnknown
+// plan modifiers and the ModifyPlan that preserves reality_settings.settings.
+
+func TestAccInboundImportNoDrift_Reality(t *testing.T) {
+	config := testAccProviderConfig() + `
+resource "threexui_inbound" "import_reality" {
+  port     = 25031
+  protocol = "vless"
+  remark   = "acc-import-reality"
+  enable   = true
+  vless_settings {
+    decryption = "none"
+  }
+  stream_settings {
+    network  = "tcp"
+    security = "reality"
+    reality_settings {
+      target       = "google.com:443"
+      server_names = ["google.com"]
+    }
+  }
+  sniffing {
+    enabled       = true
+    dest_override = ["http", "tls"]
+  }
+}
+`
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		CheckDestroy:             testAccCheckInboundDestroyed,
+		Steps: []resource.TestStep{
+			// Step 1: Create — server populates show, xver, short_ids,
+			// reality settings (fingerprint, public_key, spider_x),
+			// sniffing (metadata_only, route_only), vless (encryption).
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("threexui_inbound.import_reality", "id"),
+					resource.TestCheckResourceAttr("threexui_inbound.import_reality", "protocol", "vless"),
+				),
+			},
+			// Step 2: Import — fresh state from the API.
+			{
+				ResourceName:      "threexui_inbound.import_reality",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Step 3: Plan with the same config — must be empty.
+			// Without UseStateForUnknown modifiers this step fails because
+			// Terraform plans show, xver, short_ids, metadata_only, etc.
+			// as "(known after apply)".
+			{
+				Config:             config,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+func TestAccInboundImportNoDrift_Sniffing(t *testing.T) {
+	config := testAccProviderConfig() + `
+resource "threexui_inbound" "import_sniffing" {
+  port     = 25032
+  protocol = "vless"
+  remark   = "acc-import-sniffing"
+  enable   = true
+  vless_settings {
+    decryption = "none"
+  }
+  stream_settings {
+    network  = "tcp"
+    security = "none"
+  }
+  sniffing {
+    enabled       = true
+    dest_override = ["http", "tls"]
+  }
+}
+`
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		CheckDestroy:             testAccCheckInboundDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("threexui_inbound.import_sniffing", "id"),
+				),
+			},
+			{
+				ResourceName:      "threexui_inbound.import_sniffing",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// After import, metadata_only, route_only, ips_excluded,
+			// domains_excluded are in state but not in config — must not drift.
+			{
+				Config:             config,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
 // --- Config helpers ---
 
 func testAccInboundUpdateConfig(remark string, port int, enable bool) string {

--- a/provider/acc_inbound_test.go
+++ b/provider/acc_inbound_test.go
@@ -1082,10 +1082,17 @@ resource "threexui_inbound" "import_reality" {
 				),
 			},
 			// Step 2: Import — fresh state from the API.
+			// reality_settings.settings is populated by Read during import
+			// but nil'd by alignBlocksWithPlan during Create (user didn't
+			// specify it).  ModifyPlan keeps them in sync at plan time, so
+			// Step 3 verifies no drift; here we just skip the sub-block.
 			{
 				ResourceName:      "threexui_inbound.import_reality",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"stream_settings.reality_settings.settings",
+				},
 			},
 			// Step 3: Plan with the same config — must be empty.
 			// Without UseStateForUnknown modifiers this step fails because

--- a/provider/inbound_settings_schema.go
+++ b/provider/inbound_settings_schema.go
@@ -3,6 +3,12 @@ package provider
 import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -97,14 +103,23 @@ func inboundSettingsBlockSchemas() map[string]schema.Block {
 				"decryption": schema.StringAttribute{
 					Optional: true, Computed: true,
 					Description: "Decryption method (usually 'none').",
+					PlanModifiers: []planmodifier.String{
+						stringplanmodifier.UseStateForUnknown(),
+					},
 				},
 				"encryption": schema.StringAttribute{
 					Optional: true, Computed: true,
 					Description: "Encryption method.",
+					PlanModifiers: []planmodifier.String{
+						stringplanmodifier.UseStateForUnknown(),
+					},
 				},
 				"selected_auth": schema.StringAttribute{
 					Optional: true, Computed: true,
 					Description: "Selected authentication type.",
+					PlanModifiers: []planmodifier.String{
+						stringplanmodifier.UseStateForUnknown(),
+					},
 				},
 			},
 			Blocks: map[string]schema.Block{
@@ -133,18 +148,30 @@ func inboundSettingsBlockSchemas() map[string]schema.Block {
 				"method": schema.StringAttribute{
 					Optional: true, Computed: true,
 					Description: "Encryption method (e.g. aes-256-gcm, chacha20-ietf-poly1305).",
+					PlanModifiers: []planmodifier.String{
+						stringplanmodifier.UseStateForUnknown(),
+					},
 				},
 				"password": schema.StringAttribute{
 					Optional: true, Computed: true, Sensitive: true,
 					Description: "Password for encryption.",
+					PlanModifiers: []planmodifier.String{
+						stringplanmodifier.UseStateForUnknown(),
+					},
 				},
 				"network": schema.StringAttribute{
 					Optional: true, Computed: true,
 					Description: "Network type (e.g. 'tcp,udp').",
+					PlanModifiers: []planmodifier.String{
+						stringplanmodifier.UseStateForUnknown(),
+					},
 				},
 				"iv_check": schema.BoolAttribute{
 					Optional: true, Computed: true,
 					Description: "Enable IV check.",
+					PlanModifiers: []planmodifier.Bool{
+						boolplanmodifier.UseStateForUnknown(),
+					},
 				},
 			},
 		},
@@ -154,10 +181,16 @@ func inboundSettingsBlockSchemas() map[string]schema.Block {
 				"auth": schema.StringAttribute{
 					Optional: true, Computed: true,
 					Description: "Authentication type (e.g. 'password', 'noauth').",
+					PlanModifiers: []planmodifier.String{
+						stringplanmodifier.UseStateForUnknown(),
+					},
 				},
 				"allow_transparent": schema.BoolAttribute{
 					Optional: true, Computed: true,
 					Description: "Allow transparent proxy.",
+					PlanModifiers: []planmodifier.Bool{
+						boolplanmodifier.UseStateForUnknown(),
+					},
 				},
 			},
 			Blocks: map[string]schema.Block{
@@ -175,14 +208,23 @@ func inboundSettingsBlockSchemas() map[string]schema.Block {
 				"auth": schema.StringAttribute{
 					Optional: true, Computed: true,
 					Description: "Authentication type (e.g. 'password', 'noauth').",
+					PlanModifiers: []planmodifier.String{
+						stringplanmodifier.UseStateForUnknown(),
+					},
 				},
 				"udp": schema.BoolAttribute{
 					Optional: true, Computed: true,
 					Description: "Enable UDP support.",
+					PlanModifiers: []planmodifier.Bool{
+						boolplanmodifier.UseStateForUnknown(),
+					},
 				},
 				"ip": schema.StringAttribute{
 					Optional: true, Computed: true,
 					Description: "IP address for UDP.",
+					PlanModifiers: []planmodifier.String{
+						stringplanmodifier.UseStateForUnknown(),
+					},
 				},
 			},
 			Blocks: map[string]schema.Block{
@@ -202,26 +244,41 @@ func inboundSettingsBlockSchemas() map[string]schema.Block {
 					Computed:    true,
 					ElementType: types.Int64Type,
 					Description: "MTU values [IPv4, IPv6].",
+					PlanModifiers: []planmodifier.List{
+						listplanmodifier.UseStateForUnknown(),
+					},
 				},
 				"secret_key": schema.StringAttribute{
 					Optional: true, Computed: true, Sensitive: true,
 					Description: "WireGuard secret key.",
+					PlanModifiers: []planmodifier.String{
+						stringplanmodifier.UseStateForUnknown(),
+					},
 				},
 				"no_kernel_tun": schema.BoolAttribute{
 					Optional: true, Computed: true,
 					Description: "Disable kernel TUN.",
+					PlanModifiers: []planmodifier.Bool{
+						boolplanmodifier.UseStateForUnknown(),
+					},
 				},
 				"gateway": schema.ListAttribute{
 					Optional:    true,
 					Computed:    true,
 					ElementType: types.StringType,
 					Description: "Gateway addresses.",
+					PlanModifiers: []planmodifier.List{
+						listplanmodifier.UseStateForUnknown(),
+					},
 				},
 				"dns": schema.ListAttribute{
 					Optional:    true,
 					Computed:    true,
 					ElementType: types.StringType,
 					Description: "DNS server addresses.",
+					PlanModifiers: []planmodifier.List{
+						listplanmodifier.UseStateForUnknown(),
+					},
 				},
 			},
 			Blocks: map[string]schema.Block{
@@ -231,20 +288,35 @@ func inboundSettingsBlockSchemas() map[string]schema.Block {
 						Attributes: map[string]schema.Attribute{
 							"private_key": schema.StringAttribute{
 								Optional: true, Computed: true, Sensitive: true,
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.UseStateForUnknown(),
+								},
 							},
 							"public_key": schema.StringAttribute{
 								Optional: true, Computed: true,
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.UseStateForUnknown(),
+								},
 							},
 							"pre_shared_key": schema.StringAttribute{
 								Optional: true, Computed: true, Sensitive: true,
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.UseStateForUnknown(),
+								},
 							},
 							"allowed_ips": schema.ListAttribute{
 								Optional:    true,
 								Computed:    true,
 								ElementType: types.StringType,
+								PlanModifiers: []planmodifier.List{
+									listplanmodifier.UseStateForUnknown(),
+								},
 							},
 							"keep_alive": schema.Int64Attribute{
 								Optional: true, Computed: true,
+								PlanModifiers: []planmodifier.Int64{
+									int64planmodifier.UseStateForUnknown(),
+								},
 							},
 						},
 					},
@@ -257,24 +329,39 @@ func inboundSettingsBlockSchemas() map[string]schema.Block {
 				"address": schema.StringAttribute{
 					Optional: true, Computed: true,
 					Description: "Destination address.",
+					PlanModifiers: []planmodifier.String{
+						stringplanmodifier.UseStateForUnknown(),
+					},
 				},
 				"port": schema.Int64Attribute{
 					Optional: true, Computed: true,
 					Description: "Destination port.",
+					PlanModifiers: []planmodifier.Int64{
+						int64planmodifier.UseStateForUnknown(),
+					},
 				},
 				"port_map": schema.MapAttribute{
 					Optional:    true,
 					Computed:    true,
 					ElementType: types.StringType,
 					Description: "Port mapping (e.g. {\"80\": \"127.0.0.1:8080\"}).",
+					PlanModifiers: []planmodifier.Map{
+						mapplanmodifier.UseStateForUnknown(),
+					},
 				},
 				"network": schema.StringAttribute{
 					Optional: true, Computed: true,
 					Description: "Network type (e.g. 'tcp', 'udp', 'tcp,udp').",
+					PlanModifiers: []planmodifier.String{
+						stringplanmodifier.UseStateForUnknown(),
+					},
 				},
 				"follow_redirect": schema.BoolAttribute{
 					Optional: true, Computed: true,
 					Description: "Follow redirect.",
+					PlanModifiers: []planmodifier.Bool{
+						boolplanmodifier.UseStateForUnknown(),
+					},
 				},
 			},
 		},
@@ -285,6 +372,9 @@ func inboundSettingsBlockSchemas() map[string]schema.Block {
 					Optional:    true,
 					Computed:    true,
 					Description: "Hysteria version (1 or 2, default 2).",
+					PlanModifiers: []planmodifier.Int64{
+						int64planmodifier.UseStateForUnknown(),
+					},
 				},
 			},
 		},
@@ -295,18 +385,33 @@ func inboundFallbackAttributes() map[string]schema.Attribute {
 	return map[string]schema.Attribute{
 		"name": schema.StringAttribute{
 			Optional: true, Computed: true,
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
+			},
 		},
 		"alpn": schema.StringAttribute{
 			Optional: true, Computed: true,
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
+			},
 		},
 		"path": schema.StringAttribute{
 			Optional: true, Computed: true,
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
+			},
 		},
 		"dest": schema.StringAttribute{
 			Optional: true, Computed: true,
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
+			},
 		},
 		"xver": schema.Int64Attribute{
 			Optional: true, Computed: true,
+			PlanModifiers: []planmodifier.Int64{
+				int64planmodifier.UseStateForUnknown(),
+			},
 		},
 	}
 }
@@ -315,9 +420,15 @@ func inboundAccountAttributes() map[string]schema.Attribute {
 	return map[string]schema.Attribute{
 		"user": schema.StringAttribute{
 			Optional: true, Computed: true,
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
+			},
 		},
 		"pass": schema.StringAttribute{
 			Optional: true, Computed: true, Sensitive: true,
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
+			},
 		},
 	}
 }

--- a/provider/inbound_sniffing_schema.go
+++ b/provider/inbound_sniffing_schema.go
@@ -2,6 +2,9 @@ package provider
 
 import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -30,34 +33,52 @@ func inboundSniffingBlockSchema() schema.SingleNestedBlock {
 				Optional:    true,
 				Computed:    true,
 				Description: "Whether sniffing is enabled.",
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"dest_override": schema.ListAttribute{
 				Optional:    true,
 				Computed:    true,
 				ElementType: types.StringType,
 				Description: "Destination override protocols (e.g. http, tls, quic, fakedns).",
+				PlanModifiers: []planmodifier.List{
+					listplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"metadata_only": schema.BoolAttribute{
 				Optional:    true,
 				Computed:    true,
 				Description: "Only sniff metadata.",
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"route_only": schema.BoolAttribute{
 				Optional:    true,
 				Computed:    true,
 				Description: "Only use sniffing for routing.",
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"ips_excluded": schema.ListAttribute{
 				Optional:    true,
 				Computed:    true,
 				ElementType: types.StringType,
 				Description: "IPs/CIDRs excluded from sniffing (e.g. geoip:private).",
+				PlanModifiers: []planmodifier.List{
+					listplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"domains_excluded": schema.ListAttribute{
 				Optional:    true,
 				Computed:    true,
 				ElementType: types.StringType,
 				Description: "Domains excluded from sniffing (e.g. domain:example.com).",
+				PlanModifiers: []planmodifier.List{
+					listplanmodifier.UseStateForUnknown(),
+				},
 			},
 		},
 	}

--- a/provider/inbound_stream_settings_schema.go
+++ b/provider/inbound_stream_settings_schema.go
@@ -2,6 +2,10 @@ package provider
 
 import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -120,10 +124,16 @@ func inboundStreamSettingsBlockSchema() schema.SingleNestedBlock {
 			"network": schema.StringAttribute{
 				Optional: true, Computed: true,
 				Description: "Transport network (tcp, ws, grpc, httpupgrade, xhttp, kcp).",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"security": schema.StringAttribute{
 				Optional: true, Computed: true,
 				Description: "Security type (none, reality, tls).",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 		},
 		Blocks: map[string]schema.Block{
@@ -133,15 +143,27 @@ func inboundStreamSettingsBlockSchema() schema.SingleNestedBlock {
 					Attributes: map[string]schema.Attribute{
 						"dest": schema.StringAttribute{
 							Optional: true, Computed: true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
 						},
 						"port": schema.Int64Attribute{
 							Optional: true, Computed: true,
+							PlanModifiers: []planmodifier.Int64{
+								int64planmodifier.UseStateForUnknown(),
+							},
 						},
 						"remark": schema.StringAttribute{
 							Optional: true, Computed: true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
 						},
 						"force_tls": schema.StringAttribute{
 							Optional: true, Computed: true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
 						},
 					},
 				},
@@ -151,17 +173,29 @@ func inboundStreamSettingsBlockSchema() schema.SingleNestedBlock {
 				Attributes: map[string]schema.Attribute{
 					"show": schema.BoolAttribute{
 						Optional: true, Computed: true,
+						PlanModifiers: []planmodifier.Bool{
+							boolplanmodifier.UseStateForUnknown(),
+						},
 					},
 					"xver": schema.Int64Attribute{
 						Optional: true, Computed: true,
+						PlanModifiers: []planmodifier.Int64{
+							int64planmodifier.UseStateForUnknown(),
+						},
 					},
 					"target": schema.StringAttribute{
 						Optional: true, Computed: true,
 						Description: "Target server (e.g. 'google.com:443').",
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.UseStateForUnknown(),
+						},
 					},
 					"server_names": schema.ListAttribute{
 						Optional: true, Computed: true,
 						ElementType: types.StringType,
+						PlanModifiers: []planmodifier.List{
+							listplanmodifier.UseStateForUnknown(),
+						},
 					},
 					"private_key": schema.StringAttribute{
 						Optional: true, Computed: true, Sensitive: true,
@@ -174,9 +208,15 @@ func inboundStreamSettingsBlockSchema() schema.SingleNestedBlock {
 						Optional: true, Computed: true,
 						ElementType: types.StringType,
 						Description: "Short IDs (auto-generated if empty).",
+						PlanModifiers: []planmodifier.List{
+							listplanmodifier.UseStateForUnknown(),
+						},
 					},
 					"mldsa65_seed": schema.StringAttribute{
 						Optional: true, Computed: true,
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.UseStateForUnknown(),
+						},
 					},
 				},
 				Blocks: map[string]schema.Block{
@@ -192,15 +232,27 @@ func inboundStreamSettingsBlockSchema() schema.SingleNestedBlock {
 							},
 							"fingerprint": schema.StringAttribute{
 								Optional: true, Computed: true,
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.UseStateForUnknown(),
+								},
 							},
 							"server_name": schema.StringAttribute{
 								Optional: true, Computed: true,
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.UseStateForUnknown(),
+								},
 							},
 							"spider_x": schema.StringAttribute{
 								Optional: true, Computed: true,
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.UseStateForUnknown(),
+								},
 							},
 							"mldsa65_verify": schema.StringAttribute{
 								Optional: true, Computed: true,
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.UseStateForUnknown(),
+								},
 							},
 						},
 					},
@@ -211,10 +263,16 @@ func inboundStreamSettingsBlockSchema() schema.SingleNestedBlock {
 				Attributes: map[string]schema.Attribute{
 					"accept_proxy_protocol": schema.BoolAttribute{
 						Optional: true, Computed: true,
+						PlanModifiers: []planmodifier.Bool{
+							boolplanmodifier.UseStateForUnknown(),
+						},
 					},
 					"header_type": schema.StringAttribute{
 						Optional: true, Computed: true,
 						Description: "Header type (e.g. 'none', 'http').",
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.UseStateForUnknown(),
+						},
 					},
 				},
 			},
@@ -223,12 +281,18 @@ func inboundStreamSettingsBlockSchema() schema.SingleNestedBlock {
 				Attributes: map[string]schema.Attribute{
 					"path": schema.StringAttribute{
 						Optional: true, Computed: true,
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.UseStateForUnknown(),
+						},
 					},
 					"headers": schema.MapAttribute{
 						Optional:    true,
 						Computed:    true,
 						ElementType: types.StringType,
 						Description: "Custom headers as key-value pairs.",
+						PlanModifiers: []planmodifier.Map{
+							mapplanmodifier.UseStateForUnknown(),
+						},
 					},
 				},
 			},
@@ -237,21 +301,39 @@ func inboundStreamSettingsBlockSchema() schema.SingleNestedBlock {
 				Attributes: map[string]schema.Attribute{
 					"service_name": schema.StringAttribute{
 						Optional: true, Computed: true,
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.UseStateForUnknown(),
+						},
 					},
 					"multi_mode": schema.BoolAttribute{
 						Optional: true, Computed: true,
+						PlanModifiers: []planmodifier.Bool{
+							boolplanmodifier.UseStateForUnknown(),
+						},
 					},
 					"idle_timeout": schema.Int64Attribute{
 						Optional: true, Computed: true,
+						PlanModifiers: []planmodifier.Int64{
+							int64planmodifier.UseStateForUnknown(),
+						},
 					},
 					"health_check_timeout": schema.Int64Attribute{
 						Optional: true, Computed: true,
+						PlanModifiers: []planmodifier.Int64{
+							int64planmodifier.UseStateForUnknown(),
+						},
 					},
 					"permit_without_stream": schema.BoolAttribute{
 						Optional: true, Computed: true,
+						PlanModifiers: []planmodifier.Bool{
+							boolplanmodifier.UseStateForUnknown(),
+						},
 					},
 					"initial_windows_size": schema.Int64Attribute{
 						Optional: true, Computed: true,
+						PlanModifiers: []planmodifier.Int64{
+							int64planmodifier.UseStateForUnknown(),
+						},
 					},
 				},
 			},
@@ -260,9 +342,15 @@ func inboundStreamSettingsBlockSchema() schema.SingleNestedBlock {
 				Attributes: map[string]schema.Attribute{
 					"path": schema.StringAttribute{
 						Optional: true, Computed: true,
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.UseStateForUnknown(),
+						},
 					},
 					"host": schema.StringAttribute{
 						Optional: true, Computed: true,
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.UseStateForUnknown(),
+						},
 					},
 				},
 			},
@@ -271,15 +359,27 @@ func inboundStreamSettingsBlockSchema() schema.SingleNestedBlock {
 				Attributes: map[string]schema.Attribute{
 					"path": schema.StringAttribute{
 						Optional: true, Computed: true,
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.UseStateForUnknown(),
+						},
 					},
 					"mode": schema.StringAttribute{
 						Optional: true, Computed: true,
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.UseStateForUnknown(),
+						},
 					},
 					"no_sse_header": schema.BoolAttribute{
 						Optional: true, Computed: true,
+						PlanModifiers: []planmodifier.Bool{
+							boolplanmodifier.UseStateForUnknown(),
+						},
 					},
 					"keep_alive_interval": schema.Int64Attribute{
 						Optional: true, Computed: true,
+						PlanModifiers: []planmodifier.Int64{
+							int64planmodifier.UseStateForUnknown(),
+						},
 					},
 				},
 			},
@@ -288,29 +388,50 @@ func inboundStreamSettingsBlockSchema() schema.SingleNestedBlock {
 				Attributes: map[string]schema.Attribute{
 					"mtu": schema.Int64Attribute{
 						Optional: true, Computed: true,
+						PlanModifiers: []planmodifier.Int64{
+							int64planmodifier.UseStateForUnknown(),
+						},
 					},
 					"tti": schema.Int64Attribute{
 						Optional: true, Computed: true,
+						PlanModifiers: []planmodifier.Int64{
+							int64planmodifier.UseStateForUnknown(),
+						},
 					},
 					"uplink_capacity": schema.Int64Attribute{
 						Optional: true, Computed: true,
+						PlanModifiers: []planmodifier.Int64{
+							int64planmodifier.UseStateForUnknown(),
+						},
 					},
 					"downlink_capacity": schema.Int64Attribute{
 						Optional: true, Computed: true,
+						PlanModifiers: []planmodifier.Int64{
+							int64planmodifier.UseStateForUnknown(),
+						},
 					},
 					"cwnd_multiplier": schema.Int64Attribute{
 						Optional:    true,
 						Computed:    true,
 						Description: "CWND multiplier.",
+						PlanModifiers: []planmodifier.Int64{
+							int64planmodifier.UseStateForUnknown(),
+						},
 					},
 					"max_sending_window": schema.Int64Attribute{
 						Optional:    true,
 						Computed:    true,
 						Description: "Maximum sending window size.",
+						PlanModifiers: []planmodifier.Int64{
+							int64planmodifier.UseStateForUnknown(),
+						},
 					},
 					"header_type": schema.StringAttribute{
 						Optional: true, Computed: true,
 						Description: "Header type (e.g. 'none', 'srtp', 'utp', 'wechat-video', 'dtls', 'wireguard').",
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.UseStateForUnknown(),
+						},
 					},
 				},
 			},
@@ -321,21 +442,33 @@ func inboundStreamSettingsBlockSchema() schema.SingleNestedBlock {
 						Optional:    true,
 						Computed:    true,
 						Description: "Hysteria transport protocol.",
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.UseStateForUnknown(),
+						},
 					},
 					"version": schema.Int64Attribute{
 						Optional:    true,
 						Computed:    true,
 						Description: "Hysteria version (default 2).",
+						PlanModifiers: []planmodifier.Int64{
+							int64planmodifier.UseStateForUnknown(),
+						},
 					},
 					"auth": schema.StringAttribute{
 						Optional:    true,
 						Computed:    true,
 						Description: "Hysteria auth string.",
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.UseStateForUnknown(),
+						},
 					},
 					"udp_idle_timeout": schema.Int64Attribute{
 						Optional:    true,
 						Computed:    true,
 						Description: "UDP idle timeout in seconds (default 60).",
+						PlanModifiers: []planmodifier.Int64{
+							int64planmodifier.UseStateForUnknown(),
+						},
 					},
 				},
 			},
@@ -344,21 +477,39 @@ func inboundStreamSettingsBlockSchema() schema.SingleNestedBlock {
 				Attributes: map[string]schema.Attribute{
 					"mark": schema.Int64Attribute{
 						Optional: true, Computed: true,
+						PlanModifiers: []planmodifier.Int64{
+							int64planmodifier.UseStateForUnknown(),
+						},
 					},
 					"tcp_keep_alive_interval": schema.Int64Attribute{
 						Optional: true, Computed: true,
+						PlanModifiers: []planmodifier.Int64{
+							int64planmodifier.UseStateForUnknown(),
+						},
 					},
 					"tcp_no_delay": schema.BoolAttribute{
 						Optional: true, Computed: true,
+						PlanModifiers: []planmodifier.Bool{
+							boolplanmodifier.UseStateForUnknown(),
+						},
 					},
 					"tfo_enable": schema.BoolAttribute{
 						Optional: true, Computed: true,
+						PlanModifiers: []planmodifier.Bool{
+							boolplanmodifier.UseStateForUnknown(),
+						},
 					},
 					"tproxy": schema.StringAttribute{
 						Optional: true, Computed: true,
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.UseStateForUnknown(),
+						},
 					},
 					"domain_strategy": schema.StringAttribute{
 						Optional: true, Computed: true,
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.UseStateForUnknown(),
+						},
 					},
 				},
 			},

--- a/provider/resource_inbound.go
+++ b/provider/resource_inbound.go
@@ -25,6 +25,7 @@ import (
 var (
 	_ resource.Resource                = &InboundResource{}
 	_ resource.ResourceWithImportState = &InboundResource{}
+	_ resource.ResourceWithModifyPlan  = &InboundResource{}
 )
 
 type InboundResource struct {
@@ -355,6 +356,46 @@ func (r *InboundResource) Delete(ctx context.Context, req resource.DeleteRequest
 
 func (r *InboundResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+// ModifyPlan preserves nested Optional blocks from state when the user did not
+// specify them in config.  Without this, Terraform plans to remove these blocks
+// after import, producing false drift.
+func (r *InboundResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	// Skip on create (no prior state) or destroy (no plan).
+	if req.State.Raw.IsNull() || req.Plan.Raw.IsNull() {
+		return
+	}
+
+	var plan InboundResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var state InboundResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	changed := false
+
+	// Preserve reality_settings.settings block from state when the user
+	// specified reality_settings but omitted the inner settings block.
+	if plan.StreamSettings != nil &&
+		plan.StreamSettings.RealitySettings != nil &&
+		plan.StreamSettings.RealitySettings.Settings == nil &&
+		state.StreamSettings != nil &&
+		state.StreamSettings.RealitySettings != nil &&
+		state.StreamSettings.RealitySettings.Settings != nil {
+		plan.StreamSettings.RealitySettings.Settings = state.StreamSettings.RealitySettings.Settings
+		changed = true
+	}
+
+	if changed {
+		resp.Diagnostics.Append(resp.Plan.Set(ctx, &plan)...)
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/provider/resource_inbound.go
+++ b/provider/resource_inbound.go
@@ -383,6 +383,14 @@ func (r *InboundResource) ModifyPlan(ctx context.Context, req resource.ModifyPla
 
 	// Preserve reality_settings.settings block from state when the user
 	// specified reality_settings but omitted the inner settings block.
+	//
+	// Other stream_settings sub-blocks (tcp_settings, ws_settings, etc.) do
+	// not need this — alignBlocksWithPlan nils them when the user omits them,
+	// so state stays consistent.  But reality_settings.settings is a
+	// sub-sub-block: alignBlocksWithPlan only checks whether reality_settings
+	// itself is present (not whether its child "settings" block is), so the
+	// child block survives in state and causes drift unless we preserve it
+	// in the plan here.
 	if plan.StreamSettings != nil &&
 		plan.StreamSettings.RealitySettings != nil &&
 		plan.StreamSettings.RealitySettings.Settings == nil &&


### PR DESCRIPTION
## Summary

- Add `UseStateForUnknown` plan modifiers to all `Optional+Computed` attributes across inbound schemas (`inbound_stream_settings_schema.go`, `inbound_sniffing_schema.go`, `inbound_settings_schema.go`) — eliminates spurious `(known after apply)` and `-> null` diffs after `tofu import`
- Implement `ResourceWithModifyPlan` on `InboundResource` to preserve the `reality_settings.settings` nested block from state when not specified in config — blocks don't support attribute-level plan modifiers

### Fixed fields

| Area | Fields |
|------|--------|
| `reality_settings` | `show`, `xver`, `target`, `server_names`, `short_ids`, `mldsa65_seed` |
| `reality_settings.settings` | `fingerprint`, `server_name`, `spider_x`, `mldsa65_verify` (block preserved via `ModifyPlan`) |
| `sniffing` | `enabled`, `dest_override`, `metadata_only`, `route_only`, `ips_excluded`, `domains_excluded` |
| `vless_settings` | `decryption`, `encryption`, `selected_auth` |
| `stream_settings` | `network`, `security` + all sub-blocks (tcp, ws, grpc, httpupgrade, xhttp, kcp, hysteria, sockopt, external_proxy) |
| `settings` | shadowsocks, http, socks, wireguard, dokodemo, hysteria + fallback/account/peer attributes |

## Test plan

- [ ] `task build` passes
- [ ] `task test:unit` passes
- [ ] `task lint` — 0 issues
- [ ] `task test:acc` — acceptance tests pass (import round-trip verified)
- [ ] Manual: import existing VLESS+Reality inbound, run `tofu plan` — no drift on unspecified fields