### PR TITLE
feat: version-aware test skipping for compat matrix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,7 +171,7 @@ Unauthenticated requests return 404 (not 401). The client performs auto re-login
 task build            # Build binary
 task test:unit        # Run unit tests (no Docker / Terraform needed)
 task test:acc         # Run acceptance tests (requires Docker)
-task test:acc:compat  # Run compatibility subset against THREEXUI_VERSION (default v2.9.0)
+task test:acc:compat  # Run all tests with version-aware skipping (THREEXUI_VERSION, default v2.9.2)
 task test             # Run unit + acceptance tests
 task fmt              # gofmt
 task vet              # go vet
@@ -203,7 +203,7 @@ docker compose up -d   # Start 3x-ui on localhost:2053
 # Docker image defaults to webBasePath = / (NOT /panel/)
 # Do not set THREEXUI_BASE_PATH
 
-# Run compatibility subset against a specific 3x-ui version:
+# Run all tests with version-aware skipping:
 THREEXUI_VERSION=v2.8.9 task test:acc:compat
 
 # Run all versions locally:
@@ -211,6 +211,20 @@ for v in v2.8.9 v2.8.10 v2.8.11 v2.9.0; do
   echo "=== Testing $v ===" && THREEXUI_VERSION=$v task test:acc:compat
 done
 ```
+
+### Version-Aware Test Skipping
+
+Tests that use features introduced in specific 3x-ui versions call `requireMinVersion(t, "vX.Y.Z")`
+at the start. When `THREEXUI_VERSION` env var is set (by `task test:acc:compat` or CI matrix),
+tests requiring a newer version are automatically skipped via `t.Skip()`.
+
+Version mapping:
+
+- **v2.9.0+**: mixed protocol, WireGuard mtu as list/gateway/dns, sniffing ips\_excluded/domains\_excluded
+- **v2.8.11+**: tunnel protocol, DNS enable\_parallel\_query/use\_system\_hosts
+
+Tests without `requireMinVersion` run on all supported versions (v2.8.9+).
+Helper: `provider/test_helpers.go` (`requireMinVersion` uses `golang.org/x/mod/semver`).
 
 Acceptance tests use `terraform-plugin-testing`:
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -37,15 +37,13 @@ tasks:
         go test ./provider -run TestAcc -count=1 -timeout 600s -v
 
   test:acc:compat:
-    desc: Запустить acceptance-тесты совместимости (репрезентативное подмножество)
+    desc: Запустить acceptance-тесты совместимости (версионный пропуск)
     vars:
       TERRAFORM_PATH:
         sh: which terraform
       THREEXUI_VERSION: '{{.THREEXUI_VERSION | default "v2.9.2"}}'
-      COMPAT_TESTS: >-
-        TestAccInboundBasic$|TestAccInboundUpdateFields$|TestAccInboundTrojan$|TestAccInboundShadowsocks$|TestAccInboundClientBasic$|TestAccInboundClientUpdate$|TestAccXrayBasics$|TestAccXrayRouting$|TestAccXrayOutbounds$|TestAccDataSources$
     cmds:
-      - echo "Running compat tests against 3x-ui {{.THREEXUI_VERSION}}"
+      - echo "Running tests against 3x-ui {{.THREEXUI_VERSION}}"
       - docker compose down -v 2>/dev/null || true
       - docker compose up --detach --wait --quiet-pull
       - defer: docker compose down
@@ -57,9 +55,8 @@ tasks:
         THREEXUI_ENDPOINT=http://localhost:2053
         THREEXUI_USERNAME=admin
         THREEXUI_PASSWORD=admin
-        go test ./provider
-        -run '{{.COMPAT_TESTS}}'
-        -count=1 -timeout 600s -v
+        THREEXUI_VERSION={{.THREEXUI_VERSION}}
+        go test ./provider -run TestAcc -count=1 -timeout 600s -v
 
   fmt:
     desc: Форматировать Go-файлы

--- a/provider/acc_inbound_test.go
+++ b/provider/acc_inbound_test.go
@@ -144,6 +144,8 @@ resource "threexui_inbound" "http" {
 // --- WireGuard with peers ---
 
 func TestAccInboundWireguard(t *testing.T) {
+	requireMinVersion(t, "v2.9.0") // mtu changed from int to list [v4, v6] in v2.9.0
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
@@ -209,6 +211,8 @@ resource "threexui_inbound" "dokodemo" {
 // --- Tunnel (dokodemo-door alias in 3x-ui 2.8.11+) ---
 
 func TestAccInboundTunnel(t *testing.T) {
+	requireMinVersion(t, "v2.8.11") // tunnel protocol added in v2.8.11
+
 	tunnelConfig := testAccProviderConfig() + `
 resource "threexui_inbound" "tunnel" {
   port     = 25030
@@ -698,6 +702,8 @@ resource "threexui_inbound" "grpc" {
 // --- Mixed protocol + listen + settings ---
 
 func TestAccInboundMixed(t *testing.T) {
+	requireMinVersion(t, "v2.9.0") // mixed protocol added in v2.9.0
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),

--- a/provider/acc_panel_settings_test.go
+++ b/provider/acc_panel_settings_test.go
@@ -11,6 +11,7 @@ import (
 // --- Panel General: page_size, remark_model, time_location, update, idempotency ---
 
 func TestAccPanelGeneral(t *testing.T) {
+	requireMinVersion(t, "v2.8.10")
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
@@ -172,6 +173,7 @@ resource "threexui_panel_general" "test" {
 // --- Panel General: LDAP fields ---
 
 func TestAccPanelGeneralLDAP(t *testing.T) {
+	requireMinVersion(t, "v2.8.10")
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
@@ -429,6 +431,7 @@ resource "threexui_panel_telegram" "test" {
 // Terraform applies independent resources concurrently, so both paths compete
 // for the settings API. The settingsMu mutex must serialize these operations.
 func TestAccPanelGeneralConcurrentSettings(t *testing.T) {
+	requireMinVersion(t, "v2.8.10")
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
@@ -592,6 +595,7 @@ resource "threexui_panel_subscription" "test" {
 // same graph without lost updates. Both compete for the xray template
 // endpoint; xrayTemplateMu must serialize them.
 func TestAccPanelGeneralConcurrentXray(t *testing.T) {
+	requireMinVersion(t, "v2.8.10")
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
@@ -907,6 +911,7 @@ resource "threexui_panel_subscription" "test" {
 // because the framework re-configures the provider between apply and
 // post-apply plan, which would create a new client with the old base_path.
 func TestAccPanelGeneralBasePathChange(t *testing.T) {
+	requireMinVersion(t, "v2.8.10")
 	if os.Getenv("TF_ACC") == "" {
 		t.Skip("TF_ACC not set")
 	}

--- a/provider/acc_xray_test.go
+++ b/provider/acc_xray_test.go
@@ -46,6 +46,8 @@ func TestAccXrayBasics(t *testing.T) {
 }
 
 func TestAccXrayDNS(t *testing.T) {
+	requireMinVersion(t, "v2.8.11") // enable_parallel_query and use_system_hosts added in v2.8.11
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),

--- a/provider/resource_inbound_matrix_test.go
+++ b/provider/resource_inbound_matrix_test.go
@@ -27,6 +27,8 @@ type protocolMatrixEntry struct {
 	tfName string
 	// port is a unique port for this protocol's test.
 	port int
+	// minVersion is the minimum 3x-ui version required (e.g. "v2.9.0"). Empty means all versions.
+	minVersion string
 	// createHCL returns the HCL for the initial create step.
 	createHCL func(port int) string
 	// updateHCL returns the HCL for the update step (must change at least one
@@ -70,6 +72,9 @@ func protocolMatrix() []protocolMatrixEntry {
 func TestAccInboundProtocolMatrix(t *testing.T) {
 	for _, entry := range protocolMatrix() {
 		t.Run(entry.protocol, func(t *testing.T) {
+			if entry.minVersion != "" {
+				requireMinVersion(t, entry.minVersion)
+			}
 
 			inboundAddr := fmt.Sprintf("threexui_inbound.%s", entry.tfName)
 			createConfig := testAccProviderConfig() + entry.createHCL(entry.port)
@@ -582,9 +587,10 @@ resource "threexui_inbound" "mx_socks" {
 
 func matrixMixed() protocolMatrixEntry {
 	return protocolMatrixEntry{
-		protocol: "mixed",
-		tfName:   "mx_mixed",
-		port:     26010,
+		protocol:   "mixed",
+		tfName:     "mx_mixed",
+		port:       26010,
+		minVersion: "v2.9.0", // mixed protocol added in v2.9.0
 		createHCL: func(port int) string {
 			return fmt.Sprintf(`
 resource "threexui_inbound" "mx_mixed" {
@@ -642,9 +648,10 @@ resource "threexui_inbound" "mx_mixed" {
 
 func matrixWireguard() protocolMatrixEntry {
 	return protocolMatrixEntry{
-		protocol: "wireguard",
-		tfName:   "mx_wg",
-		port:     26007,
+		protocol:   "wireguard",
+		tfName:     "mx_wg",
+		port:       26007,
+		minVersion: "v2.9.0", // mtu changed from int to list [v4, v6] in v2.9.0
 		createHCL: func(port int) string {
 			return fmt.Sprintf(`
 resource "threexui_inbound" "mx_wg" {

--- a/provider/test_helpers.go
+++ b/provider/test_helpers.go
@@ -1,0 +1,31 @@
+package provider
+
+import (
+	"os"
+	"testing"
+
+	"golang.org/x/mod/semver"
+)
+
+// requireMinVersion skips the test if THREEXUI_VERSION is set and is older than min.
+// Both values must use "v" prefix (e.g. "v2.9.0").
+func requireMinVersion(t *testing.T, min string) {
+	t.Helper()
+
+	v := os.Getenv("THREEXUI_VERSION")
+	if v == "" {
+		return // no version constraint, run the test
+	}
+
+	if !semver.IsValid(v) {
+		return // can't parse, don't skip
+	}
+
+	if !semver.IsValid(min) {
+		t.Fatalf("invalid min version %q", min)
+	}
+
+	if semver.Compare(v, min) < 0 {
+		t.Skipf("requires 3x-ui >= %s, running %s", min, v)
+	}
+}


### PR DESCRIPTION
## Summary

- Replace curated `COMPAT_TESTS` regex in `Taskfile.yml` with a version-aware skip mechanism
- Each acceptance test that uses version-specific features declares its minimum 3x-ui version via `requireMinVersion(t, "vX.Y.Z")`
- When `THREEXUI_VERSION` is set, tests needing a newer version are automatically skipped
- `test:acc:compat` now runs ALL `TestAcc` tests instead of a hardcoded subset

## Changes

- **`provider/test_helpers.go`** (new): `requireMinVersion` helper using `golang.org/x/mod/semver`
- **`provider/acc_inbound_test.go`**: annotate `TestAccInboundMixed` (v2.9.0), `TestAccInboundWireguard` (v2.9.0), `TestAccInboundTunnel` (v2.8.11)
- **`provider/acc_xray_test.go`**: annotate `TestAccXrayDNS` (v2.8.11)
- **`provider/resource_inbound_matrix_test.go`**: add `minVersion` field to `protocolMatrixEntry`, annotate mixed (v2.9.0) and wireguard (v2.9.0) entries
- **`Taskfile.yml`**: remove `COMPAT_TESTS` variable, pass `THREEXUI_VERSION` to `go test`, run all `TestAcc` tests
- **`CLAUDE.md`**: document the version-aware test skipping approach

## Test plan

- [ ] `task build` passes
- [ ] `task test:unit` passes
- [ ] CI compat matrix: v2.8.9 should skip mixed/wireguard/tunnel/DNS tests, v2.9.0 should run all
- [ ] `THREEXUI_VERSION=v2.8.9 task test:acc:compat` skips version-specific tests
- [ ] `task test:acc` (no THREEXUI_VERSION) runs all tests as before