### PR TITLE
fix: mark threexui_xray_config data source 'json' attribute as sensitive

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,11 +69,11 @@ Taskfile.yml           — task build / test / fmt
 
 | Terraform Data Source | Description |
 | --- | --- |
-| `threexui_inbounds` | List of all inbounds (JSON string) |
+| `threexui_inbounds` | List of all inbounds (JSON string, Sensitive) |
 | `threexui_server_status` | Server status (JSON) |
 | `threexui_xray_versions` | Available Xray versions (list of strings) |
-| `threexui_xray_config` | Current Xray config (JSON) |
-| `threexui_settings` | All panel settings (JSON) |
+| `threexui_xray_config` | Current Xray config (JSON, Sensitive) |
+| `threexui_settings` | All panel settings (JSON, Sensitive) |
 | `threexui_online_clients` | List of currently online client emails |
 | `threexui_client_traffics` | Client traffic statistics by email |
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Full documentation is available on the [Terraform Registry](https://registry.ter
 | `threexui_inbounds` | List of all inbounds (JSON, sensitive) |
 | `threexui_server_status` | Server status: CPU, memory, disk, uptime (JSON) |
 | `threexui_settings` | All panel settings (JSON, sensitive) |
-| `threexui_xray_config` | Current Xray template (JSON) |
+| `threexui_xray_config` | Current Xray template (JSON, sensitive) |
 | `threexui_xray_versions` | Available Xray versions (list of strings) |
 | `threexui_online_clients` | Currently online client emails |
 | `threexui_client_traffics` | Client traffic statistics by email |

--- a/docs/data-sources/xray_config.md
+++ b/docs/data-sources/xray_config.md
@@ -15,9 +15,12 @@ Retrieves the current Xray template configuration from the 3x-ui panel as a JSON
 data "threexui_xray_config" "current" {}
 
 output "xray_config" {
-  value = data.threexui_xray_config.current.json
+  value     = data.threexui_xray_config.current.json
+  sensitive = true
 }
 ```
+
+> **Upgrade note:** The `json` attribute is marked sensitive because the Xray template includes outbound credentials (Shadowsocks/Trojan/SOCKS/HTTP passwords, VLESS/VMess UUIDs, WireGuard `secretKey`, Reality `privateKey`) and inbound client identifiers. Any `output` referencing it (or values derived from it via `jsondecode(...)`) must declare `sensitive = true`, or be wrapped in `nonsensitive(...)` for fields that are safe to expose. Without it, `terraform plan` fails with `Output refers to sensitive values`.
 
 ## Argument Reference
 
@@ -25,4 +28,4 @@ This data source has no arguments.
 
 ## Attribute Reference
 
-- `json` (String) - The current Xray template configuration as a JSON string.
+- `json` (String, Sensitive) - The current Xray template configuration as a JSON string. Marked sensitive because the payload includes outbound credentials, client UUIDs, WireGuard `secretKey`, and Reality `privateKey`.

--- a/provider/data_source_schema_test.go
+++ b/provider/data_source_schema_test.go
@@ -20,6 +20,7 @@ func TestDataSourceSensitiveAttributes(t *testing.T) {
 	}{
 		{"inbounds", NewInboundsDataSource, "inbounds"},
 		{"settings", NewSettingsDataSource, "json"},
+		{"xray_config", NewXrayConfigDataSource, "json"},
 	}
 
 	for _, tc := range cases {

--- a/provider/data_source_xray_config.go
+++ b/provider/data_source_xray_config.go
@@ -36,9 +36,7 @@ func (d *XrayConfigDataSource) Schema(_ context.Context, _ datasource.SchemaRequ
 				Computed: true,
 			},
 			"json": schema.StringAttribute{
-				Computed: true,
-				// TODO(#139): once #145 lands, extend TestDataSourceSensitiveAttributes
-				// to also cover the xray_config attribute below.
+				Computed:    true,
 				Sensitive:   true,
 				Description: "Current Xray template configuration as a JSON string. Marked Sensitive because the payload includes outbound credentials (Shadowsocks/Trojan/SOCKS/HTTP passwords, VLESS/VMess UUIDs, WireGuard secretKey, Reality privateKey) and inbound client identifiers.",
 			},

--- a/provider/data_source_xray_config.go
+++ b/provider/data_source_xray_config.go
@@ -36,7 +36,9 @@ func (d *XrayConfigDataSource) Schema(_ context.Context, _ datasource.SchemaRequ
 				Computed: true,
 			},
 			"json": schema.StringAttribute{
-				Computed: true,
+				Computed:    true,
+				Sensitive:   true,
+				Description: "Current Xray template configuration as a JSON string. Marked Sensitive because the payload includes outbound credentials (Shadowsocks/Trojan/SOCKS/HTTP passwords, VLESS/VMess UUIDs, WireGuard secretKey, Reality privateKey) and inbound client identifiers.",
 			},
 		},
 	}

--- a/provider/data_source_xray_config.go
+++ b/provider/data_source_xray_config.go
@@ -36,7 +36,9 @@ func (d *XrayConfigDataSource) Schema(_ context.Context, _ datasource.SchemaRequ
 				Computed: true,
 			},
 			"json": schema.StringAttribute{
-				Computed:    true,
+				Computed: true,
+				// TODO(#139): once #145 lands, extend TestDataSourceSensitiveAttributes
+				// to also cover the xray_config attribute below.
 				Sensitive:   true,
 				Description: "Current Xray template configuration as a JSON string. Marked Sensitive because the payload includes outbound credentials (Shadowsocks/Trojan/SOCKS/HTTP passwords, VLESS/VMess UUIDs, WireGuard secretKey, Reality privateKey) and inbound client identifiers.",
 			},


### PR DESCRIPTION
## Summary

- Marks the `json` attribute on the `threexui_xray_config` data source as `Sensitive: true`.
- The Xray template payload contains outbound credentials (Shadowsocks/Trojan/SOCKS/HTTP passwords, VLESS/VMess UUIDs, WireGuard `secretKey`, Reality `privateKey`) and inbound client identifiers. Without `Sensitive`, those values are printed in plaintext in `terraform plan`/`apply` output and stored unmarked in state.
- Mirrors the `Sensitive: true` marking already present on the equivalent fields in `xray_outbounds_schema.go` and `resource_inbound_client.go`. Matches the security note in `CLAUDE.md`.
- Updated `docs/data-sources/xray_config.md`:
  - Example output uses `sensitive = true`.
  - Inline upgrade note explains the new requirement (and the `nonsensitive(...)` escape hatch) for downstream outputs.
- Commit carries a `BREAKING CHANGE:` footer so release-please surfaces the user-visible impact in the next release notes.

A unit test covering this attribute will follow once #145 (which introduces `TestDataSourceSensitiveAttributes`) is merged — it will be extended to include `xray_config` in the same table.

Closes #139

## Test plan

- [x] `task build`
- [x] `task vet`
- [x] `task lint`
- [x] markdownlint (pre-commit)
- [ ] CI green
- [ ] Verify in a manual `terraform plan` that the `json` value is now masked as `(sensitive value)`
- [ ] After #145 merges, extend `TestDataSourceSensitiveAttributes` to cover `xray_config`