### PR TITLE
docs: warn about sensitive output requirement for threexui_settings.json

### DIFF
--- a/docs/data-sources/settings.md
+++ b/docs/data-sources/settings.md
@@ -20,6 +20,8 @@ output "panel_settings" {
 }
 ```
 
+> **Upgrade note:** Since the provider release that marked `json` as sensitive, any `output` referencing `data.threexui_settings.<name>.json` must declare `sensitive = true`. Without it, `terraform plan` fails with `Output refers to sensitive values`.
+
 ## Argument Reference
 
 This data source has no arguments.


### PR DESCRIPTION
## Summary

Follow-up to #143 (which marked `data.threexui_settings.json` as `Sensitive: true`).

#143 was merged with a plain `fix:` commit and **no** `BREAKING CHANGE:` footer, so release-please will not flag the user-visible impact in the upcoming release notes. This PR fixes that in two ways:

1. **Inline upgrade note in `docs/data-sources/settings.md`** — explains that any `output` referencing `data.threexui_settings.<name>.json` must declare `sensitive = true`, otherwise `terraform plan` fails with `Output refers to sensitive values`.
2. **`BREAKING CHANGE:` footer in this commit** — release-please honours `BREAKING CHANGE:` footers even on `docs:` / `fix:` commits, so the next release notes will surface the impact prominently.

No code change.

Refs #137

## Test plan

- [x] markdownlint (pre-commit)
- [ ] CI green
- [ ] Verify release-please picks up the footer in its next Release PR