### PR TITLE
fix: mark threexui_settings data source 'json' attribute as sensitive

### DIFF
--- a/docs/data-sources/settings.md
+++ b/docs/data-sources/settings.md
@@ -15,7 +15,8 @@ Retrieves all current panel settings from the 3x-ui panel as a JSON string. Incl
 data "threexui_settings" "all" {}
 
 output "panel_settings" {
-  value = data.threexui_settings.all.json
+  value     = data.threexui_settings.all.json
+  sensitive = true
 }
 ```
 
@@ -25,4 +26,4 @@ This data source has no arguments.
 
 ## Attribute Reference
 
-- `json` (String) - All panel settings as a JSON string.
+- `json` (String, Sensitive) - All panel settings as a JSON string. Marked as sensitive because the payload contains Telegram bot tokens, LDAP passwords, 2FA secrets, and other panel credentials.

--- a/provider/data_source_settings.go
+++ b/provider/data_source_settings.go
@@ -36,7 +36,8 @@ func (d *SettingsDataSource) Schema(_ context.Context, _ datasource.SchemaReques
 				Computed: true,
 			},
 			"json": schema.StringAttribute{
-				Computed: true,
+				Computed:  true,
+				Sensitive: true,
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

- Marks the `json` attribute on the `threexui_settings` data source as `Sensitive: true`.
- The settings payload contains Telegram bot tokens, LDAP passwords, 2FA secrets, and other panel credentials. Without `Sensitive`, those values are printed in plaintext in `terraform plan`/`apply` output and stored unmarked in state.
- This mirrors the `Sensitive: true` marking already present on the equivalent fields in `resource_settings_tabs.go` and matches the security note in `CLAUDE.md`.
- Updated `docs/data-sources/settings.md` to reflect the new sensitivity marking and updated the example to use `sensitive = true` on the output.

Closes #137

## Test plan

- [x] `task build`
- [x] `task vet`
- [x] `task lint`
- [x] `task test:unit` (only pre-existing drift test failures on `main`, unrelated to this change)
- [ ] CI green
- [ ] Verify in a manual `terraform plan` that the JSON value is now masked as `(sensitive value)`