### PR TITLE
docs: expand onboarding examples and import usage guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ resource "threexui_inbound_client" "client_a" {
 | Example | Description |
 | --- | --- |
 | [Provider with env config](examples/provider-env-config/) | Configure the provider using Terraform variables and `TF_VAR_*` environment variables |
-| [VLESS Reality](examples/) | Basic VLESS Reality inbound with a client (Quick Start) |
+| [VLESS Reality](examples/inbound-with-client/) | Basic VLESS Reality inbound with a client (Quick Start) |
 | [Trojan inbound](examples/trojan-inbound/) | Trojan protocol with WebSocket transport |
 | [Shadowsocks inbound](examples/shadowsocks-inbound/) | Shadowsocks with AEAD cipher |
 | [Inbound with clients](examples/inbound-with-client/) | Complete workflow: inbound + multiple clients |

--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ resource "threexui_inbound_client" "client_a" {
 | Example | Description |
 | --- | --- |
 | [Provider with env config](examples/provider-env-config/) | Configure the provider using Terraform variables and `TF_VAR_*` environment variables |
-| [VLESS Reality](examples/inbound-with-client/) | Basic VLESS Reality inbound with a client (Quick Start) |
 | [Trojan inbound](examples/trojan-inbound/) | Trojan protocol with WebSocket transport |
 | [Shadowsocks inbound](examples/shadowsocks-inbound/) | Shadowsocks with AEAD cipher |
 | [Inbound with clients](examples/inbound-with-client/) | Complete workflow: inbound + multiple clients |

--- a/examples/import-existing/main.tf
+++ b/examples/import-existing/main.tf
@@ -53,7 +53,8 @@
 terraform {
   required_providers {
     threexui = {
-      source = "batonogov/threexui"
+      source  = "batonogov/threexui"
+      version = "~> 2.0"
     }
   }
 }

--- a/examples/inbound-with-client/main.tf
+++ b/examples/inbound-with-client/main.tf
@@ -8,7 +8,8 @@
 terraform {
   required_providers {
     threexui = {
-      source = "batonogov/threexui"
+      source  = "batonogov/threexui"
+      version = "~> 2.0"
     }
   }
 }

--- a/examples/provider-env-config/main.tf
+++ b/examples/provider-env-config/main.tf
@@ -37,7 +37,8 @@ variable "threexui_base_path" {
 terraform {
   required_providers {
     threexui = {
-      source = "batonogov/threexui"
+      source  = "batonogov/threexui"
+      version = "~> 2.0"
     }
   }
 }

--- a/examples/shadowsocks-inbound/main.tf
+++ b/examples/shadowsocks-inbound/main.tf
@@ -3,7 +3,8 @@
 terraform {
   required_providers {
     threexui = {
-      source = "batonogov/threexui"
+      source  = "batonogov/threexui"
+      version = "~> 2.0"
     }
   }
 }

--- a/examples/trojan-inbound/main.tf
+++ b/examples/trojan-inbound/main.tf
@@ -3,7 +3,8 @@
 terraform {
   required_providers {
     threexui = {
-      source = "batonogov/threexui"
+      source  = "batonogov/threexui"
+      version = "~> 2.0"
     }
   }
 }
@@ -22,6 +23,8 @@ resource "threexui_inbound" "trojan" {
 
   stream_settings {
     network  = "ws"
+    # security = "none" is for local/testing only.
+    # In production, use "tls" or put the inbound behind a reverse proxy with TLS.
     security = "none"
     ws_settings {
       path = "/trojan-ws"

--- a/examples/trojan-inbound/main.tf
+++ b/examples/trojan-inbound/main.tf
@@ -22,7 +22,7 @@ resource "threexui_inbound" "trojan" {
   enable   = true
 
   stream_settings {
-    network  = "ws"
+    network = "ws"
     # security = "none" is for local/testing only.
     # In production, use "tls" or put the inbound behind a reverse proxy with TLS.
     security = "none"


### PR DESCRIPTION
## Summary

- Add 5 new example configurations: provider-env-config, trojan-inbound, shadowsocks-inbound, inbound-with-client, import-existing
- Add Examples section to README.md with links to all examples
- Import guide covers inbounds, clients, panel settings, and xray settings with `terraform import` commands

## Test plan

- [ ] Verify `terraform fmt -check -recursive examples/` passes in CI
- [ ] Review each example for correctness against provider schema
- [ ] Confirm README links resolve to the correct directories

Closes #74