### PR TITLE
fix: confirm inbound deletion via poll-and-retry (#136)

### DIFF
--- a/provider/inbound_client_test.go
+++ b/provider/inbound_client_test.go
@@ -2,11 +2,14 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strconv"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestClientAddInbound(t *testing.T) {
@@ -143,21 +146,19 @@ func TestClientDeleteInbound(t *testing.T) {
 	}
 }
 
-// TestInboundResourceWaitForDeletion verifies the post-Delete polling loop
-// added in #136. It exercises three scenarios:
-//   - immediate deletion (single GET that fails)
-//   - stale read followed by a successful re-delete (GET → DELETE → GET)
-//   - persistent stale read that exhausts the retry budget
+// TestInboundResourceWaitForDeletion exercises the post-Delete poll added in
+// #136. The helper checks the inbound list for the absence of id; it does NOT
+// re-issue DELETE (DelInbound is not idempotent in 3x-ui).
 func TestInboundResourceWaitForDeletion(t *testing.T) {
-	t.Run("immediate", func(t *testing.T) {
-		var gets int
+	t.Run("immediate-absent", func(t *testing.T) {
+		var lists int32
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.Method == http.MethodGet && r.URL.Path == "/panel/api/inbounds/get/9" {
-				gets++
-				w.Write(failResponse("record not found"))
+			if r.URL.Path != "/panel/api/inbounds/list" {
+				w.WriteHeader(http.StatusNotFound)
 				return
 			}
-			w.WriteHeader(http.StatusNotFound)
+			atomic.AddInt32(&lists, 1)
+			w.Write(okResponse([]Inbound{{ID: 7}}))
 		}))
 		defer srv.Close()
 
@@ -165,29 +166,24 @@ func TestInboundResourceWaitForDeletion(t *testing.T) {
 		if err := res.waitForInboundDeletion(context.Background(), 9); err != nil {
 			t.Fatalf("waitForInboundDeletion: %v", err)
 		}
-		if gets != 1 {
-			t.Fatalf("expected 1 GET, got %d", gets)
+		if got := atomic.LoadInt32(&lists); got != 1 {
+			t.Fatalf("expected exactly 1 list call, got %d", got)
 		}
 	})
 
-	t.Run("retry-then-success", func(t *testing.T) {
-		var gets, dels int
+	t.Run("becomes-absent-after-poll", func(t *testing.T) {
+		var lists int32
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			switch {
-			case r.Method == http.MethodGet && r.URL.Path == "/panel/api/inbounds/get/3":
-				gets++
-				if gets <= 2 {
-					// First two GETs report inbound still present.
-					w.Write(okResponse(&Inbound{ID: 3}))
-					return
-				}
-				w.Write(failResponse("record not found"))
-			case r.Method == http.MethodPost && r.URL.Path == "/panel/api/inbounds/del/3":
-				dels++
-				w.Write(okResponse(map[string]any{"id": 3}))
-			default:
+			if r.URL.Path != "/panel/api/inbounds/list" {
 				w.WriteHeader(http.StatusNotFound)
+				return
 			}
+			n := atomic.AddInt32(&lists, 1)
+			if n <= 2 {
+				w.Write(okResponse([]Inbound{{ID: 3}}))
+				return
+			}
+			w.Write(okResponse([]Inbound{}))
 		}))
 		defer srv.Close()
 
@@ -195,31 +191,71 @@ func TestInboundResourceWaitForDeletion(t *testing.T) {
 		if err := res.waitForInboundDeletion(context.Background(), 3); err != nil {
 			t.Fatalf("waitForInboundDeletion: %v", err)
 		}
-		if gets < 3 {
-			t.Fatalf("expected >=3 GETs, got %d", gets)
-		}
-		if dels == 0 {
-			t.Fatalf("expected at least one retry DELETE, got %d", dels)
+		if got := atomic.LoadInt32(&lists); got != 3 {
+			t.Fatalf("expected exactly 3 list calls, got %d", got)
 		}
 	})
 
-	t.Run("never-disappears", func(t *testing.T) {
+	t.Run("never-absent-returns-error", func(t *testing.T) {
+		var lists int32
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			switch {
-			case r.Method == http.MethodGet && r.URL.Path == "/panel/api/inbounds/get/1":
-				w.Write(okResponse(&Inbound{ID: 1}))
-			case r.Method == http.MethodPost && r.URL.Path == "/panel/api/inbounds/del/1":
-				w.Write(okResponse(map[string]any{"id": 1}))
-			default:
+			if r.URL.Path != "/panel/api/inbounds/list" {
 				w.WriteHeader(http.StatusNotFound)
+				return
 			}
+			atomic.AddInt32(&lists, 1)
+			w.Write(okResponse([]Inbound{{ID: 1}}))
 		}))
 		defer srv.Close()
 
 		res := &InboundResource{client: newTestClient(t, srv.URL)}
-		err := res.waitForInboundDeletion(context.Background(), 1)
+		if err := res.waitForInboundDeletion(context.Background(), 1); err == nil {
+			t.Fatalf("expected error after exhausting attempts")
+		}
+		if got := atomic.LoadInt32(&lists); got != 6 {
+			t.Fatalf("expected 6 list calls, got %d", got)
+		}
+	})
+
+	t.Run("transient-list-error-not-treated-as-success", func(t *testing.T) {
+		// A transient 5xx must not be misread as confirmed deletion.
+		var lists int32
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/panel/api/inbounds/list" {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			atomic.AddInt32(&lists, 1)
+			http.Error(w, "boom", http.StatusInternalServerError)
+		}))
+		defer srv.Close()
+
+		res := &InboundResource{client: newTestClient(t, srv.URL)}
+		err := res.waitForInboundDeletion(context.Background(), 5)
 		if err == nil {
-			t.Fatalf("expected error for persistent stale read")
+			t.Fatalf("expected error when list keeps failing")
+		}
+	})
+
+	t.Run("ctx-canceled-during-backoff", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/panel/api/inbounds/list" {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			w.Write(okResponse([]Inbound{{ID: 11}}))
+		}))
+		defer srv.Close()
+
+		res := &InboundResource{client: newTestClient(t, srv.URL)}
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+		err := res.waitForInboundDeletion(ctx, 11)
+		if err == nil {
+			t.Fatalf("expected ctx error")
+		}
+		if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context error, got %v", err)
 		}
 	})
 }

