### PR TITLE
fix: document sub_json_fragment/sub_json_noises format change for v2.9.2

### DIFF
--- a/docs/resources/panel_subscription.md
+++ b/docs/resources/panel_subscription.md
@@ -74,8 +74,12 @@ resource "threexui_panel_subscription" "settings" {
 - `sub_uri` (Optional, String) - Subscription URI.
 - `sub_json_path` (Optional, String) - JSON subscription path.
 - `sub_json_uri` (Optional, String) - JSON subscription URI.
-- `sub_json_fragment` (Optional, String) - JSON fragment settings.
-- `sub_json_noises` (Optional, String) - JSON noise settings.
+- `sub_json_fragment` (Optional, String) - JSON fragment settings. The expected format depends on the 3x-ui version:
+  - **v2.9.2+:** only the fragment parameters object, e.g. `{"packets":"tlshello","length":"100-200","interval":"10-20","maxSplit":"300-400"}`.
+  - **v2.9.1 and earlier:** full outbound object with `tag`, `protocol`, `settings`, and `streamSettings`.
+- `sub_json_noises` (Optional, String) - JSON noise settings. The expected format depends on the 3x-ui version:
+  - **v2.9.2+:** only the noises array, e.g. `[{"type":"rand","packet":"10-20","delay":"10-16","applyTo":"ip"}]`.
+  - **v2.9.1 and earlier:** full outbound object with `tag`, `protocol`, `settings`, and `streamSettings`.
 - `sub_json_mux` (Optional, String) - JSON mux settings.
 - `sub_json_rules` (Optional, String) - JSON rules.
 

--- a/provider/resource_settings_tabs.go
+++ b/provider/resource_settings_tabs.go
@@ -344,10 +344,18 @@ func panelSubscriptionSchema() schema.Schema {
 			},
 			"sub_json_fragment": schema.StringAttribute{
 				Optional: true, Computed: true,
+				Description: "JSON fragment settings for subscription. " +
+					"**v2.9.2+:** only the fragment parameters object, e.g. " +
+					"`{\"packets\":\"tlshello\",\"length\":\"100-200\",\"interval\":\"10-20\"}`. " +
+					"**v2.9.1 and earlier:** full outbound object with tag, protocol, settings and streamSettings.",
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"sub_json_noises": schema.StringAttribute{
 				Optional: true, Computed: true,
+				Description: "JSON noise settings for subscription. " +
+					"**v2.9.2+:** only the noises array, e.g. " +
+					"`[{\"type\":\"rand\",\"packet\":\"10-20\",\"delay\":\"10-16\"}]`. " +
+					"**v2.9.1 and earlier:** full outbound object with tag, protocol, settings and streamSettings.",
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"sub_json_mux": schema.StringAttribute{


### PR DESCRIPTION
## Summary

- Added version-specific descriptions to `sub_json_fragment` and `sub_json_noises` schema attributes in `provider/resource_settings_tabs.go`
- Updated `docs/resources/panel_subscription.md` to document the format change between 3x-ui v2.9.1 and v2.9.2

**Before v2.9.2:** these fields expected full outbound objects (with `tag`, `protocol`, `settings`, `streamSettings`).
**v2.9.2+:** `sub_json_fragment` expects only the fragment parameters object; `sub_json_noises` expects only the noises array.

Closes #121

## Test plan

- [x] `task build` passes
- [x] Pre-commit hooks pass (fmt, vet, lint, build, markdownlint)
- [ ] CI pipeline passes