### PR TITLE
docs: add multi-server best practice example

### DIFF
--- a/examples/multi-server/main.tf
+++ b/examples/multi-server/main.tf
@@ -7,10 +7,11 @@
 variable "servers" {
   description = "Map of 3x-ui servers to manage. Key = server name."
   type = map(object({
-    endpoint  = string
-    base_path = optional(string, "/")
-    username  = string
-    password  = string
+    endpoint             = string
+    base_path            = optional(string, "/")
+    username             = string
+    password             = string
+    insecure_skip_verify = optional(bool, false)
   }))
   sensitive = true
 }
@@ -19,8 +20,9 @@ module "server" {
   source   = "./modules/server"
   for_each = var.servers
 
-  endpoint  = each.value.endpoint
-  base_path = each.value.base_path
-  username  = each.value.username
-  password  = each.value.password
+  endpoint             = each.value.endpoint
+  base_path            = each.value.base_path
+  username             = each.value.username
+  password             = each.value.password
+  insecure_skip_verify = each.value.insecure_skip_verify
 }

--- a/examples/multi-server/main.tf
+++ b/examples/multi-server/main.tf
@@ -1,0 +1,26 @@
+# Multi-server management with map(object) pattern
+#
+# Terraform does not support for_each on providers, so each server
+# is managed via a reusable module that receives connection parameters
+# as input variables.
+
+variable "servers" {
+  description = "Map of 3x-ui servers to manage. Key = server name."
+  type = map(object({
+    endpoint  = string
+    base_path = optional(string, "/")
+    username  = string
+    password  = string
+  }))
+  sensitive = true
+}
+
+module "server" {
+  source   = "./modules/server"
+  for_each = var.servers
+
+  endpoint  = each.value.endpoint
+  base_path = each.value.base_path
+  username  = each.value.username
+  password  = each.value.password
+}

--- a/examples/multi-server/modules/server/main.tf
+++ b/examples/multi-server/modules/server/main.tf
@@ -1,0 +1,83 @@
+# Per-server module: configures the provider and manages resources
+# for a single 3x-ui instance.
+
+terraform {
+  required_providers {
+    threexui = {
+      source = "batonogov/threexui"
+    }
+  }
+}
+
+variable "endpoint" {
+  description = "Base URL of the 3x-ui panel."
+  type        = string
+}
+
+variable "base_path" {
+  description = "Base path configured in 3x-ui (webBasePath)."
+  type        = string
+  default     = "/"
+}
+
+variable "username" {
+  description = "3x-ui username."
+  type        = string
+}
+
+variable "password" {
+  description = "3x-ui password."
+  type        = string
+  sensitive   = true
+}
+
+provider "threexui" {
+  endpoint             = var.endpoint
+  base_path            = var.base_path
+  username             = var.username
+  password             = var.password
+  insecure_skip_verify = true
+}
+
+# --- Resources for this server ---
+
+resource "threexui_inbound" "vless" {
+  port     = 443
+  protocol = "vless"
+  enable   = true
+  remark   = "VLESS Reality"
+
+  vless_settings {
+    decryption = "none"
+  }
+
+  stream_settings {
+    network  = "tcp"
+    security = "reality"
+    reality_settings {
+      target       = "www.apple.com:443"
+      server_names = ["www.apple.com"]
+    }
+    tcp_settings {
+      accept_proxy_protocol = false
+      header_type           = "none"
+    }
+  }
+
+  sniffing {
+    enabled       = true
+    dest_override = ["http", "tls", "quic", "fakedns"]
+  }
+}
+
+resource "threexui_inbound_client" "user1" {
+  inbound_id = threexui_inbound.vless.id
+  email      = "user1@example.com"
+  enable     = true
+  flow       = "xtls-rprx-vision"
+}
+
+output "inbound_id" {
+  description = "ID of the created inbound."
+  value       = threexui_inbound.vless.id
+}

--- a/examples/multi-server/modules/server/main.tf
+++ b/examples/multi-server/modules/server/main.tf
@@ -4,7 +4,8 @@
 terraform {
   required_providers {
     threexui = {
-      source = "batonogov/threexui"
+      source  = "batonogov/threexui"
+      version = "~> 2.0"
     }
   }
 }
@@ -31,12 +32,18 @@ variable "password" {
   sensitive   = true
 }
 
+variable "insecure_skip_verify" {
+  description = "Skip TLS certificate verification."
+  type        = bool
+  default     = false
+}
+
 provider "threexui" {
   endpoint             = var.endpoint
   base_path            = var.base_path
   username             = var.username
   password             = var.password
-  insecure_skip_verify = true
+  insecure_skip_verify = var.insecure_skip_verify
 }
 
 # --- Resources for this server ---

--- a/examples/multi-server/terraform.tfvars.example
+++ b/examples/multi-server/terraform.tfvars.example
@@ -1,0 +1,18 @@
+servers = {
+  finland = {
+    endpoint = "https://fi.example.com:2053"
+    username = "admin"
+    password = "secret-fi"
+  }
+  netherlands = {
+    endpoint  = "https://nl.example.com:2053"
+    base_path = "/panel/"
+    username  = "admin"
+    password  = "secret-nl"
+  }
+  germany = {
+    endpoint = "https://de.example.com:2053"
+    username = "admin"
+    password = "secret-de"
+  }
+}


### PR DESCRIPTION
## Summary

- Add `examples/multi-server/` with the recommended `map(object)` pattern for managing multiple 3x-ui servers
- Root `main.tf` defines a `servers` variable and calls a reusable module with `for_each`
- `modules/server/main.tf` configures the provider and manages resources (VLESS Reality inbound + client) for a single server
- `terraform.tfvars.example` shows how to populate the variable for multiple servers

Closes #110

## Test plan

- [ ] Verify `terraform fmt -check -recursive examples/multi-server/` passes
- [ ] Review HCL syntax and provider attribute names match the current schema
- [ ] Confirm CI docs workflow passes