### PR TITLE
feat: add enable_parallel_query and use_system_hosts to xray_dns

### DIFF
--- a/provider/acc_xray_test.go
+++ b/provider/acc_xray_test.go
@@ -55,6 +55,8 @@ func TestAccXrayDNS(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("threexui_xray_dns.test", "id", "xray_dns"),
 					resource.TestCheckResourceAttr("threexui_xray_dns.test", "query_strategy", "UseIP"),
+					resource.TestCheckResourceAttr("threexui_xray_dns.test", "enable_parallel_query", "true"),
+					resource.TestCheckResourceAttr("threexui_xray_dns.test", "use_system_hosts", "false"),
 					resource.TestCheckResourceAttr("threexui_xray_dns.test", "server.0.address", "8.8.8.8"),
 					resource.TestCheckResourceAttr("threexui_xray_dns.test", "server.1.address", "localhost"),
 					resource.TestCheckResourceAttr("threexui_xray_dns.test", "server.1.port", "53"),
@@ -66,6 +68,8 @@ func TestAccXrayDNS(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("threexui_xray_dns.test", "id", "xray_dns"),
 					resource.TestCheckResourceAttr("threexui_xray_dns.test", "query_strategy", "UseIPv4"),
+					resource.TestCheckResourceAttr("threexui_xray_dns.test", "enable_parallel_query", "false"),
+					resource.TestCheckResourceAttr("threexui_xray_dns.test", "use_system_hosts", "true"),
 					resource.TestCheckResourceAttr("threexui_xray_dns.test", "server.0.address", "1.1.1.1"),
 				),
 			},
