### PR TITLE
feat: expose VLESS vision testseed as first-class field

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,17 @@ resource "threexui_inbound_client" "client_a" {
 }
 ```
 
+## Examples
+
+| Example | Description |
+| --- | --- |
+| [Provider with env config](examples/provider-env-config/) | Configure the provider using Terraform variables and `TF_VAR_*` environment variables |
+| [VLESS Reality](examples/) | Basic VLESS Reality inbound with a client (Quick Start) |
+| [Trojan inbound](examples/trojan-inbound/) | Trojan protocol with WebSocket transport |
+| [Shadowsocks inbound](examples/shadowsocks-inbound/) | Shadowsocks with AEAD cipher |
+| [Inbound with clients](examples/inbound-with-client/) | Complete workflow: inbound + multiple clients |
+| [Import existing resources](examples/import-existing/) | Import existing 3x-ui resources into Terraform state |
+
 ## Documentation
 
 Full documentation is available on the [Terraform Registry](https://registry.terraform.io/providers/batonogov/threexui/latest/docs).

--- a/examples/import-existing/main.tf
+++ b/examples/import-existing/main.tf
@@ -1,0 +1,103 @@
+# Importing existing 3x-ui resources into Terraform state.
+#
+# If you already have inbounds and clients configured in the 3x-ui panel,
+# you can import them into Terraform instead of recreating them.
+#
+# Prerequisites:
+#   - Find inbound IDs in the 3x-ui panel (Settings column or API)
+#   - Find client UUIDs in the inbound client list
+#
+# --------------------------------------------------------------------------
+# 1. Inbound import
+# --------------------------------------------------------------------------
+#
+# Import by inbound numeric ID (visible in the panel or via API):
+#
+#   terraform import threexui_inbound.existing 5
+#
+# After import, run `terraform plan` to see the current state.
+# Copy the attributes into your configuration to avoid drift.
+#
+# --------------------------------------------------------------------------
+# 2. Client import
+# --------------------------------------------------------------------------
+#
+# Import format: <inbound_id>:<client_uuid>
+#
+#   terraform import threexui_inbound_client.existing_client 5:d4f1a2b3-c4d5-6e7f-8a9b-0c1d2e3f4a5b
+#
+# --------------------------------------------------------------------------
+# 3. Singleton resources (panel settings)
+# --------------------------------------------------------------------------
+#
+# Panel settings are singletons. Import with any ID (the provider ignores it):
+#
+#   terraform import threexui_panel_general.settings settings
+#   terraform import threexui_panel_security.settings settings
+#   terraform import threexui_panel_telegram.settings settings
+#   terraform import threexui_panel_subscription.settings settings
+#
+# --------------------------------------------------------------------------
+# 4. Xray settings
+# --------------------------------------------------------------------------
+#
+# Xray settings are also singletons:
+#
+#   terraform import threexui_xray_basics.config settings
+#   terraform import threexui_xray_dns.config settings
+#   terraform import threexui_xray_routing.config settings
+#   terraform import threexui_xray_outbounds.config settings
+#
+# --------------------------------------------------------------------------
+
+terraform {
+  required_providers {
+    threexui = {
+      source = "batonogov/threexui"
+    }
+  }
+}
+
+provider "threexui" {
+  endpoint = "http://localhost:2053"
+  username = "admin"
+  password = "admin"
+}
+
+# After importing, fill in the actual values from `terraform state show`.
+resource "threexui_inbound" "existing" {
+  port     = 443
+  protocol = "vless"
+  remark   = "Imported VLESS"
+  enable   = true
+
+  vless_settings {
+    decryption = "none"
+  }
+
+  stream_settings {
+    network  = "tcp"
+    security = "reality"
+    reality_settings {
+      target       = "www.apple.com:443"
+      server_names = ["www.apple.com"]
+    }
+  }
+
+  sniffing {
+    enabled       = true
+    dest_override = ["http", "tls", "quic", "fakedns"]
+  }
+}
+
+resource "threexui_inbound_client" "existing_client" {
+  inbound_id = threexui_inbound.existing.id
+  email      = "imported-user@example.com"
+  enable     = true
+  flow       = "xtls-rprx-vision"
+}
+
+# Panel settings: import with `terraform import threexui_panel_general.settings settings`
+resource "threexui_panel_general" "settings" {
+  web_port = 2053
+}

--- a/examples/inbound-with-client/main.tf
+++ b/examples/inbound-with-client/main.tf
@@ -1,0 +1,70 @@
+# Complete workflow: VLESS Reality inbound with multiple clients.
+#
+# This example shows how to:
+#   1. Create an inbound with protocol-specific settings
+#   2. Add multiple clients to the same inbound
+#   3. Reference the inbound ID in client resources
+
+terraform {
+  required_providers {
+    threexui = {
+      source = "batonogov/threexui"
+    }
+  }
+}
+
+provider "threexui" {
+  endpoint = "http://localhost:2053"
+  username = "admin"
+  password = "admin"
+}
+
+# Step 1: Create an inbound.
+resource "threexui_inbound" "vless" {
+  port     = 443
+  protocol = "vless"
+  remark   = "VLESS Reality"
+  enable   = true
+
+  vless_settings {
+    decryption = "none"
+  }
+
+  stream_settings {
+    network  = "tcp"
+    security = "reality"
+    reality_settings {
+      target       = "www.apple.com:443"
+      server_names = ["www.apple.com"]
+    }
+  }
+
+  sniffing {
+    enabled       = true
+    dest_override = ["http", "tls", "quic", "fakedns"]
+  }
+}
+
+# Step 2: Add clients. Each client references the inbound by ID.
+resource "threexui_inbound_client" "alice" {
+  inbound_id = threexui_inbound.vless.id
+  email      = "alice@example.com"
+  enable     = true
+  flow       = "xtls-rprx-vision"
+}
+
+resource "threexui_inbound_client" "bob" {
+  inbound_id = threexui_inbound.vless.id
+  email      = "bob@example.com"
+  enable     = true
+  flow       = "xtls-rprx-vision"
+
+  # Limit total traffic to 50 GB.
+  total_gb = 50
+}
+
+# Use the subscription URL from the client output.
+output "alice_sub_id" {
+  description = "Alice subscription ID (use in subscription URL)"
+  value       = threexui_inbound_client.alice.sub_id
+}

--- a/examples/provider-env-config/main.tf
+++ b/examples/provider-env-config/main.tf
@@ -1,0 +1,53 @@
+# Provider configuration using Terraform variables.
+#
+# Set via environment variables:
+#   export TF_VAR_threexui_endpoint="https://panel.example.com:2053"
+#   export TF_VAR_threexui_username="admin"
+#   export TF_VAR_threexui_password="s3cret"
+#   export TF_VAR_threexui_base_path="/"
+#
+# Then run:
+#   terraform plan
+#   terraform apply
+
+variable "threexui_endpoint" {
+  description = "Base URL of the 3x-ui panel"
+  type        = string
+}
+
+variable "threexui_username" {
+  description = "3x-ui admin username"
+  type        = string
+  default     = "admin"
+}
+
+variable "threexui_password" {
+  description = "3x-ui admin password"
+  type        = string
+  sensitive   = true
+  default     = "admin"
+}
+
+variable "threexui_base_path" {
+  description = "Base path configured in 3x-ui (webBasePath)"
+  type        = string
+  default     = "/"
+}
+
+terraform {
+  required_providers {
+    threexui = {
+      source = "batonogov/threexui"
+    }
+  }
+}
+
+provider "threexui" {
+  endpoint  = var.threexui_endpoint
+  username  = var.threexui_username
+  password  = var.threexui_password
+  base_path = var.threexui_base_path
+
+  # Skip TLS verification for self-signed certificates
+  insecure_skip_verify = true
+}

--- a/examples/shadowsocks-inbound/main.tf
+++ b/examples/shadowsocks-inbound/main.tf
@@ -1,0 +1,33 @@
+# Shadowsocks inbound with AEAD cipher.
+
+terraform {
+  required_providers {
+    threexui = {
+      source = "batonogov/threexui"
+    }
+  }
+}
+
+provider "threexui" {
+  endpoint = "http://localhost:2053"
+  username = "admin"
+  password = "admin"
+}
+
+resource "threexui_inbound" "shadowsocks" {
+  port     = 9001
+  protocol = "shadowsocks"
+  remark   = "Shadowsocks"
+  enable   = true
+
+  shadowsocks_settings {
+    method   = "aes-256-gcm"
+    password = "change-me-to-a-strong-password"
+    network  = "tcp,udp"
+  }
+
+  sniffing {
+    enabled       = true
+    dest_override = ["http", "tls", "quic", "fakedns"]
+  }
+}

--- a/examples/trojan-inbound/main.tf
+++ b/examples/trojan-inbound/main.tf
@@ -1,0 +1,43 @@
+# Trojan inbound with WebSocket transport.
+
+terraform {
+  required_providers {
+    threexui = {
+      source = "batonogov/threexui"
+    }
+  }
+}
+
+provider "threexui" {
+  endpoint = "http://localhost:2053"
+  username = "admin"
+  password = "admin"
+}
+
+resource "threexui_inbound" "trojan" {
+  port     = 8443
+  protocol = "trojan"
+  remark   = "Trojan WS"
+  enable   = true
+
+  stream_settings {
+    network  = "ws"
+    security = "none"
+    ws_settings {
+      path = "/trojan-ws"
+    }
+  }
+
+  sniffing {
+    enabled       = true
+    dest_override = ["http", "tls", "quic", "fakedns"]
+  }
+}
+
+# Add a client to the Trojan inbound.
+resource "threexui_inbound_client" "trojan_user" {
+  inbound_id = threexui_inbound.trojan.id
+  email      = "trojan-user@example.com"
+  enable     = true
+  password   = "my-trojan-password"
+}


### PR DESCRIPTION
## Summary

- Add `testseed` attribute (`types.List` of `Int64`, `Optional+Computed`) to `vless_settings` block with `UseStateForUnknown` plan modifier
- Users can now explicitly set VLESS Vision test seed values or let the API auto-generate them
- Remove `testseed` from default settings (no longer implicitly set by the provider)
- Keep `preserveInboundSettings` fallback for migration safety (existing users without testseed in config will not lose their values on update)

## Changed files

- `provider/inbound_settings_schema.go` -- model, schema, expand/flatten for testseed
- `provider/default_settings.go` -- remove testseed from vless defaults
- `provider/default_settings_test.go` -- update test for removed default
- `provider/settings_expand_flatten_test.go` -- add unit tests for testseed round-trip
- `provider/acc_inbound_test.go` -- add acceptance tests for explicit and computed testseed
- `CLAUDE.md` -- update documentation

## Test plan

- [x] `task build` passes
- [x] `task test:unit` passes (all existing + 4 new testseed tests)
- [ ] `task test:acc` -- acceptance tests `TestAccInboundVlessTestseed` and `TestAccInboundVlessTestseedComputed` (requires Docker)

Closes #68