### PR TITLE
chore: update 3x-ui test versions to cover v2.9.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ["v2.8.9", "v2.8.10", "v2.8.11"]
+        version: ["v2.8.9", "v2.8.11", "v2.9.0"]
     steps:
       - uses: actions/checkout@v6
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -41,7 +41,7 @@ tasks:
     vars:
       TERRAFORM_PATH:
         sh: which terraform
-      THREEXUI_VERSION: '{{.THREEXUI_VERSION | default "v2.9.0"}}'
+      THREEXUI_VERSION: '{{.THREEXUI_VERSION | default "v2.9.2"}}'
       COMPAT_TESTS: >-
         TestAccInboundBasic$|TestAccInboundUpdateFields$|TestAccInboundTrojan$|TestAccInboundShadowsocks$|TestAccInboundClientBasic$|TestAccInboundClientUpdate$|TestAccXrayBasics$|TestAccXrayRouting$|TestAccXrayOutbounds$|TestAccDataSources$
     cmds:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   3xui:
-    image: ghcr.io/mhsanaei/3x-ui:${THREEXUI_VERSION:-v2.9.0}
+    image: ghcr.io/mhsanaei/3x-ui:${THREEXUI_VERSION:-v2.9.2}
     ports:
       - "2053:2053" # HTTP panel
     environment:


### PR DESCRIPTION
## Summary
- Update default 3x-ui version from v2.9.0 to v2.9.2 (latest release) in docker-compose and Taskfile
- Update CI compat matrix: drop v2.8.10 (no significant API changes vs v2.8.9), add v2.9.0

## Test coverage after this change
| Version | Tests | Purpose |
|---------|-------|---------|
| **v2.9.2** | Full (~60+) | Latest release, default |
| **v2.9.0** | Compat subset | Breaking changes boundary |
| **v2.8.11** | Compat subset | Latest pre-2.9 |
| **v2.8.9** | Compat subset | Oldest supported |

## Test plan
- [ ] CI compat matrix runs green for v2.8.9, v2.8.11, v2.9.0
- [ ] Full acceptance tests pass on v2.9.2