@@ -318,7 +322,9 @@ resource "threexui_xray_basics" "test" {
 func testAccXrayDNSConfig() string {
 	return `
 resource "threexui_xray_dns" "test" {
-  query_strategy = "UseIP"
+  query_strategy       = "UseIP"
+  enable_parallel_query = true
+  use_system_hosts      = false
 
   server {
     address = "8.8.8.8"
@@ -336,7 +342,9 @@ resource "threexui_xray_dns" "test" {
 func testAccXrayDNSConfigUpdated() string {
 	return `
 resource "threexui_xray_dns" "test" {
-  query_strategy = "UseIPv4"
+  query_strategy       = "UseIPv4"
+  enable_parallel_query = false
+  use_system_hosts      = true
 
   server {
     address = "1.1.1.1"

--- a/provider/xray_dns_schema.go
+++ b/provider/xray_dns_schema.go
@@ -24,6 +24,8 @@ type XrayDNSModel struct {
 	DisableFallback        types.Bool      `tfsdk:"disable_fallback"`
 	DisableFallbackIfMatch types.Bool      `tfsdk:"disable_fallback_if_match"`
 	ClientIP               types.String    `tfsdk:"client_ip"`
+	EnableParallelQuery    types.Bool      `tfsdk:"enable_parallel_query"`
+	UseSystemHosts         types.Bool      `tfsdk:"use_system_hosts"`
 }
 
 type XrayDNSServer struct {
@@ -67,6 +69,12 @@ func xrayDNSSchema() schema.Schema {
 				Optional: true, Computed: true,
 			},
 			"client_ip": schema.StringAttribute{
+				Optional: true, Computed: true,
+			},
+			"enable_parallel_query": schema.BoolAttribute{
+				Optional: true, Computed: true,
+			},
+			"use_system_hosts": schema.BoolAttribute{
 				Optional: true, Computed: true,
 			},
 			"hosts": schema.MapAttribute{
@@ -158,6 +166,12 @@ func expandXrayDNS(m *XrayDNSModel) map[string]any {
 	if !m.ClientIP.IsNull() && !m.ClientIP.IsUnknown() {
 		out["client_ip"] = m.ClientIP.ValueString()
 	}
+	if !m.EnableParallelQuery.IsNull() && !m.EnableParallelQuery.IsUnknown() {
+		out["enable_parallel_query"] = m.EnableParallelQuery.ValueBool()
+	}
+	if !m.UseSystemHosts.IsNull() && !m.UseSystemHosts.IsUnknown() {
+		out["use_system_hosts"] = m.UseSystemHosts.ValueBool()
+	}
 
 	return out
 }
@@ -228,6 +242,8 @@ func flattenXrayDNS(data map[string]any) *XrayDNSModel {
 		DisableFallback:        types.BoolNull(),
 		DisableFallbackIfMatch: types.BoolNull(),
 		ClientIP:               types.StringNull(),
+		EnableParallelQuery:    types.BoolNull(),
+		UseSystemHosts:         types.BoolNull(),
 	}
 
 	if v, ok := data["server"].([]any); ok {
@@ -257,6 +273,12 @@ func flattenXrayDNS(data map[string]any) *XrayDNSModel {
 	}
 	if v, ok := data["client_ip"].(string); ok {
 		m.ClientIP = types.StringValue(v)
+	}
+	if v, ok := data["enable_parallel_query"].(bool); ok {
+		m.EnableParallelQuery = types.BoolValue(v)
+	}
+	if v, ok := data["use_system_hosts"].(bool); ok {
+		m.UseSystemHosts = types.BoolValue(v)
 	}
 
 	return m
@@ -360,6 +382,12 @@ func buildXrayDNSJSON(d map[string]any) any {
 	}
 	if v, ok := d["client_ip"].(string); ok && v != "" {
 		payload["clientIp"] = v
+	}
+	if v, ok := d["enable_parallel_query"]; ok {
+		payload["enableParallelQuery"] = boolValue(v)
+	}
+	if v, ok := d["use_system_hosts"]; ok {
+		payload["useSystemHosts"] = boolValue(v)
 	}
 
 	return payload
@@ -490,6 +518,12 @@ func flattenXrayDNSToMap(data any) map[string]any {
 	}
 	if v, ok := payload["clientIp"].(string); ok {
 		out["client_ip"] = v
+	}
+	if v, ok := payload["enableParallelQuery"].(bool); ok {
+		out["enable_parallel_query"] = v
+	}
+	if v, ok := payload["useSystemHosts"].(bool); ok {
+		out["use_system_hosts"] = v
 	}
 
 	return out

--- a/provider/xray_settings_test.go
+++ b/provider/xray_settings_test.go
@@ -1315,6 +1315,123 @@ func TestBuildXrayDNSJSON_Roundtrip(t *testing.T) {
 	}
 }
 
+func TestBuildXrayDNSJSON_NewFields_Roundtrip(t *testing.T) {
+	input := map[string]any{
+		"server": []any{
+			map[string]any{"address": "8.8.8.8"},
+		},
+		"query_strategy":        "UseIP",
+		"enable_parallel_query": true,
+		"use_system_hosts":      false,
+	}
+	flattened := flattenXrayDNSToMap(buildXrayDNSJSON(input))
+	if flattened["enable_parallel_query"] != true {
+		t.Fatalf("expected enable_parallel_query true, got %v", flattened["enable_parallel_query"])
+	}
+	if flattened["use_system_hosts"] != false {
+		t.Fatalf("expected use_system_hosts false, got %v", flattened["use_system_hosts"])
+	}
+}
+
+func TestFlattenXrayDNSToMap_NewFields(t *testing.T) {
+	data := map[string]any{
+		"servers":             []any{"8.8.8.8"},
+		"queryStrategy":       "UseIP",
+		"enableParallelQuery": true,
+		"useSystemHosts":      true,
+	}
+	result := flattenXrayDNSToMap(data)
+	if result["enable_parallel_query"] != true {
+		t.Fatalf("expected enable_parallel_query true, got %v", result["enable_parallel_query"])
+	}
+	if result["use_system_hosts"] != true {
+		t.Fatalf("expected use_system_hosts true, got %v", result["use_system_hosts"])
+	}
+}
+
+func TestFlattenXrayDNSToMap_NewFields_Missing(t *testing.T) {
+	data := map[string]any{
+		"servers":       []any{"8.8.8.8"},
+		"queryStrategy": "UseIP",
+	}
+	result := flattenXrayDNSToMap(data)
+	if _, ok := result["enable_parallel_query"]; ok {
+		t.Fatalf("enable_parallel_query should be absent when not in payload")
+	}
+	if _, ok := result["use_system_hosts"]; ok {
+		t.Fatalf("use_system_hosts should be absent when not in payload")
+	}
+}
+
+func TestExpandXrayDNS_NewFields(t *testing.T) {
+	m := &XrayDNSModel{
+		ID:                     types.StringValue("xray_dns"),
+		Hosts:                  types.MapNull(types.StringType),
+		QueryStrategy:          types.StringValue("UseIP"),
+		Tag:                    types.StringNull(),
+		DisableCache:           types.BoolNull(),
+		DisableFallback:        types.BoolNull(),
+		DisableFallbackIfMatch: types.BoolNull(),
+		ClientIP:               types.StringNull(),
+		EnableParallelQuery:    types.BoolValue(true),
+		UseSystemHosts:         types.BoolValue(false),
+	}
+	result := expandXrayDNS(m)
+	if result["enable_parallel_query"] != true {
+		t.Fatalf("expected enable_parallel_query true, got %v", result["enable_parallel_query"])
+	}
+	if result["use_system_hosts"] != false {
+		t.Fatalf("expected use_system_hosts false, got %v", result["use_system_hosts"])
+	}
+}
+
+func TestExpandXrayDNS_NewFields_Null(t *testing.T) {
+	m := &XrayDNSModel{
+		ID:                     types.StringValue("xray_dns"),
+		Hosts:                  types.MapNull(types.StringType),
+		QueryStrategy:          types.StringNull(),
+		Tag:                    types.StringNull(),
+		DisableCache:           types.BoolNull(),
+		DisableFallback:        types.BoolNull(),
+		DisableFallbackIfMatch: types.BoolNull(),
+		ClientIP:               types.StringNull(),
+		EnableParallelQuery:    types.BoolNull(),
+		UseSystemHosts:         types.BoolNull(),
+	}
+	result := expandXrayDNS(m)
+	if _, ok := result["enable_parallel_query"]; ok {
+		t.Fatalf("null enable_parallel_query should not be in expanded map")
+	}
+	if _, ok := result["use_system_hosts"]; ok {
+		t.Fatalf("null use_system_hosts should not be in expanded map")
+	}
+}
+
+func TestFlattenXrayDNS_NewFields(t *testing.T) {
+	data := map[string]any{
+		"enable_parallel_query": true,
+		"use_system_hosts":      false,
+	}
+	result := flattenXrayDNS(data)
+	if result.EnableParallelQuery.ValueBool() != true {
+		t.Fatalf("expected EnableParallelQuery true, got %v", result.EnableParallelQuery)
+	}
+	if result.UseSystemHosts.ValueBool() != false {
+		t.Fatalf("expected UseSystemHosts false, got %v", result.UseSystemHosts)
+	}
+}
+
+func TestFlattenXrayDNS_NewFields_Missing(t *testing.T) {
+	data := map[string]any{}
+	result := flattenXrayDNS(data)
+	if !result.EnableParallelQuery.IsNull() {
+		t.Fatalf("expected null EnableParallelQuery when not in data")
+	}
+	if !result.UseSystemHosts.IsNull() {
+		t.Fatalf("expected null UseSystemHosts when not in data")
+	}
+}
+
 func TestBuildXrayRoutingJSON_Roundtrip(t *testing.T) {
 	input := map[string]any{
 		"domain_strategy": "IPIfNonMatch",


### PR DESCRIPTION
## Summary

- Added `enable_parallel_query` (bool, Optional+Computed) to `threexui_xray_dns` -- maps to `enableParallelQuery` in Xray DNS JSON
- Added `use_system_hosts` (bool, Optional+Computed) to `threexui_xray_dns` -- maps to `useSystemHosts` in Xray DNS JSON
- Wired through all four conversion layers: typed model, schema, expand/flatten typed, build/flatten untyped
- `fakedns` is a root-level Xray config section (not a DNS field), so it was not included here

Closes #65

## Test plan

- [x] 7 unit tests added: round-trip, null handling, missing field scenarios
- [x] Acceptance tests updated with new fields (create + update + import + idempotency)
- [x] `go build` passes
- [x] `go test` (unit) passes
- [ ] Acceptance tests (`task test:acc`) -- require Docker