### PR TITLE
fix: trigger CI on CHANGELOG.md changes for release PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ on:
       - .golangci.yml
       - .github/workflows/ci.yml
       - .github/workflows/docs.yml
+      - CHANGELOG.md
   push:
     branches: [main]
     paths:
@@ -23,6 +24,7 @@ on:
       - .golangci.yml
       - .github/workflows/ci.yml
       - .github/workflows/docs.yml
+      - CHANGELOG.md
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Add `CHANGELOG.md` to CI workflow `paths` filter (both `pull_request` and `push`)
- Release Please PRs only change `CHANGELOG.md`, so CI was not triggered on them

## Test plan
- [ ] Next Release Please PR should trigger CI checks