--- a/provider/inbound_client_test.go
+++ b/provider/inbound_client_test.go
@@ -143,6 +143,87 @@ func TestClientDeleteInbound(t *testing.T) {
 	}
 }
 
+// TestInboundResourceWaitForDeletion verifies the post-Delete polling loop
+// added in #136. It exercises three scenarios:
+//   - immediate deletion (single GET that fails)
+//   - stale read followed by a successful re-delete (GET → DELETE → GET)
+//   - persistent stale read that exhausts the retry budget
+func TestInboundResourceWaitForDeletion(t *testing.T) {
+	t.Run("immediate", func(t *testing.T) {
+		var gets int
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodGet && r.URL.Path == "/panel/api/inbounds/get/9" {
+				gets++
+				w.Write(failResponse("record not found"))
+				return
+			}
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer srv.Close()
+
+		res := &InboundResource{client: newTestClient(t, srv.URL)}
+		if err := res.waitForInboundDeletion(context.Background(), 9); err != nil {
+			t.Fatalf("waitForInboundDeletion: %v", err)
+		}
+		if gets != 1 {
+			t.Fatalf("expected 1 GET, got %d", gets)
+		}
+	})
+
+	t.Run("retry-then-success", func(t *testing.T) {
+		var gets, dels int
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodGet && r.URL.Path == "/panel/api/inbounds/get/3":
+				gets++
+				if gets <= 2 {
+					// First two GETs report inbound still present.
+					w.Write(okResponse(&Inbound{ID: 3}))
+					return
+				}
+				w.Write(failResponse("record not found"))
+			case r.Method == http.MethodPost && r.URL.Path == "/panel/api/inbounds/del/3":
+				dels++
+				w.Write(okResponse(map[string]any{"id": 3}))
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer srv.Close()
+
+		res := &InboundResource{client: newTestClient(t, srv.URL)}
+		if err := res.waitForInboundDeletion(context.Background(), 3); err != nil {
+			t.Fatalf("waitForInboundDeletion: %v", err)
+		}
+		if gets < 3 {
+			t.Fatalf("expected >=3 GETs, got %d", gets)
+		}
+		if dels == 0 {
+			t.Fatalf("expected at least one retry DELETE, got %d", dels)
+		}
+	})
+
+	t.Run("never-disappears", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodGet && r.URL.Path == "/panel/api/inbounds/get/1":
+				w.Write(okResponse(&Inbound{ID: 1}))
+			case r.Method == http.MethodPost && r.URL.Path == "/panel/api/inbounds/del/1":
+				w.Write(okResponse(map[string]any{"id": 1}))
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer srv.Close()
+
+		res := &InboundResource{client: newTestClient(t, srv.URL)}
+		err := res.waitForInboundDeletion(context.Background(), 1)
+		if err == nil {
+			t.Fatalf("expected error for persistent stale read")
+		}
+	})
+}
+
 func TestInboundToForm(t *testing.T) {
 	in := &Inbound{
 		ID:             1,

--- a/provider/inbound_client_test.go
+++ b/provider/inbound_client_test.go
@@ -250,12 +250,19 @@ func TestInboundResourceWaitForDeletion(t *testing.T) {
 		res := &InboundResource{client: newTestClient(t, srv.URL)}
 		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 		defer cancel()
+		start := time.Now()
 		err := res.waitForInboundDeletion(ctx, 11)
+		elapsed := time.Since(start)
 		if err == nil {
 			t.Fatalf("expected ctx error")
 		}
 		if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
 			t.Fatalf("expected context error, got %v", err)
+		}
+		// Full attempt budget is 6 × 500ms ≈ 3s. Cancellation must
+		// short-circuit the backoff well before that.
+		if elapsed > 600*time.Millisecond {
+			t.Fatalf("backoff did not respect ctx cancel; elapsed=%v", elapsed)
 		}
 	})
 }

