### PR TITLE
fix: revert unnecessary polling in xray_version, fix version annotations

### DIFF
--- a/provider/acc_inbound_test.go
+++ b/provider/acc_inbound_test.go
@@ -1195,6 +1195,7 @@ resource "threexui_inbound" "import_sniffing" {
 // --- XHTTP with xPadding fields ---
 
 func TestAccInboundXHTTPPadding(t *testing.T) {
+	requireMinVersion(t, "v2.9.2") // xPaddingObfsMode, xPaddingKey added in v2.9.2
 	config := testAccProviderConfig() + `
 resource "threexui_inbound" "xhttp_pad" {
   port     = 25033

--- a/provider/acc_xray_test.go
+++ b/provider/acc_xray_test.go
@@ -46,8 +46,6 @@ func TestAccXrayBasics(t *testing.T) {
 }
 
 func TestAccXrayDNS(t *testing.T) {
-	requireMinVersion(t, "v2.8.11") // enable_parallel_query and use_system_hosts added in v2.8.11
-
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),

--- a/provider/resource_xray_version.go
+++ b/provider/resource_xray_version.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -83,7 +84,7 @@ func (r *XrayVersionResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
-	current, err := r.client.GetCurrentXrayVersion(ctx)
+	current, err := r.waitForXrayVersion(ctx, version)
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to get current Xray version", err.Error())
 		return
@@ -146,7 +147,7 @@ func (r *XrayVersionResource) Update(ctx context.Context, req resource.UpdateReq
 		return
 	}
 
-	current, err := r.client.GetCurrentXrayVersion(ctx)
+	current, err := r.waitForXrayVersion(ctx, version)
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to get current Xray version", err.Error())
 		return
@@ -163,6 +164,28 @@ func (r *XrayVersionResource) Update(ctx context.Context, req resource.UpdateReq
 	plan.ID = types.StringValue("xray_version")
 	plan.CurrentVersion = types.StringValue(current)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+// waitForXrayVersion polls GetCurrentXrayVersion until it matches the desired
+// version or the timeout (30s) is exceeded. Although UpdateXray in 3x-ui is
+// synchronous (download → extract → RestartXray), the restarted xray process
+// may not report the new version immediately via GetXrayVersion.
+func (r *XrayVersionResource) waitForXrayVersion(ctx context.Context, version string) (string, error) {
+	for i := 0; i < 30; i++ {
+		current, err := r.client.GetCurrentXrayVersion(ctx)
+		if err != nil {
+			return "", err
+		}
+		if current == version {
+			return current, nil
+		}
+		time.Sleep(time.Second)
+	}
+	current, err := r.client.GetCurrentXrayVersion(ctx)
+	if err != nil {
+		return "", err
+	}
+	return current, nil
 }
 
 func (r *XrayVersionResource) Delete(_ context.Context, _ resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/provider/resource_xray_version.go
+++ b/provider/resource_xray_version.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -84,7 +83,7 @@ func (r *XrayVersionResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
-	current, err := r.waitForXrayVersion(ctx, version)
+	current, err := r.client.GetCurrentXrayVersion(ctx)
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to get current Xray version", err.Error())
 		return
@@ -147,7 +146,7 @@ func (r *XrayVersionResource) Update(ctx context.Context, req resource.UpdateReq
 		return
 	}
 
-	current, err := r.waitForXrayVersion(ctx, version)
+	current, err := r.client.GetCurrentXrayVersion(ctx)
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to get current Xray version", err.Error())
 		return
@@ -164,27 +163,6 @@ func (r *XrayVersionResource) Update(ctx context.Context, req resource.UpdateReq
 	plan.ID = types.StringValue("xray_version")
 	plan.CurrentVersion = types.StringValue(current)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
-}
-
-// waitForXrayVersion polls GetCurrentXrayVersion until it matches the desired
-// version or the timeout (30s) is exceeded. InstallXray is asynchronous — the
-// API returns immediately while the download/install runs in the background.
-func (r *XrayVersionResource) waitForXrayVersion(ctx context.Context, version string) (string, error) {
-	for i := 0; i < 30; i++ {
-		current, err := r.client.GetCurrentXrayVersion(ctx)
-		if err != nil {
-			return "", err
-		}
-		if current == version {
-			return current, nil
-		}
-		time.Sleep(time.Second)
-	}
-	current, err := r.client.GetCurrentXrayVersion(ctx)
-	if err != nil {
-		return "", err
-	}
-	return current, nil
 }
 
 func (r *XrayVersionResource) Delete(_ context.Context, _ resource.DeleteRequest, resp *resource.DeleteResponse) {


### PR DESCRIPTION
## Summary
Cleanup before v2.1.0 release based on 3x-ui source review.

- **Revert `waitForXrayVersion` polling** — `UpdateXray` in 3x-ui is fully synchronous (download → extract → restart → return). Polling added unnecessary 30s timeout on failures without fixing root cause.
- **Remove `requireMinVersion(v2.8.11)` from `TestAccXrayDNS`** — `enableParallelQuery`/`useSystemHosts` are Xray template fields passed through by 3x-ui, present in UI translations since v2.8.9.
- **Add `requireMinVersion(v2.9.2)` to `TestAccInboundXHTTPPadding`** — `xPaddingObfsMode`, `xPaddingKey` fields exist only from v2.9.2 (confirmed from 3x-ui sources).

## Test plan
- [ ] Unit tests pass
- [ ] Acceptance tests pass on v2.9.2
- [ ] Compat v2.8.9 does not skip DNS test unnecessarily