### PR TITLE
chore(security): pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,14 +53,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
 
       - name: Install Task
-        uses: arduino/setup-task@v2
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2
         with:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }} # see top-of-file note
@@ -78,14 +78,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
 
       - name: Install Task
-        uses: arduino/setup-task@v2
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2
         with:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }} # see top-of-file note
@@ -102,25 +102,25 @@ jobs:
     # kills the second attempt mid-flight.
     timeout-minutes: 40
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
 
       - name: Install Terraform
-        uses: hashicorp/setup-terraform@v4
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4
         with:
           terraform_wrapper: false
 
       - name: Install Task
-        uses: arduino/setup-task@v2
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2
         with:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }} # see top-of-file note
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -133,7 +133,7 @@ jobs:
       # if it does, that is a real bug and the diff between attempts will
       # show it. max_attempts=2 is the cheap-insurance setting.
       - name: Run acceptance tests
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
         with:
           timeout_minutes: 18
           max_attempts: 2
@@ -153,32 +153,32 @@ jobs:
       matrix:
         version: ["v2.8.9", "v2.8.10", "v2.8.11", "v2.9.0", "v2.9.1", "v2.9.2", "v2.9.3"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
 
       - name: Install Terraform
-        uses: hashicorp/setup-terraform@v4
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4
         with:
           terraform_wrapper: false
 
       - name: Install Task
-        uses: arduino/setup-task@v2
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2
         with:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }} # see top-of-file note
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run compatibility tests
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
         env:
           THREEXUI_VERSION: ${{ matrix.version }}
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,10 +28,10 @@ jobs:
     name: Terraform Format Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Terraform
-        uses: hashicorp/setup-terraform@v4
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4
         with:
           terraform_wrapper: false
 
@@ -42,10 +42,10 @@ jobs:
     name: Markdown Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run markdownlint
-        uses: DavidAnson/markdownlint-cli2-action@v23
+        uses: DavidAnson/markdownlint-cli2-action@ce4853d43830c74c1753b39f3cf40f71c2031eb9 # v23
         with:
           globs: |
             docs/**/*.md
@@ -56,7 +56,7 @@ jobs:
     name: YAML Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install yamllint
         run: pip install yamllint

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,7 +16,7 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@v5
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         id: release
         with:
           release-type: simple
@@ -27,23 +27,23 @@ jobs:
     if: needs.release-please.outputs.release_created == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
 
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v7
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7
         id: import_gpg
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7
         with:
           args: release --clean
         env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,9 +40,13 @@ repos:
         language: system
         types: [markdown]
 
-  # Common hooks for any files
+  # Common hooks for any files.
+  # rev pinned to a commit SHA (not a tag) — same rationale as the pinned
+  # GitHub Actions in .github/workflows/: tags are mutable. Update via
+  # `pre-commit autoupdate --freeze` which produces this exact `<sha>
+  # frozen: <tag>` format. Bare `pre-commit autoupdate` will un-pin.
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: c4a0b883114b00d8d76b479c820ce7950211c99b  # frozen: v4.5.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -251,7 +251,7 @@ All third-party code that runs in CI or pre-commit is pinned to a commit SHA, no
 
 **Pre-commit hooks** (`.pre-commit-config.yaml`) — external `repo:` references use `rev: <sha>  # frozen: <tag>`. This is the format `pre-commit autoupdate --freeze` produces. Bare `pre-commit autoupdate` will un-pin — always use the `--freeze` flag locally, or update the SHA manually.
 
