### PR TITLE
fix: mark threexui_inbounds data source 'inbounds' attribute as sensitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ Full documentation is available on the [Terraform Registry](https://registry.ter
 
 | Data Source | Description |
 | --- | --- |
-| `threexui_inbounds` | List of all inbounds (JSON) |
+| `threexui_inbounds` | List of all inbounds (JSON, sensitive) |
 | `threexui_server_status` | Server status: CPU, memory, disk, uptime (JSON) |
-| `threexui_settings` | All panel settings (JSON) |
+| `threexui_settings` | All panel settings (JSON, sensitive) |
 | `threexui_xray_config` | Current Xray template (JSON) |
 | `threexui_xray_versions` | Available Xray versions (list of strings) |
 | `threexui_online_clients` | Currently online client emails |

--- a/docs/data-sources/inbounds.md
+++ b/docs/data-sources/inbounds.md
@@ -18,10 +18,15 @@ locals {
   inbounds = jsondecode(data.threexui_inbounds.all.inbounds)
 }
 
+# Ports themselves are not secrets, so wrap with `nonsensitive()` to expose
+# them in plan output. Sensitivity propagates from the source attribute, so
+# any expression derived from `inbounds` is sensitive by default.
 output "inbound_ports" {
-  value = [for i in local.inbounds : i.port]
+  value = nonsensitive([for i in local.inbounds : i.port])
 }
 ```
+
+> **Upgrade note:** The `inbounds` attribute is marked sensitive because each inbound object contains client UUIDs/passwords, Reality `privateKey`, WireGuard `secretKey`, and similar credentials. Outputs that reference it (or values derived from it) must declare `sensitive = true` or be wrapped in `nonsensitive(...)` for fields that are safe to expose.
 
 ## Argument Reference
 
@@ -30,4 +35,4 @@ This data source has no arguments.
 ## Attribute Reference
 
 - `id` (String) - ID derived from the first inbound.
-- `inbounds` (String) - JSON-encoded array of all inbound objects. Use `jsondecode()` to work with the data. Each object contains fields like `id`, `port`, `protocol`, `remark`, `enable`, `settings`, `streamSettings`, `sniffing`, etc.
+- `inbounds` (String, Sensitive) - JSON-encoded array of all inbound objects. Use `jsondecode()` to work with the data. Each object contains fields like `id`, `port`, `protocol`, `remark`, `enable`, `settings`, `streamSettings`, `sniffing`, etc. Marked sensitive because the payload includes client UUIDs/passwords, Reality `privateKey`, WireGuard `secretKey`, and other credentials.

--- a/provider/data_source_inbounds.go
+++ b/provider/data_source_inbounds.go
@@ -38,7 +38,7 @@ func (d *InboundsDataSource) Schema(_ context.Context, _ datasource.SchemaReques
 			"inbounds": schema.StringAttribute{
 				Computed:    true,
 				Sensitive:   true,
-				Description: "JSON array of inbound objects.",
+				Description: "JSON array of inbound objects. Marked Sensitive because the payload includes client UUIDs/passwords, Reality privateKey, WireGuard secretKey, and similar credentials.",
 			},
 		},
 	}

--- a/provider/data_source_inbounds.go
+++ b/provider/data_source_inbounds.go
@@ -37,6 +37,7 @@ func (d *InboundsDataSource) Schema(_ context.Context, _ datasource.SchemaReques
 			},
 			"inbounds": schema.StringAttribute{
 				Computed:    true,
+				Sensitive:   true,
 				Description: "JSON array of inbound objects.",
 			},
 		},

--- a/provider/data_source_schema_test.go
+++ b/provider/data_source_schema_test.go
@@ -1,0 +1,39 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+)
+
+// TestDataSourceSensitiveAttributes guards the CLAUDE.md security rule that any
+// data source returning a raw JSON payload from the panel/Xray API must mark its
+// JSON attribute Sensitive. Without this assertion a future refactor could
+// silently drop the flag and re-expose client UUIDs/passwords, Reality keys,
+// WireGuard secrets, Telegram tokens, etc. in plan output.
+func TestDataSourceSensitiveAttributes(t *testing.T) {
+	cases := []struct {
+		name      string
+		factory   func() datasource.DataSource
+		attribute string
+	}{
+		{"inbounds", NewInboundsDataSource, "inbounds"},
+		{"settings", NewSettingsDataSource, "json"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var resp datasource.SchemaResponse
+			tc.factory().Schema(context.Background(), datasource.SchemaRequest{}, &resp)
+
+			attr, ok := resp.Schema.Attributes[tc.attribute]
+			if !ok {
+				t.Fatalf("attribute %q missing on data source", tc.attribute)
+			}
+			if !attr.IsSensitive() {
+				t.Fatalf("attribute %q must be Sensitive", tc.attribute)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Marks the `inbounds` attribute on the `threexui_inbounds` data source as `Sensitive: true`.
- Each inbound object contains client UUIDs/passwords, Reality `privateKey`, WireGuard `secretKey`, and similar credentials. Without `Sensitive`, those values are printed in plaintext in `terraform plan`/`apply` output and stored unmarked in state.
- Mirrors the `Sensitive: true` marking already present on the equivalent fields in `inbound_settings_schema.go`, `inbound_stream_settings_schema.go`, and `resource_inbound_client.go`. Matches the security note in `CLAUDE.md`.
- Updated `docs/data-sources/inbounds.md`:
  - Example output wraps the derived port list with `nonsensitive(...)` (sensitivity propagates through expressions; ports themselves are not secrets).
  - Inline upgrade note explains the new requirement for downstream outputs.
- Commit carries a `BREAKING CHANGE:` footer so release-please surfaces the user-visible impact in the next release notes (the previous PR #143 landed without one — see follow-up #144).

Closes #138

## Test plan

- [x] `task build`
- [x] `task vet`
- [x] `task lint`
- [x] markdownlint (pre-commit)
- [ ] CI green
- [ ] Verify in a manual `terraform plan` that the `inbounds` value is now masked as `(sensitive value)`