### PR TITLE
chore: add community health files and contribution templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,87 @@
+name: Bug Report
+description: Report a bug in terraform-provider-3x-ui
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for reporting a bug. Please fill out the fields below to help us investigate.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Minimal Terraform config and steps to trigger the issue.
+      placeholder: |
+        1. Create the following resource:
+        ```hcl
+        resource "threexui_inbound" "example" { ... }
+        ```
+        2. Run `terraform apply`
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened. Include error messages or `terraform plan` output if applicable.
+    validations:
+      required: true
+
+  - type: input
+    id: provider_version
+    attributes:
+      label: Provider Version
+      placeholder: "e.g. 2.0.0"
+    validations:
+      required: true
+
+  - type: input
+    id: threexui_version
+    attributes:
+      label: 3x-ui Version
+      placeholder: "e.g. v2.9.0"
+    validations:
+      required: true
+
+  - type: input
+    id: terraform_version
+    attributes:
+      label: Terraform Version
+      placeholder: "e.g. 1.9.0"
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating System
+      placeholder: "e.g. Ubuntu 24.04, macOS 15"
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any other information (logs, screenshots, related issues).
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,5 @@
 blank_issues_enabled: false
+contact_links:
+  - name: Documentation
+    url: https://registry.terraform.io/providers/batonogov/threexui/latest/docs
+    about: Check the documentation before filing an issue

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,46 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for your suggestion! Please describe the feature you would like to see.
+
+  - type: textarea
+    id: use_case
+    attributes:
+      label: Use Case
+      description: What problem does this feature solve? Why do you need it?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed_solution
+    attributes:
+      label: Proposed Solution
+      description: How do you think this should work? Include example Terraform config if applicable.
+      placeholder: |
+        ```hcl
+        resource "threexui_..." "example" {
+          ...
+        }
+        ```
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any alternative approaches you have considered.
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any other information (links to 3x-ui docs, related issues).
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+# Pull Request
+
+## Description
+
+<!-- What does this PR do? Why is it needed? -->
+
+## Type of Change
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] Documentation update
+
+## Checklist
+
+- [ ] `task build` passes
+- [ ] Tests added/updated (`task test:unit` / `task test:acc`)
+- [ ] Documentation updated (if applicable)
+- [ ] No breaking changes without prior discussion
+- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @batonogov

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this project, please report it responsibly.
+
+**Email:** [fekinos@me.com](mailto:fekinos@me.com)
+
+Please include:
+
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+
+**Do not** open a public GitHub issue for security vulnerabilities.
+
+## Response
+
+- You can expect an initial response within **48 hours**.
+- We will work with you to understand and address the issue before any public disclosure.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,12 @@
 # Security Policy
 
+## Supported Versions
+
+| Version | Supported |
+| ------- | --------- |
+| 2.x     | Yes       |
+| < 2.0   | No        |
+
 ## Reporting a Vulnerability
 
 If you discover a security vulnerability in this project, please report it responsibly.


### PR DESCRIPTION
## Summary

- Add structured GitHub issue templates: bug report (`bug_report.yml`) and feature request (`feature_request.yml`) with YAML forms
- Add issue template chooser config (`config.yml`) — blank issues disabled
- Add pull request template (`PULL_REQUEST_TEMPLATE.md`) with description, type of change, and checklist sections
- Add `CODEOWNERS` — @batonogov as owner for all files
- Add `SECURITY.md` — responsible vulnerability disclosure instructions (email, 48h response time)

Closes #76

## Test plan

- [ ] Verify issue templates render correctly on GitHub (New Issue page)
- [ ] Verify PR template auto-populates when creating a new PR
- [ ] Verify CODEOWNERS is recognized in repository settings
- [ ] Verify SECURITY.md appears in the repository's Security tab