### PR TITLE
fix!: convert reality_settings.settings from block to attribute

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,7 @@ Unauthenticated requests return 404 (not 401). The client performs auto re-login
 - Hysteria: `auth` field on `threexui_inbound_client` used as client identifier (instead of UUID-based `id`)
 - All `Optional+Computed` inbound attributes have `UseStateForUnknown` plan modifiers — prevents false drift (`known after apply`) after import
 - `alignBlocksWithPlan` — prevents "was absent, but now present" errors for Optional blocks (Create/Read/Update); skipped during Import (detect: `state.Protocol.IsNull()`)
-- `ModifyPlan` — preserves `reality_settings.settings` nested block from state when absent in config; needed because blocks don't support attribute-level plan modifiers, and `alignBlocksWithPlan` doesn't nil sub-sub-blocks when the parent block is present
+- `reality_settings.settings` — `SingleNestedAttribute` (not block) with `objectplanmodifier.UseStateForUnknown()`; preserves auto-generated values (public_key, fingerprint, etc.) from state when user omits the attribute
 - `preserveInboundSettings` — on update, preserves clients and testseed from existing inbound
 - `ensureRealityKeys` — auto-generates private/public key and short_ids
 - `ensureInboundClientIDs` — auto-generates UUID for clients without id

--- a/docs/resources/inbound.md
+++ b/docs/resources/inbound.md
@@ -290,7 +290,7 @@ Used for both `tunnel` and `dokodemo-door` protocols.
   - `private_key` (Optional, String) - Auto-generated if not specified.
   - `short_ids` (Optional, List of String) - Auto-generated if not specified.
   - `mldsa65_seed` (Optional, String)
-  - `settings` (Optional, Block)
+  - `settings` (Optional, Attribute) - Reality inner settings (client-side). Auto-populated if omitted.
     - `public_key` (Optional, String) - Auto-generated if not specified.
     - `fingerprint` (Optional, String)
     - `server_name` (Optional, String)

