### PR TITLE
fix: retry post-write reads to absorb 3x-ui SQLite visibility lag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,13 +26,25 @@ on:
       - .github/workflows/docs.yml
       - CHANGELOG.md
 
+# Cancel superseded runs on the same PR/branch — avoids wasting minutes
+# and burning the GHCR pull quota on stale commits when force-pushing.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
+  # Required for docker/login-action to authenticate against ghcr.io with
+  # GITHUB_TOKEN — anonymous ghcr pulls share a low rate limit per runner
+  # IP and were the root cause of intermittent "API rate limit exceeded"
+  # failures on the compat matrix.
+  packages: read
 
 jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
 
@@ -56,6 +68,7 @@ jobs:
   unit-tests:
     name: Unit Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
 
@@ -75,6 +88,7 @@ jobs:
     name: Acceptance Tests
     runs-on: ubuntu-latest
     needs: [lint]
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
 
@@ -92,6 +106,13 @@ jobs:
         with:
           version: 3.x
 
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run acceptance tests
         run: task test:acc
 
@@ -99,6 +120,7 @@ jobs:
     name: Compat (${{ matrix.version }})
     runs-on: ubuntu-latest
     needs: [lint]
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -119,6 +141,13 @@ jobs:
         uses: arduino/setup-task@v2
         with:
           version: 3.x
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run compatibility tests
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,15 @@ Unauthenticated requests return 404 (not 401). The client performs auto re-login
 - Composes with the 401/404 auto-relogin in `doRequest`: relogin happens inside a single `withRetry` attempt; only an HTTP 5xx surfaced from `decodeAPIResponse` triggers the outer retry
 - `HTTPStatusError` — error type returned by `decodeAPIResponse` when `resp.StatusCode >= 400` (both empty-body and non-JSON paths). `errors.As` is the supported way to inspect status
 
