### PR TITLE
feat: add xPadding fields to xhttp_settings block

### DIFF
--- a/provider/acc_inbound_test.go
+++ b/provider/acc_inbound_test.go
@@ -1186,6 +1186,62 @@ resource "threexui_inbound" "import_sniffing" {
 	})
 }
 
+// --- XHTTP with xPadding fields ---
+
+func TestAccInboundXHTTPPadding(t *testing.T) {
+	config := testAccProviderConfig() + `
+resource "threexui_inbound" "xhttp_pad" {
+  port     = 25033
+  protocol = "vless"
+  remark   = "acc-xhttp-xpadding"
+  enable   = true
+  vless_settings {
+    decryption = "none"
+  }
+  stream_settings {
+    network  = "xhttp"
+    security = "none"
+    xhttp_settings {
+      path                = "/xhttp-padded"
+      mode                = "auto"
+      x_padding_bytes     = "100-1000"
+      x_padding_obfs_mode = true
+      x_padding_key       = "my-secret-key"
+      x_padding_header    = "X-Padding"
+      x_padding_placement = "header"
+      x_padding_method    = "aes"
+    }
+  }
+}
+`
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		CheckDestroy:             testAccCheckInboundDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("threexui_inbound.xhttp_pad", "id"),
+					resource.TestCheckResourceAttr("threexui_inbound.xhttp_pad", "protocol", "vless"),
+					resource.TestCheckResourceAttr("threexui_inbound.xhttp_pad", "stream_settings.xhttp_settings.path", "/xhttp-padded"),
+					resource.TestCheckResourceAttr("threexui_inbound.xhttp_pad", "stream_settings.xhttp_settings.x_padding_bytes", "100-1000"),
+					resource.TestCheckResourceAttr("threexui_inbound.xhttp_pad", "stream_settings.xhttp_settings.x_padding_obfs_mode", "true"),
+					resource.TestCheckResourceAttr("threexui_inbound.xhttp_pad", "stream_settings.xhttp_settings.x_padding_key", "my-secret-key"),
+					resource.TestCheckResourceAttr("threexui_inbound.xhttp_pad", "stream_settings.xhttp_settings.x_padding_header", "X-Padding"),
+					resource.TestCheckResourceAttr("threexui_inbound.xhttp_pad", "stream_settings.xhttp_settings.x_padding_placement", "header"),
+					resource.TestCheckResourceAttr("threexui_inbound.xhttp_pad", "stream_settings.xhttp_settings.x_padding_method", "aes"),
+				),
+			},
+			{
+				Config:             config,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
 // --- Config helpers ---
 
 func testAccInboundUpdateConfig(remark string, port int, enable bool) string {

--- a/provider/corpus_test.go
+++ b/provider/corpus_test.go
@@ -153,6 +153,7 @@ func TestCorpusStreamSettings_RoundTrip(t *testing.T) {
 		{"stream_settings_kcp.json", "KCP with cwndMultiplier/maxSendingWindow (2.9.0)"},
 		{"stream_settings_httpupgrade.json", "HTTP Upgrade transport"},
 		{"stream_settings_xhttp.json", "XHTTP transport with keepAliveInterval"},
+		{"stream_settings_xhttp_xpadding.json", "XHTTP transport with xPadding fields"},
 		{"stream_settings_sockopt.json", "TCP with full sockopt"},
 		{"stream_settings_hysteria.json", "Hysteria transport with auth and version"},
 	}

--- a/provider/inbound_stream_settings_schema.go
+++ b/provider/inbound_stream_settings_schema.go
@@ -89,6 +89,12 @@ type InboundXHTTPSettingsModel struct {
 	Mode              types.String `tfsdk:"mode"`
 	NoSSEHeader       types.Bool   `tfsdk:"no_sse_header"`
 	KeepAliveInterval types.Int64  `tfsdk:"keep_alive_interval"`
+	XPaddingBytes     types.String `tfsdk:"x_padding_bytes"`
+	XPaddingObfsMode  types.Bool   `tfsdk:"x_padding_obfs_mode"`
+	XPaddingKey       types.String `tfsdk:"x_padding_key"`
+	XPaddingHeader    types.String `tfsdk:"x_padding_header"`
+	XPaddingPlacement types.String `tfsdk:"x_padding_placement"`
+	XPaddingMethod    types.String `tfsdk:"x_padding_method"`
 }
 
 type InboundKCPSettingsModel struct {
@@ -385,6 +391,48 @@ func inboundStreamSettingsBlockSchema() schema.SingleNestedBlock {
 						Optional: true, Computed: true,
 						PlanModifiers: []planmodifier.Int64{
 							int64planmodifier.UseStateForUnknown(),
+						},
+					},
+					"x_padding_bytes": schema.StringAttribute{
+						Optional: true, Computed: true,
+						Description: "xPadding bytes range (e.g. '100-1000').",
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.UseStateForUnknown(),
+						},
+					},
+					"x_padding_obfs_mode": schema.BoolAttribute{
+						Optional: true, Computed: true,
+						Description: "Enable xPadding obfuscation mode.",
+						PlanModifiers: []planmodifier.Bool{
+							boolplanmodifier.UseStateForUnknown(),
+						},
+					},
+					"x_padding_key": schema.StringAttribute{
+						Optional: true, Computed: true,
+						Description: "xPadding encryption key.",
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.UseStateForUnknown(),
+						},
+					},
+					"x_padding_header": schema.StringAttribute{
+						Optional: true, Computed: true,
+						Description: "xPadding header name.",
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.UseStateForUnknown(),
+						},
+					},
+					"x_padding_placement": schema.StringAttribute{
+						Optional: true, Computed: true,
+						Description: "xPadding placement (e.g. 'header', 'body').",
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.UseStateForUnknown(),
+						},
+					},
+					"x_padding_method": schema.StringAttribute{
+						Optional: true, Computed: true,
+						Description: "xPadding method.",
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.UseStateForUnknown(),
 						},
 					},
 				},
