### PR TITLE
chore: bump Go to 1.26.2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for your interest in contributing to the Terraform Provider for 3x-ui!
 
 ## Prerequisites
 
-- **Go 1.25+**
+- **Go 1.26+**
 - **[Task](https://taskfile.dev/)** — task runner (`brew install go-task` / `go install github.com/go-task/task/v3/cmd/task@latest`)
 - **[golangci-lint](https://golangci-lint.run/welcome/install/)**
 - **[pre-commit](https://pre-commit.com/)** — git hooks framework (`pip install pre-commit`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for your interest in contributing to the Terraform Provider for 3x-ui!
 
 ## Prerequisites
 
-- **Go 1.26+**
+- **Go** — version pinned in [`go.mod`](go.mod)
 - **[Task](https://taskfile.dev/)** — task runner (`brew install go-task` / `go install github.com/go-task/task/v3/cmd/task@latest`)
 - **[golangci-lint](https://golangci-lint.run/welcome/install/)**
 - **[pre-commit](https://pre-commit.com/)** — git hooks framework (`pip install pre-commit`)

--- a/README.ar_EG.md
+++ b/README.ar_EG.md
@@ -162,7 +162,7 @@ resource "threexui_inbound_client" "client_a" {
 
 ### المتطلبات
 
-- Go 1.26+
+- Go (الإصدار مثبّت في [`go.mod`](go.mod))
 - [Task](https://taskfile.dev/) — task runner
 - [golangci-lint](https://golangci-lint.run/welcome/install/) — linter
 - [pre-commit](https://pre-commit.com/) — git hooks

--- a/README.ar_EG.md
+++ b/README.ar_EG.md
@@ -162,7 +162,7 @@ resource "threexui_inbound_client" "client_a" {
 
 ### المتطلبات
 
-- Go 1.25+
+- Go 1.26+
 - [Task](https://taskfile.dev/) — task runner
 - [golangci-lint](https://golangci-lint.run/welcome/install/) — linter
 - [pre-commit](https://pre-commit.com/) — git hooks

--- a/README.es_ES.md
+++ b/README.es_ES.md
@@ -160,7 +160,7 @@ El proveedor maneja secretos que el panel emite automáticamente (Reality `priva
 
 ### Requisitos
 
-- Go 1.26+
+- Go (versión fijada en [`go.mod`](go.mod))
 - [Task](https://taskfile.dev/) — runner de tareas
 - [golangci-lint](https://golangci-lint.run/welcome/install/) — linter
 - [pre-commit](https://pre-commit.com/) — hooks de git

--- a/README.es_ES.md
+++ b/README.es_ES.md
@@ -160,7 +160,7 @@ El proveedor maneja secretos que el panel emite automáticamente (Reality `priva
 
 ### Requisitos
 
-- Go 1.25+
+- Go 1.26+
 - [Task](https://taskfile.dev/) — runner de tareas
 - [golangci-lint](https://golangci-lint.run/welcome/install/) — linter
 - [pre-commit](https://pre-commit.com/) — hooks de git

--- a/README.fa_IR.md
+++ b/README.fa_IR.md
@@ -162,7 +162,7 @@ resource "threexui_inbound_client" "client_a" {
 
 ### پیش‌نیازها
 
-- Go 1.26+
+- Go (نسخه در [`go.mod`](go.mod) ثابت شده است)
 - [Task](https://taskfile.dev/) — task runner
 - [golangci-lint](https://golangci-lint.run/welcome/install/) — linter
 - [pre-commit](https://pre-commit.com/) — هوک‌های git

--- a/README.fa_IR.md
+++ b/README.fa_IR.md
@@ -162,7 +162,7 @@ resource "threexui_inbound_client" "client_a" {
 
 ### پیش‌نیازها
 
-- Go 1.25+
+- Go 1.26+
 - [Task](https://taskfile.dev/) — task runner
 - [golangci-lint](https://golangci-lint.run/welcome/install/) — linter
 - [pre-commit](https://pre-commit.com/) — هوک‌های git

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ The provider handles secrets the panel issues automatically (Reality `privateKey
 
 ### Requirements
 
-- Go 1.26+
+- Go (version pinned in [`go.mod`](go.mod))
 - [Task](https://taskfile.dev/) — task runner
 - [golangci-lint](https://golangci-lint.run/welcome/install/) — linter
 - [pre-commit](https://pre-commit.com/) — git hooks framework

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ The provider handles secrets the panel issues automatically (Reality `privateKey
 
 ### Requirements
 
-- Go 1.25+
+- Go 1.26+
 - [Task](https://taskfile.dev/) — task runner
 - [golangci-lint](https://golangci-lint.run/welcome/install/) — linter
 - [pre-commit](https://pre-commit.com/) — git hooks framework

--- a/README.ru_RU.md
+++ b/README.ru_RU.md
@@ -160,7 +160,7 @@ resource "threexui_inbound_client" "client_a" {
 
 ### Что нужно
 
-- Go 1.25+
+- Go 1.26+
 - [Task](https://taskfile.dev/) — раннер задач
 - [golangci-lint](https://golangci-lint.run/welcome/install/) — линтер
 - [pre-commit](https://pre-commit.com/) — git-хуки

--- a/README.ru_RU.md
+++ b/README.ru_RU.md
@@ -160,7 +160,7 @@ resource "threexui_inbound_client" "client_a" {
 
 ### Что нужно
 
-- Go 1.26+
+- Go (версия закреплена в [`go.mod`](go.mod))
 - [Task](https://taskfile.dev/) — раннер задач
 - [golangci-lint](https://golangci-lint.run/welcome/install/) — линтер
 - [pre-commit](https://pre-commit.com/) — git-хуки

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -160,7 +160,7 @@ provider 会处理面板自动派发的各种密钥(Reality `privateKey`、WireG
 
 ### 依赖
 
-- Go 1.26+
+- Go（版本以 [`go.mod`](go.mod) 为准）
 - [Task](https://taskfile.dev/) —— 任务运行器
 - [golangci-lint](https://golangci-lint.run/welcome/install/) —— linter
 - [pre-commit](https://pre-commit.com/) —— git hooks 框架

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -160,7 +160,7 @@ provider 会处理面板自动派发的各种密钥(Reality `privateKey`、WireG
 
 ### 依赖
 
-- Go 1.25+
+- Go 1.26+
 - [Task](https://taskfile.dev/) —— 任务运行器
 - [golangci-lint](https://golangci-lint.run/welcome/install/) —— linter
 - [pre-commit](https://pre-commit.com/) —— git hooks 框架

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/batonogov/terraform-provider-threexui
 
-go 1.25.8
+go 1.26.2
 
 require (
 	github.com/hashicorp/terraform-plugin-framework v1.19.0


### PR DESCRIPTION
## Summary
- Bump `go` directive in `go.mod` from `1.25.8` → `1.26.2` (latest stable in the 1.26 line).
- No workflow changes needed: all CI jobs use `setup-go` with `go-version-file: go.mod`, so the toolchain follows automatically.

## Test plan
- [x] `task build` passes
- [x] `task test:unit` passes locally (Go 1.26.2)
- [ ] CI: lint + unit + acceptance matrix green