### PR TITLE
feat: add mixed_settings block for mixed inbound protocol

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ provider/              — all provider code
   xray_balancers_schema.go   — model, schema, expand/flatten for xray_balancers
   xray_reverse_schema.go     — model, schema, expand/flatten for xray_reverse (bridges, portals)
   xray_outbounds_schema.go   — model, schema, expand/flatten for xray_outbounds (per-protocol settings)
-  inbound_settings_schema.go      — model, schema, expand/flatten for per-protocol settings (vless, trojan, ss, http, socks, wg, dokodemo, hysteria)
+  inbound_settings_schema.go      — model, schema, expand/flatten for per-protocol settings (vless, trojan, ss, http, socks, mixed, wg, dokodemo, hysteria)
   inbound_stream_settings_schema.go — model, schema, expand/flatten for stream_settings (tcp, ws, grpc, httpupgrade, xhttp, kcp, hysteria, reality, sockopt)
   inbound_sniffing_schema.go      — model, schema, expand/flatten for sniffing
   settings.go          — buildSettingsJSON(map[string]any), flattenSettings(string), expand/flatten clients/fallbacks/peers
@@ -112,7 +112,7 @@ Unauthenticated requests return 404 (not 401). The client performs auto re-login
 
 - `settings`, `stream_settings`, `sniffing` — JSON strings in the API, typed blocks in TF schema
 - Three-layer conversion: Typed Model ↔ Untyped Map (expand/flatten*FromModel/*ToModel) ↔ JSON String (build*/flatten*)
-- Per-protocol settings blocks: `vless_settings`, `trojan_settings`, `shadowsocks_settings`, `http_settings`, `socks_settings`, `wireguard_settings`, `dokodemo_settings`, `hysteria_settings`
+- Per-protocol settings blocks: `vless_settings`, `trojan_settings`, `shadowsocks_settings`, `http_settings`, `socks_settings`, `mixed_settings`, `wireguard_settings`, `dokodemo_settings`, `hysteria_settings`
 - stream_settings supports transports: tcp, ws, grpc, httpupgrade, xhttp, kcp, hysteria + reality, sockopt, external_proxy
 - Sniffing supports `ips_excluded` and `domains_excluded` fields (added in 3x-ui 2.9.0)
 - KCP: `congestion`, `read_buffer_size`, `write_buffer_size` replaced by `cwnd_multiplier`, `max_sending_window` (breaking, 2.9.0)

--- a/provider/acc_inbound_test.go
+++ b/provider/acc_inbound_test.go
@@ -695,7 +695,7 @@ resource "threexui_inbound" "grpc" {
 	})
 }
 