-**Docker images** in `docker-compose.yaml` are NOT digest-pinned. They run only as ephemeral test environments (3x-ui panel for acceptance tests), never in published artifacts — so the supply-chain blast radius is limited to a CI run.
+**Docker images** in `docker-compose.yaml` are intentionally NOT digest-pinned. They run only as ephemeral test environments (3x-ui panel for acceptance tests), never in published artifacts, and have no access to release secrets — the residual risk is a tampered test signal, not a poisoned release. Maintaining digests for all 7 matrix versions manually outweighs the closed-off risk (#168).
 
 **Go modules** are covered by `go.sum` hashing — no extra pinning needed. The `go install ...@vX.Y.Z` references in workflows install specific versions whose contents are verified by Go's module proxy.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,6 +243,26 @@ Configuration files: `.pre-commit-config.yaml`, `.golangci.yml`, `.markdownlint-
 - Glob list intentionally covers only `README.md`, `CONTRIBUTING.md`, `docs/**/*.md`. Localized READMEs (`README.<locale>.md`) are not linted — they mirror `README.md` structurally and a single lint pass is the source of truth.
 - `first-line-heading: false` is set because every README starts with the language-switcher line, not a heading.
 
+## Supply-Chain Pinning
+
+All third-party code that runs in CI or pre-commit is pinned to a commit SHA, not a floating tag. Tags are mutable — a maintainer can re-tag to point at different code without any diff in our workflow files. SHA pins make every dependency change a reviewable diff.
+
+**GitHub Actions** (`.github/workflows/*.yml`) — every `uses:` reference is pinned as `<owner>/<repo>@<sha> # vN`. The trailing `# vN` comment is the format Dependabot recognizes for major-version tracking; weekly Dependabot PRs bump the SHA when the action publishes a new vN.x release. Same rule applies to first-party `actions/*` for consistency.
+
+**Pre-commit hooks** (`.pre-commit-config.yaml`) — external `repo:` references use `rev: <sha>  # frozen: <tag>`. This is the format `pre-commit autoupdate --freeze` produces. Bare `pre-commit autoupdate` will un-pin — always use the `--freeze` flag locally, or update the SHA manually.
+
+**Docker images** in `docker-compose.yaml` are NOT digest-pinned. They run only as ephemeral test environments (3x-ui panel for acceptance tests), never in published artifacts — so the supply-chain blast radius is limited to a CI run.
+
+**Go modules** are covered by `go.sum` hashing — no extra pinning needed. The `go install ...@vX.Y.Z` references in workflows install specific versions whose contents are verified by Go's module proxy.
+
+When adding a new third-party action or pre-commit hook, resolve the SHA via:
+
+```bash
+gh api repos/<owner>/<repo>/git/refs/tags/<tag> --jq '.object.sha,.object.type'
+# if type is "tag" (annotated), dereference:
+gh api repos/<owner>/<repo>/git/tags/<sha> --jq '.object.sha'
+```
+
 ## Test Environment
 
 ```bash


### PR DESCRIPTION
## Summary

Action tags (\`@v6\`, \`@v3\`, etc) are mutable — a maintainer can re-tag to point at different code without any change in our workflow files. A compromised maintainer account, or a deliberately malicious one, could swap in arbitrary code on every CI run undetected. Pinning to commit SHAs makes the dependency immutable and any change visible as a diff that must be reviewed.

Pinned **every** external action to its current commit SHA, with the major version kept as a trailing \`# vN\` comment. Dependabot is already configured for the \`github-actions\` ecosystem (.github/dependabot.yml) and will open weekly PRs to bump these hashes when actions publish new releases — the comment gives it the major-version hint.

## Coverage

| Action | Tag → SHA |
| --- | --- |
| actions/checkout | v6 → de0fac2e... |
| actions/setup-go | v6 → 4a360112... |
| arduino/setup-task | v2 → b91d5d2c... |
| hashicorp/setup-terraform | v4 → 5e8dbf3c... |
| docker/login-action | v3 → c94ce9fb... |
| nick-fields/retry | v3 → ce71cc2a... |
| googleapis/release-please-action | v5 → 45996ed1... |
| crazy-max/ghaction-import-gpg | v7 → 2dc316de... |
| goreleaser/goreleaser-action | v7 → 1a80836c... |
| DavidAnson/markdownlint-cli2-action | v23 → ce4853d4... |

The only remaining \`@vN\` reference (\`go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.3\`) is a Go module install, not a GitHub Action, and already pinned to a specific patch version.

## Test plan

- [x] Workflow YAML still parses (pre-commit \`check yaml\` hook passed)
- [ ] CI runs against this PR — all jobs should pass identically since the pinned SHAs are exactly what \`@vN\` resolved to a few minutes ago
- [ ] Verify dependabot picks these up on the next weekly cycle (no manual config needed; \`# vN\` comment is the recognized format)

## Tradeoffs

**Pros.** Immutable references; supply-chain attack via re-tagged action becomes impossible; every dependency change is a reviewable PR.

**Cons.** Small visual noise in workflow files. Without Dependabot, hashes would drift — but Dependabot is already configured.

Refs: [GitHub security hardening guide](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).