@@ -754,6 +802,24 @@ func expandXHTTPSettingsFromModel(m *InboundXHTTPSettingsModel) map[string]any {
 	}
 	if !m.KeepAliveInterval.IsNull() && !m.KeepAliveInterval.IsUnknown() {
 		out["keep_alive_interval"] = int(m.KeepAliveInterval.ValueInt64())
+	}
+	if !m.XPaddingBytes.IsNull() && !m.XPaddingBytes.IsUnknown() {
+		out["x_padding_bytes"] = m.XPaddingBytes.ValueString()
+	}
+	if !m.XPaddingObfsMode.IsNull() && !m.XPaddingObfsMode.IsUnknown() {
+		out["x_padding_obfs_mode"] = m.XPaddingObfsMode.ValueBool()
+	}
+	if !m.XPaddingKey.IsNull() && !m.XPaddingKey.IsUnknown() {
+		out["x_padding_key"] = m.XPaddingKey.ValueString()
+	}
+	if !m.XPaddingHeader.IsNull() && !m.XPaddingHeader.IsUnknown() {
+		out["x_padding_header"] = m.XPaddingHeader.ValueString()
+	}
+	if !m.XPaddingPlacement.IsNull() && !m.XPaddingPlacement.IsUnknown() {
+		out["x_padding_placement"] = m.XPaddingPlacement.ValueString()
+	}
+	if !m.XPaddingMethod.IsNull() && !m.XPaddingMethod.IsUnknown() {
+		out["x_padding_method"] = m.XPaddingMethod.ValueString()
 	}
 	return out
 }
@@ -1142,6 +1208,36 @@ func flattenXHTTPSettingsToModel(data map[string]any) *InboundXHTTPSettingsModel
 		m.KeepAliveInterval = types.Int64Value(int64(intValue(v)))
 	} else {
 		m.KeepAliveInterval = types.Int64Null()
+	}
+	if v, ok := data["x_padding_bytes"].(string); ok && v != "" {
+		m.XPaddingBytes = types.StringValue(v)
+	} else {
+		m.XPaddingBytes = types.StringNull()
+	}
+	if v, ok := data["x_padding_obfs_mode"].(bool); ok {
+		m.XPaddingObfsMode = types.BoolValue(v)
+	} else {
+		m.XPaddingObfsMode = types.BoolNull()
+	}
+	if v, ok := data["x_padding_key"].(string); ok && v != "" {
+		m.XPaddingKey = types.StringValue(v)
+	} else {
+		m.XPaddingKey = types.StringNull()
+	}
+	if v, ok := data["x_padding_header"].(string); ok && v != "" {
+		m.XPaddingHeader = types.StringValue(v)
+	} else {
+		m.XPaddingHeader = types.StringNull()
+	}
+	if v, ok := data["x_padding_placement"].(string); ok && v != "" {
+		m.XPaddingPlacement = types.StringValue(v)
+	} else {
+		m.XPaddingPlacement = types.StringNull()
+	}
+	if v, ok := data["x_padding_method"].(string); ok && v != "" {
+		m.XPaddingMethod = types.StringValue(v)
+	} else {
+		m.XPaddingMethod = types.StringNull()
 	}
 	return m
 }