--- a/provider/resource_inbound.go
+++ b/provider/resource_inbound.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -369,6 +370,50 @@ func (r *InboundResource) Delete(ctx context.Context, req resource.DeleteRequest
 		resp.Diagnostics.AddError("Failed to delete inbound", err.Error())
 		return
 	}
+
+	// Verify the inbound is actually gone. 3x-ui's DelInbound is a multi-step
+	// operation against SQLite; under load (CI matrix runs) the DELETE may
+	// occasionally appear to succeed at the API level while the row still
+	// being visible to a follow-up GET. Re-issuing the delete is idempotent,
+	// so we poll and retry to guard against this race (#136).
+	if err := r.waitForInboundDeletion(ctx, id); err != nil {
+		resp.Diagnostics.AddError("Inbound deletion not confirmed", err.Error())
+	}
+}
+
+// waitForInboundDeletion polls GetInbound until it reports the inbound is
+// gone. If the inbound is still visible after a short interval it re-issues
+// the delete (the API is idempotent for a non-existent ID — it simply
+// returns success). The total budget is intentionally small: any longer
+// delay indicates a real server-side problem rather than a flake.
+func (r *InboundResource) waitForInboundDeletion(ctx context.Context, id int) error {
+	const (
+		attempts = 6
+		delay    = 500 * time.Millisecond
+	)
+	for i := 0; i < attempts; i++ {
+		if _, err := r.client.GetInbound(ctx, id); err != nil {
+			// API reported failure (typically "record not found"). The
+			// inbound is gone.
+			return nil
+		}
+		if i+1 == attempts {
+			break
+		}
+		// Re-issue the delete on every other iteration to recover from a
+		// transient SQLite write that did not actually remove the row.
+		if i%2 == 1 {
+			if err := r.client.DeleteInbound(ctx, id); err != nil {
+				return fmt.Errorf("retry delete after stale read: %w", err)
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(delay):
+		}
+	}
+	return fmt.Errorf("inbound %d still visible after delete", id)
 }
 
 func (r *InboundResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {

--- a/provider/resource_inbound.go
+++ b/provider/resource_inbound.go
@@ -371,47 +371,61 @@ func (r *InboundResource) Delete(ctx context.Context, req resource.DeleteRequest
 		return
 	}
 
-	// Verify the inbound is actually gone. 3x-ui's DelInbound is a multi-step
-	// operation against SQLite; under load (CI matrix runs) the DELETE may
-	// occasionally appear to succeed at the API level while the row still
-	// being visible to a follow-up GET. Re-issuing the delete is idempotent,
-	// so we poll and retry to guard against this race (#136).
+	// The DELETE was accepted by the API. 3x-ui's DelInbound is a multi-step
+	// SQLite operation; under load the row may still be visible to a follow-up
+	// list call for a short time. Poll the list to confirm absence so the
+	// post-test sweep does not see a "dangling resource" (#136). Exhaustion is
+	// reported as a Warning, not Error: the API has already accepted the
+	// delete, so leaving the resource in TF state would be the worse failure
+	// mode — the next refresh will reconcile.
 	if err := r.waitForInboundDeletion(ctx, id); err != nil {
-		resp.Diagnostics.AddError("Inbound deletion not confirmed", err.Error())
+		resp.Diagnostics.AddWarning("Inbound deletion not confirmed within budget", err.Error())
 	}
 }
 
-// waitForInboundDeletion polls GetInbound until it reports the inbound is
-// gone. If the inbound is still visible after a short interval it re-issues
-// the delete (the API is idempotent for a non-existent ID — it simply
-// returns success). The total budget is intentionally small: any longer
-// delay indicates a real server-side problem rather than a flake.
+// waitForInboundDeletion polls the inbound list until id is absent. Errors
+// from the list call are treated as retryable, not as success: a transient
+// network blip must not be misread as confirmed deletion. DelInbound is NOT
+// idempotent in 3x-ui (it calls GetInbound first and errors on a missing
+// row), so we never re-issue DELETE — the original DELETE has already been
+// accepted.
 func (r *InboundResource) waitForInboundDeletion(ctx context.Context, id int) error {
 	const (
 		attempts = 6
 		delay    = 500 * time.Millisecond
 	)
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	var lastErr error
 	for i := 0; i < attempts; i++ {
-		if _, err := r.client.GetInbound(ctx, id); err != nil {
-			// API reported failure (typically "record not found"). The
-			// inbound is gone.
-			return nil
+		inbounds, err := r.client.GetInbounds(ctx)
+		if err != nil {
+			lastErr = err
+		} else {
+			lastErr = nil
+			present := false
+			for _, in := range inbounds {
+				if in.ID == id {
+					present = true
+					break
+				}
+			}
+			if !present {
+				return nil
+			}
 		}
 		if i+1 == attempts {
 			break
 		}
-		// Re-issue the delete on every other iteration to recover from a
-		// transient SQLite write that did not actually remove the row.
-		if i%2 == 1 {
-			if err := r.client.DeleteInbound(ctx, id); err != nil {
-				return fmt.Errorf("retry delete after stale read: %w", err)
-			}
-		}
+		timer.Reset(delay)
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-time.After(delay):
+		case <-timer.C:
 		}
+	}
+	if lastErr != nil {
+		return fmt.Errorf("inbound %d delete confirmation failed: %w", id, lastErr)
 	}
 	return fmt.Errorf("inbound %d still visible after delete", id)
 }

--- a/provider/resource_inbound.go
+++ b/provider/resource_inbound.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"slices"
 	"strings"
 	"time"
 
@@ -394,8 +395,6 @@ func (r *InboundResource) waitForInboundDeletion(ctx context.Context, id int) er
 		attempts = 6
 		delay    = 500 * time.Millisecond
 	)
-	timer := time.NewTimer(delay)
-	defer timer.Stop()
 	var lastErr error
 	for i := 0; i < attempts; i++ {
 		inbounds, err := r.client.GetInbounds(ctx)
@@ -403,25 +402,17 @@ func (r *InboundResource) waitForInboundDeletion(ctx context.Context, id int) er
 			lastErr = err
 		} else {
 			lastErr = nil
-			present := false
-			for _, in := range inbounds {
-				if in.ID == id {
-					present = true
-					break
-				}
-			}
-			if !present {
+			if !slices.ContainsFunc(inbounds, func(in Inbound) bool { return in.ID == id }) {
 				return nil
 			}
 		}
 		if i+1 == attempts {
 			break
 		}
-		timer.Reset(delay)
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-timer.C:
+		case <-time.After(delay):
 		}
 	}
 	if lastErr != nil {


### PR DESCRIPTION
## Summary

Fixes #136 — `TestAccInboundProtocolMatrix/mixed` (and other matrix subtests) occasionally fails with:

> `Error running post-test destroy, there may be dangling resources: inbound N still exists`

After `DeleteInbound` succeeds at the API level, 3x-ui's SQLite-backed `DelInbound` is multi-step and under matrix-test load the row sometimes remains visible to the immediate follow-up read. Terraform's post-test sweep then reports a dangling resource and the test fails.

This PR adds `waitForInboundDeletion` after the Delete call:

- polls the inbound **list** (`GetInbounds`) up to 6 × 500ms (~3s budget) for the absence of the deleted id
- does **not** re-issue DELETE — `DelInbound` is non-idempotent in 3x-ui (it calls `GetInbound` first and errors on a missing row), so a second DELETE after a successful-but-stale read would turn success into failure
- a transient list error is **not** treated as confirmed deletion — only an explicit `id absent from list` outcome counts as success
- on exhaustion of the budget the Delete reports a **Warning**, not Error: the API has already accepted the delete, so leaving the resource in TF state is the worse failure mode — the next refresh will reconcile

3-second budget is intentionally tight: longer-than-3s persistence indicates a real bug worth surfacing, not flakiness to paper over.

## Test plan

- [x] `task fmt vet lint build` clean
- [x] `TestInboundResourceWaitForDeletion` covers five branches:
  - `immediate-absent` — id never present, exactly 1 list call
  - `becomes-absent-after-poll` — present for 2 polls, then gone
  - `never-absent-returns-error` — present for full budget, returns error after 6 calls
  - `transient-list-error-not-treated-as-success` — list keeps 5xx-ing, returns error (not success)
  - `ctx-canceled-during-backoff` — ctx cancel short-circuits backoff (verified via elapsed-time bound)
- [x] Pre-existing `TestDriftInboundProtocols_*` failures verified to exist on `main` too — unrelated to this change
- [ ] CI green (matrix should now be stable)