--- a/provider/acc_inbound_test.go
+++ b/provider/acc_inbound_test.go
@@ -1038,9 +1038,9 @@ resource "threexui_inbound" "hysteria" {
 //
 // After importing an existing inbound, planning with a config that omits
 // Optional+Computed fields (show, xver, short_ids, metadata_only, route_only,
-// encryption, selected_auth, reality settings block, etc.) must produce an
+// encryption, selected_auth, reality settings attribute, etc.) must produce an
 // empty plan.  This is the primary regression test for the UseStateForUnknown
-// plan modifiers and the ModifyPlan that preserves reality_settings.settings.
+// plan modifiers (including the object-level modifier on reality_settings.settings).
 
 func TestAccInboundImportNoDrift_Reality(t *testing.T) {
 	config := testAccProviderConfig() + `
@@ -1082,17 +1082,13 @@ resource "threexui_inbound" "import_reality" {
 				),
 			},
 			// Step 2: Import — fresh state from the API.
-			// reality_settings.settings is populated by Read during import
-			// but nil'd by alignBlocksWithPlan during Create (user didn't
-			// specify it).  ModifyPlan keeps them in sync at plan time, so
-			// Step 3 verifies no drift; here we just skip the sub-block.
+			// reality_settings.settings is an Optional+Computed attribute
+			// with UseStateForUnknown — both Create and Import populate it
+			// from the API, so ImportStateVerify passes without ignores.
 			{
 				ResourceName:      "threexui_inbound.import_reality",
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"stream_settings.reality_settings.settings",
-				},
 			},
 			// Step 3: Plan with the same config — must be empty.
 			// Without UseStateForUnknown modifiers this step fails because

--- a/provider/inbound_stream_settings_schema.go
+++ b/provider/inbound_stream_settings_schema.go
@@ -1,11 +1,13 @@
 package provider
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -38,22 +40,24 @@ type InboundExternalProxyModel struct {
 }
 
 type InboundRealitySettingsModel struct {
-	Show        types.Bool                        `tfsdk:"show"`
-	Xver        types.Int64                       `tfsdk:"xver"`
-	Target      types.String                      `tfsdk:"target"`
-	ServerNames types.List                        `tfsdk:"server_names"` // list of string
-	PrivateKey  types.String                      `tfsdk:"private_key"`
-	ShortIDs    types.List                        `tfsdk:"short_ids"` // list of string
-	Mldsa65Seed types.String                      `tfsdk:"mldsa65_seed"`
-	Settings    *InboundRealityInnerSettingsModel `tfsdk:"settings"`
+	Show        types.Bool   `tfsdk:"show"`
+	Xver        types.Int64  `tfsdk:"xver"`
+	Target      types.String `tfsdk:"target"`
+	ServerNames types.List   `tfsdk:"server_names"` // list of string
+	PrivateKey  types.String `tfsdk:"private_key"`
+	ShortIDs    types.List   `tfsdk:"short_ids"` // list of string
+	Mldsa65Seed types.String `tfsdk:"mldsa65_seed"`
+	Settings    types.Object `tfsdk:"settings"` // realityInnerSettingsAttrTypes
 }
 
-type InboundRealityInnerSettingsModel struct {
-	PublicKey     types.String `tfsdk:"public_key"`
-	Fingerprint   types.String `tfsdk:"fingerprint"`
-	ServerName    types.String `tfsdk:"server_name"`
-	SpiderX       types.String `tfsdk:"spider_x"`
-	Mldsa65Verify types.String `tfsdk:"mldsa65_verify"`
+// realityInnerSettingsAttrTypes defines the attribute types for the
+// reality_settings.settings nested attribute (SingleNestedAttribute).
+var realityInnerSettingsAttrTypes = map[string]attr.Type{
+	"public_key":     types.StringType,
+	"fingerprint":    types.StringType,
+	"server_name":    types.StringType,
+	"spider_x":       types.StringType,
+	"mldsa65_verify": types.StringType,
 }
 
 type InboundTCPSettingsModel struct {
@@ -218,10 +222,12 @@ func inboundStreamSettingsBlockSchema() schema.SingleNestedBlock {
 							stringplanmodifier.UseStateForUnknown(),
 						},
 					},
-				},
-				Blocks: map[string]schema.Block{
-					"settings": schema.SingleNestedBlock{
+					"settings": schema.SingleNestedAttribute{
+						Optional: true, Computed: true,
 						Description: "Reality inner settings (client-side).",
+						PlanModifiers: []planmodifier.Object{
+							objectplanmodifier.UseStateForUnknown(),
+						},
 						Attributes: map[string]schema.Attribute{
 							"public_key": schema.StringAttribute{
 								Optional: true, Computed: true,
@@ -634,33 +640,24 @@ func expandRealitySettingsFromModel(m *InboundRealitySettingsModel) map[string]a
 	if !m.Mldsa65Seed.IsNull() && !m.Mldsa65Seed.IsUnknown() {
 		out["mldsa65_seed"] = m.Mldsa65Seed.ValueString()
 	}
-	if m.Settings != nil {
-		if s := expandRealityInnerSettingsFromModel(m.Settings); len(s) > 0 {
-			out["settings"] = []any{s}
+	if !m.Settings.IsNull() && !m.Settings.IsUnknown() {
+		if s := expandRealityInnerSettingsFromObject(m.Settings); len(s) > 0 {
+			out["settings"] = s
 		}
 	}
 	return out
 }
 
-func expandRealityInnerSettingsFromModel(m *InboundRealityInnerSettingsModel) map[string]any {
-	if m == nil {
+func expandRealityInnerSettingsFromObject(obj types.Object) map[string]any {
+	if obj.IsNull() || obj.IsUnknown() {
 		return nil
 	}
 	out := map[string]any{}
-	if !m.PublicKey.IsNull() && !m.PublicKey.IsUnknown() {
-		out["public_key"] = m.PublicKey.ValueString()
-	}
-	if !m.Fingerprint.IsNull() && !m.Fingerprint.IsUnknown() {
-		out["fingerprint"] = m.Fingerprint.ValueString()
-	}
-	if !m.ServerName.IsNull() && !m.ServerName.IsUnknown() {
-		out["server_name"] = m.ServerName.ValueString()
-	}
-	if !m.SpiderX.IsNull() && !m.SpiderX.IsUnknown() {
-		out["spider_x"] = m.SpiderX.ValueString()
-	}
-	if !m.Mldsa65Verify.IsNull() && !m.Mldsa65Verify.IsUnknown() {
-		out["mldsa65_verify"] = m.Mldsa65Verify.ValueString()
+	attrs := obj.Attributes()
+	for _, key := range []string{"public_key", "fingerprint", "server_name", "spider_x", "mldsa65_verify"} {
+		if v, ok := attrs[key].(types.String); ok && !v.IsNull() && !v.IsUnknown() {
+			out[key] = v.ValueString()
+		}
 	}
 	return out
 }
@@ -992,45 +989,32 @@ func flattenRealitySettingsToModel(data map[string]any) *InboundRealitySettingsM
 	} else {
 		m.Mldsa65Seed = types.StringNull()
 	}
-	if v, ok := data["settings"].([]any); ok && len(v) > 0 {
-		if raw, ok := v[0].(map[string]any); ok {
-			m.Settings = flattenRealityInnerSettingsToModel(raw)
-		}
+	if v, ok := data["settings"].(map[string]any); ok && len(v) > 0 {
+		m.Settings = flattenRealityInnerSettingsToObject(v)
+	} else {
+		m.Settings = types.ObjectNull(realityInnerSettingsAttrTypes)
 	}
 	return m
 }
 
-func flattenRealityInnerSettingsToModel(data map[string]any) *InboundRealityInnerSettingsModel {
+func flattenRealityInnerSettingsToObject(data map[string]any) types.Object {
 	if len(data) == 0 {
-		return nil
+		return types.ObjectNull(realityInnerSettingsAttrTypes)
 	}
-	m := &InboundRealityInnerSettingsModel{}
-	if v, ok := data["public_key"].(string); ok && v != "" {
-		m.PublicKey = types.StringValue(v)
-	} else {
-		m.PublicKey = types.StringNull()
+	attrs := map[string]attr.Value{
+		"public_key":     types.StringNull(),
+		"fingerprint":    types.StringNull(),
+		"server_name":    types.StringNull(),
+		"spider_x":       types.StringNull(),
+		"mldsa65_verify": types.StringNull(),
 	}
-	if v, ok := data["fingerprint"].(string); ok && v != "" {
-		m.Fingerprint = types.StringValue(v)
-	} else {
-		m.Fingerprint = types.StringNull()
+	for _, key := range []string{"public_key", "fingerprint", "server_name", "spider_x", "mldsa65_verify"} {
+		if v, ok := data[key].(string); ok && v != "" {
+			attrs[key] = types.StringValue(v)
+		}
 	}
-	if v, ok := data["server_name"].(string); ok && v != "" {
-		m.ServerName = types.StringValue(v)
-	} else {
-		m.ServerName = types.StringNull()
-	}
-	if v, ok := data["spider_x"].(string); ok && v != "" {
-		m.SpiderX = types.StringValue(v)
-	} else {
-		m.SpiderX = types.StringNull()
-	}
-	if v, ok := data["mldsa65_verify"].(string); ok && v != "" {
-		m.Mldsa65Verify = types.StringValue(v)
-	} else {
-		m.Mldsa65Verify = types.StringNull()
-	}
-	return m
+	obj, _ := types.ObjectValue(realityInnerSettingsAttrTypes, attrs)
+	return obj
 }
 
 func flattenTCPSettingsToModel(data map[string]any) *InboundTCPSettingsModel {

--- a/provider/resource_inbound.go
+++ b/provider/resource_inbound.go
@@ -25,7 +25,6 @@ import (
 var (
 	_ resource.Resource                = &InboundResource{}
 	_ resource.ResourceWithImportState = &InboundResource{}
-	_ resource.ResourceWithModifyPlan  = &InboundResource{}
 )
 
 type InboundResource struct {
@@ -358,54 +357,6 @@ func (r *InboundResource) ImportState(ctx context.Context, req resource.ImportSt
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
-// ModifyPlan preserves nested Optional blocks from state when the user did not
-// specify them in config.  Without this, Terraform plans to remove these blocks
-// after import, producing false drift.
-func (r *InboundResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
-	// Skip on create (no prior state) or destroy (no plan).
-	if req.State.Raw.IsNull() || req.Plan.Raw.IsNull() {
-		return
-	}
-
-	var plan InboundResourceModel
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	var state InboundResourceModel
-	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	changed := false
-
-	// Preserve reality_settings.settings block from state when the user
-	// specified reality_settings but omitted the inner settings block.
-	//
-	// Other stream_settings sub-blocks (tcp_settings, ws_settings, etc.) do
-	// not need this — alignBlocksWithPlan nils them when the user omits them,
-	// so state stays consistent.  But reality_settings.settings is a
-	// sub-sub-block: alignBlocksWithPlan only checks whether reality_settings
-	// itself is present (not whether its child "settings" block is), so the
-	// child block survives in state and causes drift unless we preserve it
-	// in the plan here.
-	if plan.StreamSettings != nil &&
-		plan.StreamSettings.RealitySettings != nil &&
-		plan.StreamSettings.RealitySettings.Settings == nil &&
-		state.StreamSettings != nil &&
-		state.StreamSettings.RealitySettings != nil &&
-		state.StreamSettings.RealitySettings.Settings != nil {
-		plan.StreamSettings.RealitySettings.Settings = state.StreamSettings.RealitySettings.Settings
-		changed = true
-	}
-
-	if changed {
-		resp.Diagnostics.Append(resp.Plan.Set(ctx, &plan)...)
-	}
-}
-
 // ---------------------------------------------------------------------------
 // Model <-> Inbound conversion
 // ---------------------------------------------------------------------------
@@ -547,10 +498,6 @@ func alignBlocksWithPlan(state *InboundResourceModel, plan *InboundResourceModel
 		// Align nested stream_settings sub-blocks
 		if plan.StreamSettings.RealitySettings == nil {
 			state.StreamSettings.RealitySettings = nil
-		} else if state.StreamSettings.RealitySettings != nil {
-			if plan.StreamSettings.RealitySettings.Settings == nil {
-				state.StreamSettings.RealitySettings.Settings = nil
-			}
 		}
 		if plan.StreamSettings.TCPSettings == nil {
 			state.StreamSettings.TCPSettings = nil

--- a/provider/stream_settings.go
+++ b/provider/stream_settings.go
@@ -269,8 +269,8 @@ func expandRealitySettings(list []any) map[string]any {
 		rs["mldsa65Seed"] = v
 	}
 	if v, ok := item["settings"]; ok {
-		if list, ok := v.([]any); ok {
-			if s := expandRealityInnerSettings(list); s != nil {
+		if m, ok := v.(map[string]any); ok {
+			if s := expandRealityInnerSettings(m); s != nil {
 				rs["settings"] = s
 			}
 		}
@@ -293,12 +293,8 @@ func expandRealitySettings(list []any) map[string]any {
 	return rs
 }
 
-func expandRealityInnerSettings(list []any) map[string]any {
-	if len(list) == 0 {
-		return nil
-	}
-	item, ok := list[0].(map[string]any)
-	if !ok {
+func expandRealityInnerSettings(item map[string]any) map[string]any {
+	if len(item) == 0 {
 		return nil
 	}
 	out := map[string]any{}
@@ -360,7 +356,7 @@ func flattenRealitySettings(in map[string]any) map[string]any {
 	}
 	if v, ok := in["settings"].(map[string]any); ok {
 		if s := flattenRealityInnerSettings(v); s != nil {
-			out["settings"] = []any{s}
+			out["settings"] = s
 		}
 	}
 	if len(out) == 0 {

--- a/provider/stream_settings_test.go
+++ b/provider/stream_settings_test.go
@@ -25,7 +25,7 @@ func TestExpandRealitySettings_Full(t *testing.T) {
 			"max_timediff":   60,
 			"short_ids":      []any{"abc123"},
 			"mldsa65_seed":   "seed",
-			"settings":       []any{map[string]any{"public_key": "pubkey", "fingerprint": "chrome"}},
+			"settings":       map[string]any{"public_key": "pubkey", "fingerprint": "chrome"},
 		},
 	}
 	result := expandRealitySettings(input)
@@ -129,9 +129,12 @@ func TestFlattenRealitySettings_Full(t *testing.T) {
 	if out["xver"] != 2 {
 		t.Fatalf("unexpected xver: %v", out["xver"])
 	}
-	settings, ok := out["settings"].([]any)
-	if !ok || len(settings) != 1 {
-		t.Fatalf("expected settings list with 1 element")
+	settings, ok := out["settings"].(map[string]any)
+	if !ok || len(settings) == 0 {
+		t.Fatalf("expected settings map with entries")
+	}
+	if settings["public_key"] != "pub" {
+		t.Fatalf("unexpected public_key: %v", settings["public_key"])
 	}
 }
 
@@ -150,21 +153,19 @@ func TestFlattenRealitySettings_Partial(t *testing.T) {
 }
 
 func TestExpandRealityInnerSettings_Empty(t *testing.T) {
-	result := expandRealityInnerSettings([]any{})
+	result := expandRealityInnerSettings(map[string]any{})
 	if result != nil {
 		t.Fatalf("expected nil, got %v", result)
 	}
 }
 
 func TestExpandRealityInnerSettings_Full(t *testing.T) {
-	input := []any{
-		map[string]any{
-			"public_key":     "pub",
-			"fingerprint":    "chrome",
-			"server_name":    "example.com",
-			"spider_x":       "/",
-			"mldsa65_verify": "verify",
-		},
+	input := map[string]any{
+		"public_key":     "pub",
+		"fingerprint":    "chrome",
+		"server_name":    "example.com",
+		"spider_x":       "/",
+		"mldsa65_verify": "verify",
 	}
 	result := expandRealityInnerSettings(input)
 	if result == nil {
@@ -185,9 +186,7 @@ func TestExpandRealityInnerSettings_Full(t *testing.T) {
 }
 
 func TestExpandRealityInnerSettings_PublicKeyOnly(t *testing.T) {
-	input := []any{
-		map[string]any{"public_key": "pub"},
-	}
+	input := map[string]any{"public_key": "pub"}
 	result := expandRealityInnerSettings(input)
 	if result == nil {
 		t.Fatalf("expected non-nil")


### PR DESCRIPTION
## Summary

- Convert `reality_settings.settings` from `SingleNestedBlock` to `SingleNestedAttribute` with `objectplanmodifier.UseStateForUnknown()` — fixes "planned for existence but config wants absence" error
- Remove `ModifyPlan` method (no longer needed — the attribute's plan modifier handles state preservation natively)
- Model field `*InboundRealityInnerSettingsModel` → `types.Object` (struct pointers can't represent the unknown state needed for `Optional+Computed` attributes during Create)
- Update intermediate layer from `[]any{map}` to plain `map[string]any`

**BREAKING CHANGE**: users who explicitly specify `reality_settings.settings` must change from block syntax (`settings { ... }`) to attribute syntax (`settings = { ... }`). Most users omit this entirely and are unaffected.

## Test plan

- [x] `task build` passes
- [x] Unit tests pass (14 reality/stream settings tests + corpus roundtrip)
- [x] Pre-existing drift test failures confirmed unrelated (dokodemo-door, same on main)
- [ ] Acceptance tests: `task test:acc` (Create, Import, PlanOnly no-drift)