+### Read-after-write retry (post-write reads)
+
+Distinct from the 5xx retry above. 3x-ui occasionally returns `success: true` from a create/update endpoint while the underlying SQLite commit is not yet visible to a follow-up GET (#157). The 5xx retry doesn't help — the response is HTTP 200, just empty/missing the row. So a separate application-layer policy:
+
+- `Client.WithReadAfterWriteRetry` — polls a caller-provided `func() (found bool, err error)` up to `readAfterWriteAttempts` (5) times with `readAfterWriteBackoff` (500ms) between attempts. A non-nil err aborts immediately (read failures are not retried — only the "not visible yet" condition is). Emits `tflog.Warn` per retry with `operation`, `attempt`, `max_attempts`, `backoff`
+- Applied to: `InboundResource.Create` (resolves the new row by `port` if `AddInbound` returned an empty obj), `InboundClientResource.Create`/`Update` (waits for the new client to appear in the inbound's settings JSON), `XrayVersionResource.waitForXrayVersion` (ignores `ErrXrayVersionUnknown` while xray is restarting)
+- **Not** applied to plain `Read` — for an idle read, "row not present" is meaningful (resource was deleted out-of-band) and must be reported to Terraform immediately rather than retried
+- Test helpers `testAccCheckInboundDestroyed` / `testAccCheckInboundClientDestroyed` use a similar bounded poll (`destroyVisibilityAttempts × destroyVisibilityBackoff`) for the inverse case: waiting for a successful DELETE to become invisible to a follow-up GET
+
 ## Key Code Details
 
 ### Framework (terraform-plugin-framework)

--- a/provider/acc_test.go
+++ b/provider/acc_test.go
@@ -150,10 +150,12 @@ func testAccClientFromEnvNoLogin() (*Client, error) {
 // destroyVisibilityAttempts × destroyVisibilityBackoff is how long the
 // CheckDestroy helpers wait for a successful DELETE to become visible to a
 // follow-up GET. 3x-ui's DELETE endpoint can return success while a
-// concurrent GET still observes the row for up to a few hundred ms under
-// SQLite contention — see issue #157.
+// concurrent GET still observes the row under SQLite contention — see
+// issue #157. CI runners are slower than local hardware and the matrix
+// test hammers SQLite for tens of seconds before late subtests run, so
+// the budget here has to cover that worst case (~7s).
 const (
-	destroyVisibilityAttempts = 5
+	destroyVisibilityAttempts = 15
 	destroyVisibilityBackoff  = 500 * time.Millisecond
 )
 

--- a/provider/acc_test.go
+++ b/provider/acc_test.go
@@ -147,6 +147,16 @@ func testAccClientFromEnvNoLogin() (*Client, error) {
 	})
 }
 
+// destroyVisibilityAttempts × destroyVisibilityBackoff is how long the
+// CheckDestroy helpers wait for a successful DELETE to become visible to a
+// follow-up GET. 3x-ui's DELETE endpoint can return success while a
+// concurrent GET still observes the row for up to a few hundred ms under
+// SQLite contention — see issue #157.
+const (
+	destroyVisibilityAttempts = 5
+	destroyVisibilityBackoff  = 500 * time.Millisecond
+)
+
 func testAccCheckInboundDestroyed(state *terraform.State) error {
 	client, err := testAccClientFromEnv()
 	if err != nil {
@@ -160,8 +170,21 @@ func testAccCheckInboundDestroyed(state *terraform.State) error {
 		if err != nil {
 			continue
 		}
-		if _, err := client.GetInbound(context.Background(), id); err == nil {
-			return fmt.Errorf("inbound %d still exists", id)
+		var lastErr error
+		gone := false
+		for attempt := 0; attempt < destroyVisibilityAttempts; attempt++ {
+			if _, getErr := client.GetInbound(context.Background(), id); getErr != nil {
+				gone = true
+				break
+			}
+			lastErr = nil
+			time.Sleep(destroyVisibilityBackoff)
+		}
+		if !gone {
+			if lastErr != nil {
+				return fmt.Errorf("inbound %d still exists after %d attempts: %w", id, destroyVisibilityAttempts, lastErr)
+			}
+			return fmt.Errorf("inbound %d still exists after %d attempts", id, destroyVisibilityAttempts)
 		}
 	}
 	return nil
@@ -180,16 +203,25 @@ func testAccCheckInboundClientDestroyed(state *terraform.State) error {
 		if err != nil {
 			continue
 		}
-		inbound, err := client.GetInbound(context.Background(), inboundID)
-		if err != nil {
-			continue
+		gone := false
+		for attempt := 0; attempt < destroyVisibilityAttempts; attempt++ {
+			inbound, getErr := client.GetInbound(context.Background(), inboundID)
+			if getErr != nil {
+				gone = true
+				break
+			}
+			settings, parseErr := parseInboundSettings(inbound.Settings)
+			if parseErr != nil {
+				return parseErr
+			}
+			if findClientByID(settings.Clients, clientID) == nil {
+				gone = true
+				break
+			}
+			time.Sleep(destroyVisibilityBackoff)
 		}
-		settings, err := parseInboundSettings(inbound.Settings)
-		if err != nil {
-			return err
-		}
-		if found := findClientByID(settings.Clients, clientID); found != nil {
-			return fmt.Errorf("inbound client %s still exists", rs.Primary.ID)
+		if !gone {
+			return fmt.Errorf("inbound client %s still exists after %d attempts", rs.Primary.ID, destroyVisibilityAttempts)
 		}
 	}
 	return nil

--- a/provider/acc_xray_version_test.go
+++ b/provider/acc_xray_version_test.go
@@ -161,10 +161,11 @@ resource "threexui_xray_version" "test" {
 						t.Fatalf("failed to simulate drift by installing %s: %s", altVersion, err)
 					}
 					// InstallXray is async — wait for the version to actually
-					// change. The window has to cover binary download + 3x-ui's
-					// internal pickup; on slow CI runners (older 3x-ui lines)
-					// 30s was occasionally too tight (issue #157).
-					const maxAttempts = 60
+					// change. The window has to cover binary download +
+					// 3x-ui's internal pickup. On slow CI runners with older
+					// 3x-ui lines (v2.9.1 specifically), 60s was still
+					// occasionally too tight (issue #157).
+					const maxAttempts = 120
 					const pollInterval = time.Second
 					for i := 0; i < maxAttempts; i++ {
 						time.Sleep(pollInterval)

--- a/provider/acc_xray_version_test.go
+++ b/provider/acc_xray_version_test.go
@@ -160,16 +160,21 @@ resource "threexui_xray_version" "test" {
 					if err := client.InstallXray(ctx, altVersion); err != nil {
 						t.Fatalf("failed to simulate drift by installing %s: %s", altVersion, err)
 					}
-					// InstallXray is async — wait for the version to actually change.
-					for i := 0; i < 30; i++ {
-						time.Sleep(time.Second)
+					// InstallXray is async — wait for the version to actually
+					// change. The window has to cover binary download + 3x-ui's
+					// internal pickup; on slow CI runners (older 3x-ui lines)
+					// 30s was occasionally too tight (issue #157).
+					const maxAttempts = 60
+					const pollInterval = time.Second
+					for i := 0; i < maxAttempts; i++ {
+						time.Sleep(pollInterval)
 						cur, err := client.GetCurrentXrayVersion(ctx)
 						if err == nil && cur == altVersion {
 							t.Logf("drift simulated: version changed to %s after %ds", altVersion, i+1)
 							return
 						}
 					}
-					t.Fatalf("InstallXray(%s) returned success but version did not change within 30s", altVersion)
+					t.Fatalf("InstallXray(%s) returned success but version did not change within %ds", altVersion, maxAttempts)
 				},
 				Config:             config,
 				PlanOnly:           true,

--- a/provider/client.go
+++ b/provider/client.go
@@ -24,6 +24,17 @@ import (
 // in 3x-ui's SQLite write path on older versions.
 const defaultRetryBackoff = 500 * time.Millisecond
 
+// readAfterWriteAttempts is the maximum number of times a post-write read
+// will be retried while the just-written row is not yet visible. 3x-ui
+// occasionally returns success from add/update endpoints before the SQLite
+// commit becomes visible to a follow-up GET — see issue #157.
+const readAfterWriteAttempts = 5
+
+// readAfterWriteBackoff is the delay between read-after-write retry attempts.
+// Same rationale as defaultRetryBackoff: long enough to absorb a typical
+// SQLite contention spike, short enough not to mask real bugs.
+const readAfterWriteBackoff = 500 * time.Millisecond
+
 type ClientConfig struct {
 	Endpoint           string
 	BasePath           string
@@ -647,6 +658,44 @@ func (c *Client) doJSONRetryable(ctx context.Context, method, relPath string, bo
 	return c.withRetry(ctx, method+" "+relPath, func() error {
 		return c.doJSON(ctx, method, relPath, body, out)
 	})
+}
+
+// WithReadAfterWriteRetry polls fn until the row is visible (found=true) or
+// the budget is exhausted. It is distinct from withRetry: that one absorbs
+// transient HTTP 5xx, this one absorbs application-layer "success but the
+// row is not visible yet" gaps. Callers pass an opName for telemetry.
+//
+// fn returns (found, err). A non-nil err aborts immediately (no retry — if
+// the read itself failed, the panel is in worse shape than just slow).
+// found=false triggers a backoff and another attempt.
+func (c *Client) WithReadAfterWriteRetry(ctx context.Context, opName string, fn func() (bool, error)) error {
+	for attempt := 0; attempt < readAfterWriteAttempts; attempt++ {
+		found, err := fn()
+		if err != nil {
+			return err
+		}
+		if found {
+			return nil
+		}
+		if attempt == readAfterWriteAttempts-1 {
+			break
+		}
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		tflog.Warn(ctx, "retrying read-after-write", map[string]any{
+			"operation":    opName,
+			"attempt":      attempt + 1,
+			"max_attempts": readAfterWriteAttempts,
+			"backoff":      readAfterWriteBackoff.String(),
+		})
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(readAfterWriteBackoff):
+		}
+	}
+	return fmt.Errorf("%s: row not visible after %d attempts (%s total)", opName, readAfterWriteAttempts, readAfterWriteBackoff*time.Duration(readAfterWriteAttempts-1))
 }
 
 func (c *Client) doRequestOnce(ctx context.Context, method, endpoint, contentType string, body []byte) (*http.Response, error) {

--- a/provider/client.go
+++ b/provider/client.go
@@ -27,8 +27,11 @@ const defaultRetryBackoff = 500 * time.Millisecond
 // readAfterWriteAttempts is the maximum number of times a post-write read
 // will be retried while the just-written row is not yet visible. 3x-ui
 // occasionally returns success from add/update endpoints before the SQLite
-// commit becomes visible to a follow-up GET — see issue #157.
-const readAfterWriteAttempts = 5
+// commit becomes visible to a follow-up GET — see issue #157. The matrix
+// acceptance test sustains write pressure for tens of seconds, and CI
+// runners are slower than local hardware, so the budget is sized for the
+// worst-case lag observed (~5s).
+const readAfterWriteAttempts = 10
 
 // readAfterWriteBackoff is the delay between read-after-write retry attempts.
 // Same rationale as defaultRetryBackoff: long enough to absorb a typical

--- a/provider/client.go
+++ b/provider/client.go
@@ -30,8 +30,8 @@ const defaultRetryBackoff = 500 * time.Millisecond
 // commit becomes visible to a follow-up GET — see issue #157. The matrix
 // acceptance test sustains write pressure for tens of seconds, and CI
 // runners are slower than local hardware, so the budget is sized for the
-// worst-case lag observed (~5s).
-const readAfterWriteAttempts = 10
+// worst-case lag observed in CI (~10s — local lag is sub-second).
+const readAfterWriteAttempts = 20
 
 // readAfterWriteBackoff is the delay between read-after-write retry attempts.
 // Same rationale as defaultRetryBackoff: long enough to absorb a typical

--- a/provider/resource_inbound.go
+++ b/provider/resource_inbound.go
@@ -224,9 +224,32 @@ func (r *InboundResource) Create(ctx context.Context, req resource.CreateRequest
 		resp.Diagnostics.AddError("Failed to create inbound", err.Error())
 		return
 	}
+
+	// 3x-ui occasionally returns success with an empty obj when SQLite is
+	// contended: the row is committed seconds later. Recover by polling the
+	// list endpoint for the matching port (3x-ui enforces port uniqueness).
+	// See issue #157.
 	if created == nil || created.ID == 0 {
-		resp.Diagnostics.AddError("Empty response", "API returned nil inbound or zero ID")
-		return
+		var resolvedID int
+		retryErr := r.client.WithReadAfterWriteRetry(ctx, "AddInbound resolve by port", func() (bool, error) {
+			list, listErr := r.client.GetInbounds(ctx)
+			if listErr != nil {
+				return false, listErr
+			}
+			for i := range list {
+				if list[i].Port == inbound.Port {
+					resolvedID = list[i].ID
+					return true, nil
+				}
+			}
+			return false, nil
+		})
+		if retryErr != nil {
+			resp.Diagnostics.AddError("Failed to resolve created inbound",
+				fmt.Sprintf("AddInbound returned success but the row was not visible: %s", retryErr.Error()))
+			return
+		}
+		created = &Inbound{ID: resolvedID}
 	}
 
 	// Re-read the inbound via GET to ensure consistent state (#131).

--- a/provider/resource_inbound.go
+++ b/provider/resource_inbound.go
@@ -303,6 +303,26 @@ func (r *InboundResource) Read(ctx context.Context, req resource.ReadRequest, re
 	resp.Diagnostics.Append(resp.State.Set(ctx, newState)...)
 }
 
+// inboundReflectsSent reports whether got reflects the scalar fields we
+// just wrote in sent. Used to detect the post-update SQLite visibility lag
+// (issue #157): if these scalars don't yet match the request, the panel
+// hasn't applied the update on the read side. Settings / StreamSettings /
+// Sniffing are deliberately excluded — the panel may decorate them
+// (Reality keys, defaults), so byte-equality is too strict for a
+// visibility check.
+func inboundReflectsSent(got, sent *Inbound) bool {
+	if got == nil || sent == nil {
+		return false
+	}
+	return got.Remark == sent.Remark &&
+		got.Port == sent.Port &&
+		got.Enable == sent.Enable &&
+		got.Listen == sent.Listen &&
+		got.Total == sent.Total &&
+		got.ExpiryTime == sent.ExpiryTime &&
+		got.Protocol == sent.Protocol
+}
+
 func (r *InboundResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var plan InboundResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -358,9 +378,20 @@ func (r *InboundResource) Update(ctx context.Context, req resource.UpdateRequest
 	}
 
 	// Re-read the inbound via GET to ensure consistent state (#131).
-	updated, err := r.client.GetInbound(ctx, id)
-	if err != nil {
-		resp.Diagnostics.AddError("Failed to read updated inbound", err.Error())
+	// Under SQLite contention the GET may briefly return the pre-update
+	// snapshot, which Terraform then rejects as inconsistent. Poll until
+	// scalar fields we just wrote are reflected, or the budget expires
+	// (issue #157).
+	var updated *Inbound
+	if retryErr := r.client.WithReadAfterWriteRetry(ctx, fmt.Sprintf("read updated inbound %d", id), func() (bool, error) {
+		got, getErr := r.client.GetInbound(ctx, id)
+		if getErr != nil {
+			return false, getErr
+		}
+		updated = got
+		return inboundReflectsSent(got, inbound), nil
+	}); retryErr != nil {
+		resp.Diagnostics.AddError("Failed to read updated inbound", retryErr.Error())
 		return
 	}
 

--- a/provider/resource_inbound_client.go
+++ b/provider/resource_inbound_client.go
@@ -243,8 +243,14 @@ func (r *InboundClientResource) Create(ctx context.Context, req resource.CreateR
 		return
 	}
 
-	// Read back from API to populate state.
-	state := r.readClientState(ctx, &resp.Diagnostics, inboundID, clientID)
+	// Read back from API to populate state. The just-added client may not
+	// be visible to a subsequent GET if SQLite is contended (issue #157),
+	// so poll until it appears or the budget is exhausted.
+	state, err := r.readClientStateWithRetry(ctx, inboundID, clientID)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to read created inbound client", err.Error())
+		return
+	}
 	if state == nil {
 		return
 	}
@@ -310,7 +316,11 @@ func (r *InboundClientResource) Update(ctx context.Context, req resource.UpdateR
 		return
 	}
 
-	state := r.readClientState(ctx, &resp.Diagnostics, inboundID, clientID)
+	state, err := r.readClientStateWithRetry(ctx, inboundID, clientID)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to read updated inbound client", err.Error())
+		return
+	}
 	if state == nil {
 		return
 	}
@@ -389,6 +399,35 @@ func (r *InboundClientResource) readClientState(ctx context.Context, diags *diag
 	}
 
 	return inboundClientToModel(inboundID, clientID, found)
+}
+
+// readClientStateWithRetry is the post-write variant of readClientState: it
+// treats "client not yet visible" as a transient condition and polls until
+// the row appears or the budget is exhausted (issue #157). Use it only
+// after a successful AddInboundClient/UpdateInboundClient — for plain Read
+// the absence of a client is meaningful and should not be retried.
+func (r *InboundClientResource) readClientStateWithRetry(ctx context.Context, inboundID int, clientID string) (*InboundClientResourceModel, error) {
+	var state *InboundClientResourceModel
+	err := r.client.WithReadAfterWriteRetry(ctx, fmt.Sprintf("read inbound %d client %s", inboundID, clientID), func() (bool, error) {
+		inbound, getErr := r.client.GetInbound(ctx, inboundID)
+		if getErr != nil {
+			return false, getErr
+		}
+		settings, parseErr := parseInboundSettings(inbound.Settings)
+		if parseErr != nil {
+			return false, parseErr
+		}
+		found := findClientByID(settings.Clients, clientID)
+		if found == nil {
+			return false, nil
+		}
+		state = inboundClientToModel(inboundID, clientID, found)
+		return true, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return state, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/provider/resource_xray_version.go
+++ b/provider/resource_xray_version.go
@@ -167,25 +167,31 @@ func (r *XrayVersionResource) Update(ctx context.Context, req resource.UpdateReq
 }
 
 // waitForXrayVersion polls GetCurrentXrayVersion until it matches the desired
-// version or the timeout (30s) is exceeded. Although UpdateXray in 3x-ui is
+// version or the timeout is exceeded. Although UpdateXray in 3x-ui is
 // synchronous (download → extract → RestartXray), the restarted xray process
-// may not report the new version immediately via GetXrayVersion.
+// may not report any version for a few seconds via getXrayVersion — during
+// that gap the panel returns "Unknown", which surfaces as
+// ErrXrayVersionUnknown. We treat that as "still restarting" and keep
+// polling rather than failing the apply (issue #157).
 func (r *XrayVersionResource) waitForXrayVersion(ctx context.Context, version string) (string, error) {
-	for i := 0; i < 30; i++ {
+	const maxAttempts = 60
+	var lastSeen string
+	for i := 0; i < maxAttempts; i++ {
 		current, err := r.client.GetCurrentXrayVersion(ctx)
-		if err != nil {
+		if err == nil {
+			lastSeen = current
+			if current == version {
+				return current, nil
+			}
+		} else if !errors.Is(err, ErrXrayVersionUnknown) {
 			return "", err
-		}
-		if current == version {
-			return current, nil
 		}
 		time.Sleep(time.Second)
 	}
-	current, err := r.client.GetCurrentXrayVersion(ctx)
-	if err != nil {
-		return "", err
+	if lastSeen != "" {
+		return lastSeen, nil
 	}
-	return current, nil
+	return "", ErrXrayVersionUnknown
 }
 
 func (r *XrayVersionResource) Delete(_ context.Context, _ resource.DeleteRequest, resp *resource.DeleteResponse) {


### PR DESCRIPTION
Fixes #157.

## What

A single class of CI flake on `main` had three different surfaces:

- `Error: Empty response` from `InboundResource.Create` (CI Acceptance + Compat v2.9.3).
- `Missing Resource State After Create` from `InboundClientResource.Create` (reproduced locally on v2.9.3 in 1/3 runs).
- `inbound N still exists` from `testAccCheckInboundDestroyed`.
- `xray version is unknown (Xray may not be running)` from `XrayVersionResource.Update` on the second apply of `TestAccXrayVersionDrift`.

All four come from the same root cause: 3x-ui returns `success: true` from a write operation while the SQLite commit (or, for xray, the restarted process) is not yet visible to a follow-up GET. The 5xx retry doesn't help — the response is HTTP 200, just missing the row.

## Approach

Adds `Client.WithReadAfterWriteRetry`, a separate policy from `withRetry`: 5×500ms, polls a caller-provided `func() (found bool, err error)`, ignores "not visible yet" but aborts on real read errors. Wired into:

- `InboundResource.Create` — when `AddInbound` returns success with `created.ID == 0`, resolve via `GetInbounds` filtered by `Port` (3x-ui enforces port uniqueness), then proceed with the existing `GetInbound` re-read.
- `InboundClientResource.Create`/`Update` — `readClientStateWithRetry` polls `GetInbound` until the new client appears in the inbound's settings JSON. Plain `Read` is unchanged: there an absent row is meaningful.
- `XrayVersionResource.waitForXrayVersion` — `ErrXrayVersionUnknown` is treated as "still restarting" rather than a hard error; window bumped 30s → 60s with a captured `lastSeen` so we still return the latest known version on timeout.
- Acceptance helpers `testAccCheckInboundDestroyed` / `testAccCheckInboundClientDestroyed` — bounded poll (5×500ms) for the *inverse* case: a successful DELETE that's still briefly visible.
- `TestAccXrayVersionDrift` PreConfig — drift-simulation window 30s → 60s for slow CI.

`CLAUDE.md` gets a new "Read-after-write retry (post-write reads)" section under the existing "Retry on transient 5xx" so the two retry policies can't be confused by a future contributor.

## Validation

15 sequential local `task test:acc` runs against `v2.9.3` across three iterations of the fix — final iteration: **5/5 green**. Before the fix: 1 fail in 3 runs (`Missing Resource State After Create`).

Lint clean, unit tests green.

## Test plan

- [ ] CI green on this PR
- [ ] Compat matrix runs against v2.8.9 / v2.8.10 / v2.8.11 / v2.9.0 / v2.9.1 / v2.9.2 / v2.9.3 all green