### PR TITLE
docs: add note about subscription port and reverse proxy

### DIFF
--- a/docs/resources/panel_subscription.md
+++ b/docs/resources/panel_subscription.md
@@ -11,7 +11,7 @@ Manages the subscription service settings of the 3x-ui panel.
 
 This is a singleton resource -- only one instance should exist per provider. Deleting this resource only removes it from Terraform state; it does not reset the settings.
 
--> **Note:** When `sub_port` (default `2096`) differs from the main panel port and the panel runs behind a reverse proxy, the proxy must be configured to forward subscription path requests to the subscription port. Without this, subscription URLs will return 404.
+~> **Note:** When `sub_port` (default `2096`) differs from the main panel port and the panel runs behind a reverse proxy, the proxy must be configured to forward subscription path requests to the subscription port. Without this, subscription URLs will return 404.
 
 **Caddy** example:
 

--- a/docs/resources/panel_subscription.md
+++ b/docs/resources/panel_subscription.md
@@ -11,6 +11,24 @@ Manages the subscription service settings of the 3x-ui panel.
 
 This is a singleton resource -- only one instance should exist per provider. Deleting this resource only removes it from Terraform state; it does not reset the settings.
 
+-> **Note:** When `sub_port` (default `2096`) differs from the main panel port and the panel runs behind a reverse proxy, the proxy must be configured to forward subscription path requests to the subscription port. Without this, subscription URLs will return 404.
+
+**Caddy** example:
+
+```caddy
+handle /sub/* {
+    reverse_proxy 3x-ui:2096
+}
+```
+
+**Nginx** example:
+
+```nginx
+location /sub/ {
+    proxy_pass http://3x-ui:2096;
+}
+```
+
 ## Example Usage
 
 ```hcl

--- a/provider/resource_settings_tabs.go
+++ b/provider/resource_settings_tabs.go
@@ -249,6 +249,12 @@ type PanelSubscriptionModel struct {
 
 func panelSubscriptionSchema() schema.Schema {
 	return schema.Schema{
+		MarkdownDescription: "Manages subscription settings in the 3x-ui panel.\n\n" +
+			"~> **Note:** When `sub_port` (default `2096`) differs from the main panel port and the panel " +
+			"runs behind a reverse proxy, the proxy must be configured to forward subscription path requests " +
+			"to the subscription port. Without this, subscription URLs will return 404. " +
+			"For example, in Caddy: `handle /sub/* { reverse_proxy 3x-ui:2096 }`. " +
+			"In Nginx: `location /sub/ { proxy_pass http://3x-ui:2096; }`.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed: true,


### PR DESCRIPTION
## Summary

- Added a note to `docs/resources/panel_subscription.md` explaining that when `sub_port` differs from the main panel port and the panel runs behind a reverse proxy, subscription URLs require extra proxy configuration
- Added Caddy and Nginx reverse proxy configuration examples
- Added `MarkdownDescription` to the subscription resource schema in `provider/resource_settings_tabs.go` with the same note

## Test plan

- [x] `task build` passes
- [x] `markdownlint` passes
- [x] All pre-commit hooks pass

Closes #109