-// --- Mixed protocol + listen ---
+// --- Mixed protocol + listen + settings ---
 
 func TestAccInboundMixed(t *testing.T) {
 	resource.Test(t, resource.TestCase{
@@ -711,12 +711,48 @@ resource "threexui_inbound" "mixed" {
   remark   = "acc-mixed"
   listen   = "127.0.0.1"
   enable   = true
+  mixed_settings {
+    auth = "password"
+    udp  = true
+    ip   = "127.0.0.1"
+    account {
+      user = "mixeduser"
+      pass = "mixedpass"
+    }
+  }
 }
 `,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("threexui_inbound.mixed", "id"),
 					resource.TestCheckResourceAttr("threexui_inbound.mixed", "protocol", "mixed"),
 					resource.TestCheckResourceAttr("threexui_inbound.mixed", "listen", "127.0.0.1"),
+					resource.TestCheckResourceAttr("threexui_inbound.mixed", "mixed_settings.auth", "password"),
+					resource.TestCheckResourceAttr("threexui_inbound.mixed", "mixed_settings.udp", "true"),
+				),
+			},
+			// Update: change udp to false
+			{
+				Config: testAccProviderConfig() + `
+resource "threexui_inbound" "mixed" {
+  port     = 25024
+  protocol = "mixed"
+  remark   = "acc-mixed-updated"
+  listen   = "127.0.0.1"
+  enable   = true
+  mixed_settings {
+    auth = "password"
+    udp  = false
+    ip   = "127.0.0.1"
+    account {
+      user = "mixeduser"
+      pass = "mixedpass"
+    }
+  }
+}
+`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("threexui_inbound.mixed", "remark", "acc-mixed-updated"),
+					resource.TestCheckResourceAttr("threexui_inbound.mixed", "mixed_settings.udp", "false"),
 				),
 			},
 		},

--- a/provider/corpus_test.go
+++ b/provider/corpus_test.go
@@ -65,6 +65,7 @@ func TestCorpusSettings_RoundTrip(t *testing.T) {
 		{"settings_shadowsocks.json", "Shadowsocks with method/password/network"},
 		{"settings_http.json", "HTTP with multiple accounts"},
 		{"settings_socks.json", "SOCKS with auth and UDP"},
+		{"settings_mixed.json", "Mixed with auth, accounts, UDP and IP"},
 		{"settings_wireguard.json", "WireGuard with peers, gateway, dns, mtu list"},
 		{"settings_dokodemo.json", "Dokodemo-door with portMap and followRedirect"},
 		{"settings_hysteria.json", "Hysteria v2 with version field"},

--- a/provider/drift_test.go
+++ b/provider/drift_test.go
@@ -483,6 +483,7 @@ func TestDriftProtocolForms(t *testing.T) {
 	providerExtras := map[string]bool{
 		"vmess": true, // vmess has no settings block but is handled
 		"tun":   true, // alias for tunnel/dokodemo-door
+		"mixed": true, // mixed reuses the socks form in 3x-ui
 	}
 	for k := range providerExtras {
 		providerBlocks[k] = true

--- a/provider/inbound_settings_schema.go
+++ b/provider/inbound_settings_schema.go
@@ -64,6 +64,13 @@ type InboundDokodemoSettingsModel struct {
 	FollowRedirect types.Bool   `tfsdk:"follow_redirect"`
 }
 
+type InboundMixedSettingsModel struct {
+	Auth    types.String          `tfsdk:"auth"`
+	UDP     types.Bool            `tfsdk:"udp"`
+	IP      types.String          `tfsdk:"ip"`
+	Account []InboundAccountModel `tfsdk:"account"`
+}
+
 type InboundHysteriaSettingsModel struct {
 	Version types.Int64 `tfsdk:"version"`
 }
@@ -204,6 +211,40 @@ func inboundSettingsBlockSchemas() map[string]schema.Block {
 		},
 		"socks_settings": schema.SingleNestedBlock{
 			Description: "Settings for SOCKS proxy protocol.",
+			Attributes: map[string]schema.Attribute{
+				"auth": schema.StringAttribute{
+					Optional: true, Computed: true,
+					Description: "Authentication type (e.g. 'password', 'noauth').",
+					PlanModifiers: []planmodifier.String{
+						stringplanmodifier.UseStateForUnknown(),
+					},
+				},
+				"udp": schema.BoolAttribute{
+					Optional: true, Computed: true,
+					Description: "Enable UDP support.",
+					PlanModifiers: []planmodifier.Bool{
+						boolplanmodifier.UseStateForUnknown(),
+					},
+				},
+				"ip": schema.StringAttribute{
+					Optional: true, Computed: true,
+					Description: "IP address for UDP.",
+					PlanModifiers: []planmodifier.String{
+						stringplanmodifier.UseStateForUnknown(),
+					},
+				},
+			},
+			Blocks: map[string]schema.Block{
+				"account": schema.ListNestedBlock{
+					Description: "User accounts for authentication.",
+					NestedObject: schema.NestedBlockObject{
+						Attributes: inboundAccountAttributes(),
+					},
+				},
+			},
+		},
+		"mixed_settings": schema.SingleNestedBlock{
+			Description: "Settings for mixed (HTTP+SOCKS) proxy protocol.",
 			Attributes: map[string]schema.Attribute{
 				"auth": schema.StringAttribute{
 					Optional: true, Computed: true,
@@ -449,6 +490,8 @@ func expandSettingsFromModel(protocol string, m *InboundResourceModel) map[strin
 		return expandHTTPInboundSettings(m.HTTPSettings)
 	case "socks":
 		return expandSocksInboundSettings(m.SocksSettings)
+	case "mixed":
+		return expandMixedInboundSettings(m.MixedSettings)
 	case "wireguard":
 		return expandWireguardInboundSettings(m.WireguardSettings)
 	case "dokodemo-door", "tunnel":
@@ -529,6 +572,26 @@ func expandHTTPInboundSettings(m *InboundHTTPSettingsModel) map[string]any {
 }
 
 func expandSocksInboundSettings(m *InboundSocksSettingsModel) map[string]any {
+	if m == nil {
+		return nil
+	}
+	out := map[string]any{}
+	if !m.Auth.IsNull() && !m.Auth.IsUnknown() {
+		out["auth"] = m.Auth.ValueString()
+	}
+	if !m.UDP.IsNull() && !m.UDP.IsUnknown() {
+		out["udp"] = m.UDP.ValueBool()
+	}
+	if !m.IP.IsNull() && !m.IP.IsUnknown() {
+		out["ip"] = m.IP.ValueString()
+	}
+	if len(m.Account) > 0 {
+		out["accounts"] = expandAccountsFromModel(m.Account)
+	}
+	return out
+}
+
+func expandMixedInboundSettings(m *InboundMixedSettingsModel) map[string]any {
 	if m == nil {
 		return nil
 	}
@@ -701,6 +764,8 @@ func flattenSettingsToModel(protocol string, data map[string]any, m *InboundReso
 		m.HTTPSettings = flattenHTTPInboundSettings(data)
 	case "socks":
 		m.SocksSettings = flattenSocksInboundSettings(data)
+	case "mixed":
+		m.MixedSettings = flattenMixedInboundSettings(data)
 	case "wireguard":
 		m.WireguardSettings = flattenWireguardInboundSettings(data)
 	case "dokodemo-door", "tunnel":
@@ -801,6 +866,32 @@ func flattenSocksInboundSettings(data map[string]any) *InboundSocksSettingsModel
 		return nil
 	}
 	m := &InboundSocksSettingsModel{}
+	if v, ok := data["auth"].(string); ok {
+		m.Auth = types.StringValue(v)
+	} else {
+		m.Auth = types.StringNull()
+	}
+	if v, ok := data["udp"].(bool); ok {
+		m.UDP = types.BoolValue(v)
+	} else {
+		m.UDP = types.BoolNull()
+	}
+	if v, ok := data["ip"].(string); ok && v != "" {
+		m.IP = types.StringValue(v)
+	} else {
+		m.IP = types.StringNull()
+	}
+	if v, ok := data["accounts"].([]any); ok && len(v) > 0 {
+		m.Account = flattenAccountsToModel(v)
+	}
+	return m
+}
+
+func flattenMixedInboundSettings(data map[string]any) *InboundMixedSettingsModel {
+	if len(data) == 0 {
+		return nil
+	}
+	m := &InboundMixedSettingsModel{}
 	if v, ok := data["auth"].(string); ok {
 		m.Auth = types.StringValue(v)
 	} else {

--- a/provider/resource_inbound.go
+++ b/provider/resource_inbound.go
@@ -53,6 +53,7 @@ type InboundResourceModel struct {
 	ShadowsocksSettings *InboundShadowsocksSettingsModel `tfsdk:"shadowsocks_settings"`
 	HTTPSettings        *InboundHTTPSettingsModel        `tfsdk:"http_settings"`
 	SocksSettings       *InboundSocksSettingsModel       `tfsdk:"socks_settings"`
+	MixedSettings       *InboundMixedSettingsModel       `tfsdk:"mixed_settings"`
 	WireguardSettings   *InboundWireguardSettingsModel   `tfsdk:"wireguard_settings"`
 	DokodemoSettings    *InboundDokodemoSettingsModel    `tfsdk:"dokodemo_settings"`
 	HysteriaSettings    *InboundHysteriaSettingsModel    `tfsdk:"hysteria_settings"`
@@ -482,6 +483,9 @@ func alignBlocksWithPlan(state *InboundResourceModel, plan *InboundResourceModel
 	}
 	if plan.SocksSettings == nil {
 		state.SocksSettings = nil
+	}
+	if plan.MixedSettings == nil {
+		state.MixedSettings = nil
 	}
 	if plan.WireguardSettings == nil {
 		state.WireguardSettings = nil

--- a/provider/resource_inbound_matrix_test.go
+++ b/provider/resource_inbound_matrix_test.go
@@ -56,6 +56,7 @@ func protocolMatrix() []protocolMatrixEntry {
 		matrixShadowsocks(),
 		matrixHTTP(),
 		matrixSocks(),
+		matrixMixed(),
 		matrixWireguard(),
 		matrixDokodemo(),
 		matrixHysteria(),
@@ -574,6 +575,66 @@ resource "threexui_inbound" "mx_socks" {
 				resource.TestCheckResourceAttr(addr, "socks_settings.udp", "false"),
 				resource.TestCheckResourceAttr(addr, "socks_settings.account.0.user", "socksuser"),
 				resource.TestCheckResourceAttr(addr, "socks_settings.account.0.pass", "sockspass"),
+			}
+		},
+	}
+}
+
+func matrixMixed() protocolMatrixEntry {
+	return protocolMatrixEntry{
+		protocol: "mixed",
+		tfName:   "mx_mixed",
+		port:     26010,
+		createHCL: func(port int) string {
+			return fmt.Sprintf(`
+resource "threexui_inbound" "mx_mixed" {
+  port     = %d
+  protocol = "mixed"
+  remark   = "matrix-mixed-create"
+  enable   = true
+  mixed_settings {
+    auth = "password"
+    udp  = true
+    ip   = "127.0.0.1"
+    account {
+      user = "mixeduser"
+      pass = "mixedpass"
+    }
+  }
+}
+`, port)
+		},
+		updateHCL: func(port int) string {
+			return fmt.Sprintf(`
+resource "threexui_inbound" "mx_mixed" {
+  port     = %d
+  protocol = "mixed"
+  remark   = "matrix-mixed-updated"
+  enable   = true
+  mixed_settings {
+    auth = "password"
+    udp  = false
+    ip   = "127.0.0.1"
+    account {
+      user = "mixeduser"
+      pass = "mixedpass"
+    }
+  }
+}
+`, port)
+		},
+		createChecks: func(addr string) []resource.TestCheckFunc {
+			return []resource.TestCheckFunc{
+				resource.TestCheckResourceAttr(addr, "remark", "matrix-mixed-create"),
+				resource.TestCheckResourceAttr(addr, "mixed_settings.udp", "true"),
+			}
+		},
+		updateChecks: func(addr string) []resource.TestCheckFunc {
+			return []resource.TestCheckFunc{
+				resource.TestCheckResourceAttr(addr, "remark", "matrix-mixed-updated"),
+				resource.TestCheckResourceAttr(addr, "mixed_settings.udp", "false"),
+				resource.TestCheckResourceAttr(addr, "mixed_settings.account.0.user", "mixeduser"),
+				resource.TestCheckResourceAttr(addr, "mixed_settings.account.0.pass", "mixedpass"),
 			}
 		},
 	}

--- a/provider/settings_expand_flatten_test.go
+++ b/provider/settings_expand_flatten_test.go
@@ -3,6 +3,8 @@ package provider
 import (
 	"reflect"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 func TestExpandFallbacks_Empty(t *testing.T) {
@@ -261,6 +263,117 @@ func TestBuildFlattenSettings_DokodemoPortMap(t *testing.T) {
 	}
 	if pm["80"] != "http" || pm["443"] != "https" {
 		t.Fatalf("unexpected port_map: %v", pm)
+	}
+}
+
+func TestBuildFlattenSettings_Mixed(t *testing.T) {
+	input := map[string]any{
+		"auth":     "password",
+		"accounts": []any{map[string]any{"user": "mixeduser", "pass": "mixedpass"}},
+		"udp":      true,
+		"ip":       "127.0.0.1",
+	}
+	jsonStr := buildSettingsJSON(input)
+	result, err := flattenSettings(jsonStr)
+	if err != nil {
+		t.Fatalf("flattenSettings error: %v", err)
+	}
+	if len(result) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(result))
+	}
+	m, ok := result[0].(map[string]any)
+	if !ok {
+		t.Fatal("expected map[string]any")
+	}
+	if m["auth"] != "password" {
+		t.Fatalf("unexpected auth: %v", m["auth"])
+	}
+	if m["udp"] != true {
+		t.Fatalf("unexpected udp: %v", m["udp"])
+	}
+	if m["ip"] != "127.0.0.1" {
+		t.Fatalf("unexpected ip: %v", m["ip"])
+	}
+	accounts, ok := m["accounts"].([]any)
+	if !ok || len(accounts) != 1 {
+		t.Fatalf("unexpected accounts: %v", m["accounts"])
+	}
+	acc, _ := accounts[0].(map[string]any)
+	if acc["user"] != "mixeduser" || acc["pass"] != "mixedpass" {
+		t.Fatalf("unexpected account: %v", acc)
+	}
+}
+
+func TestExpandFlattenMixedSettingsModel_RoundTrip(t *testing.T) {
+	model := &InboundResourceModel{
+		MixedSettings: &InboundMixedSettingsModel{
+			Auth: types.StringValue("password"),
+			UDP:  types.BoolValue(true),
+			IP:   types.StringValue("127.0.0.1"),
+			Account: []InboundAccountModel{
+				{User: types.StringValue("u1"), Pass: types.StringValue("p1")},
+			},
+		},
+	}
+
+	expanded := expandSettingsFromModel("mixed", model)
+	if expanded == nil {
+		t.Fatal("expected non-nil result for mixed protocol")
+	}
+	if expanded["auth"] != "password" {
+		t.Fatalf("unexpected auth: %v", expanded["auth"])
+	}
+	if expanded["udp"] != true {
+		t.Fatalf("unexpected udp: %v", expanded["udp"])
+	}
+	if expanded["ip"] != "127.0.0.1" {
+		t.Fatalf("unexpected ip: %v", expanded["ip"])
+	}
+
+	// Build JSON and flatten back
+	jsonStr := buildSettingsJSON(expanded)
+	flatMap, err := flattenSettingsToMap(jsonStr)
+	if err != nil {
+		t.Fatalf("flattenSettingsToMap error: %v", err)
+	}
+
+	result := &InboundResourceModel{}
+	flattenSettingsToModel("mixed", flatMap, result)
+	if result.MixedSettings == nil {
+		t.Fatal("expected MixedSettings to be set")
+	}
+	if result.MixedSettings.Auth.ValueString() != "password" {
+		t.Fatalf("unexpected auth: %s", result.MixedSettings.Auth.ValueString())
+	}
+	if result.MixedSettings.UDP.ValueBool() != true {
+		t.Fatalf("unexpected udp: %v", result.MixedSettings.UDP.ValueBool())
+	}
+	if result.MixedSettings.IP.ValueString() != "127.0.0.1" {
+		t.Fatalf("unexpected ip: %s", result.MixedSettings.IP.ValueString())
+	}
+	if len(result.MixedSettings.Account) != 1 {
+		t.Fatalf("expected 1 account, got %d", len(result.MixedSettings.Account))
+	}
+	if result.MixedSettings.Account[0].User.ValueString() != "u1" {
+		t.Fatalf("unexpected user: %s", result.MixedSettings.Account[0].User.ValueString())
+	}
+}
+
+func TestExpandSettingsFromModel_MixedNil(t *testing.T) {
+	model := &InboundResourceModel{
+		MixedSettings: nil,
+	}
+	result := expandSettingsFromModel("mixed", model)
+	if result != nil {
+		t.Fatalf("expected nil for nil MixedSettings, got %v", result)
+	}
+}
+
+func TestFlattenSettingsToModel_MixedEmptyData(t *testing.T) {
+	model := &InboundResourceModel{}
+	flattenSettingsToModel("mixed", map[string]any{}, model)
+	if model.MixedSettings != nil {
+		t.Fatal("expected nil MixedSettings for empty data")
 	}
 }
 

--- a/provider/testdata/settings_mixed.json
+++ b/provider/testdata/settings_mixed.json
@@ -1,0 +1,11 @@
+{
+  "auth": "password",
+  "accounts": [
+    {
+      "user": "mixed-user",
+      "pass": "mixed-pass"
+    }
+  ],
+  "udp": true,
+  "ip": "127.0.0.1"
+}


### PR DESCRIPTION
## Summary

- Add `mixed_settings` typed block for the mixed (HTTP+SOCKS) inbound protocol with fields: `auth`, `udp`, `ip`, `account`
- Follow existing patterns from `socks_settings` and `http_settings` (model, schema, expand/flatten, plan modifiers)
- Add unit tests (expand/flatten round-trip, corpus fixture), acceptance test, and protocol matrix entry

## Changed files

- `provider/inbound_settings_schema.go` -- model, schema block, expand/flatten functions for mixed
- `provider/resource_inbound.go` -- `MixedSettings` field in model, `alignBlocksWithPlan` support
- `provider/settings_expand_flatten_test.go` -- unit tests for mixed expand/flatten
- `provider/resource_inbound_matrix_test.go` -- `matrixMixed()` entry
- `provider/acc_inbound_test.go` -- updated `TestAccInboundMixed` to use `mixed_settings` block
- `provider/corpus_test.go` -- added `settings_mixed.json` fixture to round-trip test
- `provider/testdata/settings_mixed.json` -- test fixture
- `provider/drift_test.go` -- added `mixed` to `providerExtras` (no upstream form)
- `CLAUDE.md` -- updated docs to include `mixed_settings`

## Test plan

- [x] `task build` passes
- [x] `task test:unit` -- all unit tests pass (including new mixed-specific tests)
- [ ] `task test:acc` -- acceptance tests (requires Docker with 3x-ui)

Closes #64