--- a/provider/stream_settings.go
+++ b/provider/stream_settings.go
@@ -654,6 +654,24 @@ func expandXHTTPSettings(list []any) map[string]any {
 			out["keepAliveInterval"] = n
 		}
 	}
+	if v, ok := item["x_padding_bytes"].(string); ok && v != "" {
+		out["xPaddingBytes"] = v
+	}
+	if v, ok := item["x_padding_obfs_mode"]; ok {
+		out["xPaddingObfsMode"] = boolValue(v)
+	}
+	if v, ok := item["x_padding_key"].(string); ok && v != "" {
+		out["xPaddingKey"] = v
+	}
+	if v, ok := item["x_padding_header"].(string); ok && v != "" {
+		out["xPaddingHeader"] = v
+	}
+	if v, ok := item["x_padding_placement"].(string); ok && v != "" {
+		out["xPaddingPlacement"] = v
+	}
+	if v, ok := item["x_padding_method"].(string); ok && v != "" {
+		out["xPaddingMethod"] = v
+	}
 	if len(out) == 0 {
 		return nil
 	}
@@ -676,6 +694,24 @@ func flattenXHTTPSettings(in map[string]any) map[string]any {
 	}
 	if v, ok := in["keepAliveInterval"]; ok {
 		out["keep_alive_interval"] = intValue(v)
+	}
+	if v, ok := in["xPaddingBytes"].(string); ok {
+		out["x_padding_bytes"] = v
+	}
+	if v, ok := in["xPaddingObfsMode"].(bool); ok {
+		out["x_padding_obfs_mode"] = v
+	}
+	if v, ok := in["xPaddingKey"].(string); ok {
+		out["x_padding_key"] = v
+	}
+	if v, ok := in["xPaddingHeader"].(string); ok {
+		out["x_padding_header"] = v
+	}
+	if v, ok := in["xPaddingPlacement"].(string); ok {
+		out["x_padding_placement"] = v
+	}
+	if v, ok := in["xPaddingMethod"].(string); ok {
+		out["x_padding_method"] = v
 	}
 	if len(out) == 0 {
 		return nil

--- a/provider/testdata/stream_settings_xhttp_xpadding.json
+++ b/provider/testdata/stream_settings_xhttp_xpadding.json
@@ -1,0 +1,16 @@
+{
+  "network": "xhttp",
+  "security": "none",
+  "xhttpSettings": {
+    "path": "/xhttp-padded",
+    "mode": "auto",
+    "noSSEHeader": false,
+    "keepAliveInterval": 30,
+    "xPaddingBytes": "100-1000",
+    "xPaddingObfsMode": true,
+    "xPaddingKey": "my-secret-key",
+    "xPaddingHeader": "X-Padding",
+    "xPaddingPlacement": "header",
+    "xPaddingMethod": "aes"
+  }
+}


### PR DESCRIPTION
## Summary

- Add six new `xPadding` fields to the `xhttp_settings` block in `stream_settings`: `x_padding_bytes`, `x_padding_obfs_mode`, `x_padding_key`, `x_padding_header`, `x_padding_placement`, `x_padding_method`
- All fields are Optional+Computed with `UseStateForUnknown` plan modifiers, following the existing pattern
- Three-layer conversion updated: typed model (schema), untyped map (expand/flatten), JSON (camelCase keys `xPaddingBytes`, `xPaddingObfsMode`, etc.)

Closes #122

## Changed files

- `provider/inbound_stream_settings_schema.go` -- model, schema, expand/flatten for typed model layer
- `provider/stream_settings.go` -- expand/flatten for JSON camelCase layer
- `provider/corpus_test.go` -- added xPadding round-trip test case
- `provider/acc_inbound_test.go` -- added acceptance test `TestAccInboundXHTTPPadding`
- `provider/testdata/stream_settings_xhttp_xpadding.json` -- fixture for corpus round-trip test

## Test plan

- [x] Unit tests pass (`go test ./provider/ -run '^Test[^A]'`)
- [x] Corpus round-trip test for xhttp with xPadding fields passes
- [x] Build succeeds (`go build ./...`)
- [x] Pre-commit hooks pass (fmt, vet, lint, build)
- [ ] Acceptance test `TestAccInboundXHTTPPadding` (requires Docker with 3x-ui)