### PR TITLE
feat: add 3x-ui v2.9.4 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ["v2.8.9", "v2.8.10", "v2.8.11", "v2.9.0", "v2.9.1", "v2.9.2", "v2.9.3"]
+        version: ["v2.8.9", "v2.8.10", "v2.8.11", "v2.9.0", "v2.9.1", "v2.9.2", "v2.9.3", "v2.9.4"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Use `task` for all routine work:
 - `task lint` runs `golangci-lint run`.
 - `task test:unit` runs unit tests only.
 - `task test:acc` starts Docker Compose and runs Terraform acceptance tests.
-- `task test:acc:compat` runs acceptance tests against a selectable 3x-ui version via `THREEXUI_VERSION` (defaults to `v2.9.3`).
+- `task test:acc:compat` runs acceptance tests against a selectable 3x-ui version via `THREEXUI_VERSION` (defaults to `v2.9.4`).
 - `task test` runs both unit and acceptance suites.
 - `task pre-commit` runs the Go pre-commit checks: fmt, vet, lint, and build. The actual `.pre-commit-config.yaml` also includes markdown and common file checks.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ docs/
 README.md              — English README; localized in 5 more languages mirroring 3x-ui upstream:
                          README.ru_RU.md, README.fa_IR.md, README.ar_EG.md, README.zh_CN.md, README.es_ES.md
 3x-ui-<version>/      — 3x-ui source snapshots (in .gitignore, for reference/diffing)
-docker-compose.yaml    — 3x-ui on port 2053 (version via THREEXUI_VERSION env, default v2.9.3)
+docker-compose.yaml    — 3x-ui on port 2053 (version via THREEXUI_VERSION env, default v2.9.4)
 Taskfile.yml           — task build / test / fmt
 .github/workflows/
   ci.yml               — lint, unit tests, acceptance tests, compatibility matrix (PR + push main)
@@ -200,7 +200,7 @@ Distinct from the 5xx retry above. 3x-ui occasionally returns `success: true` fr
 - `xrayApplyTyped` / `xrayReadSection` — shared CRUD logic
 - CRUD: plan.Get → expand → build → xrayApplyTyped → xrayReadSection → flattenToMap → flatten → state.Set
 - DNS servers: address-only → serialized as string in JSON, with extra fields → as object
-- Outbound settings: per-protocol blocks (`freedom_settings`, `blackhole_settings`, ...) determined by `protocol` value; `freedom_settings` includes `ips_blocked` (list of string, added in 2.9.0)
+- Outbound settings: per-protocol blocks (`freedom_settings`, `blackhole_settings`, ...) determined by `protocol` value; `freedom_settings` includes legacy `ips_blocked` (2.9.0) and `final_rule` (2.9.4+), `vless_settings` includes `reverse_tag` (2.9.4+)
 - Policy levels: in Xray JSON map `{"0": {...}}`, in TF list `[{id=0, ...}]`
 - Delete for xray resources only clears TF state, does not reset the xray config
 
@@ -210,7 +210,7 @@ Distinct from the 5xx retry above. 3x-ui occasionally returns `success: true` fr
 task build            # Build binary
 task test:unit        # Run unit tests (no Docker / Terraform needed)
 task test:acc         # Run acceptance tests (requires Docker)
-task test:acc:compat  # Run all tests with version-aware skipping (THREEXUI_VERSION, default v2.9.3)
+task test:acc:compat  # Run all tests with version-aware skipping (THREEXUI_VERSION, default v2.9.4)
 task test             # Run unit + acceptance tests
 task fmt              # gofmt
 task vet              # go vet
@@ -276,7 +276,7 @@ docker compose up -d   # Start 3x-ui on localhost:2053
 THREEXUI_VERSION=v2.8.9 task test:acc:compat
 
 # Run all versions locally:
-for v in v2.8.9 v2.8.10 v2.8.11 v2.9.0 v2.9.1 v2.9.2 v2.9.3; do
+for v in v2.8.9 v2.8.10 v2.8.11 v2.9.0 v2.9.1 v2.9.2 v2.9.3 v2.9.4; do
   echo "=== Testing $v ===" && THREEXUI_VERSION=$v task test:acc:compat
 done
 ```

--- a/README.ar_EG.md
+++ b/README.ar_EG.md
@@ -65,8 +65,8 @@ resource "threexui_inbound" "vless" {
     network  = "tcp"
     security = "reality"
     reality_settings {
-      target       = "www.apple.com:443"
-      server_names = ["www.apple.com"]
+      target       = "www.amazon.com:443"
+      server_names = ["www.amazon.com"]
     }
   }
 
@@ -90,6 +90,7 @@ resource "threexui_inbound_client" "client_a" {
 
 | إصدار 3x-ui | الحالة |
 | --- | --- |
+| v2.9.4 | تم اختباره |
 | v2.9.3 | تم اختباره |
 | v2.9.2 | تم اختباره |
 | v2.9.1 | تم اختباره |

--- a/README.es_ES.md
+++ b/README.es_ES.md
@@ -63,8 +63,8 @@ resource "threexui_inbound" "vless" {
     network  = "tcp"
     security = "reality"
     reality_settings {
-      target       = "www.apple.com:443"
-      server_names = ["www.apple.com"]
+      target       = "www.amazon.com:443"
+      server_names = ["www.amazon.com"]
     }
   }
 
@@ -88,6 +88,7 @@ resource "threexui_inbound_client" "client_a" {
 
 | Versión de 3x-ui | Estado |
 | --- | --- |
+| v2.9.4 | Probado |
 | v2.9.3 | Probado |
 | v2.9.2 | Probado |
 | v2.9.1 | Probado |

--- a/README.fa_IR.md
+++ b/README.fa_IR.md
@@ -65,8 +65,8 @@ resource "threexui_inbound" "vless" {
     network  = "tcp"
     security = "reality"
     reality_settings {
-      target       = "www.apple.com:443"
-      server_names = ["www.apple.com"]
+      target       = "www.amazon.com:443"
+      server_names = ["www.amazon.com"]
     }
   }
 
@@ -90,6 +90,7 @@ resource "threexui_inbound_client" "client_a" {
 
 | نسخهٔ 3x-ui | وضعیت |
 | --- | --- |
+| v2.9.4 | تست‌شده |
 | v2.9.3 | تست‌شده |
 | v2.9.2 | تست‌شده |
 | v2.9.1 | تست‌شده |

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ resource "threexui_inbound" "vless" {
     network  = "tcp"
     security = "reality"
     reality_settings {
-      target       = "www.apple.com:443"
-      server_names = ["www.apple.com"]
+      target       = "www.amazon.com:443"
+      server_names = ["www.amazon.com"]
     }
   }
 
@@ -88,6 +88,7 @@ resource "threexui_inbound_client" "client_a" {
 
 | 3x-ui version | Status |
 | --- | --- |
+| v2.9.4 | Tested |
 | v2.9.3 | Tested |
 | v2.9.2 | Tested |
 | v2.9.1 | Tested |

--- a/README.ru_RU.md
+++ b/README.ru_RU.md
@@ -63,8 +63,8 @@ resource "threexui_inbound" "vless" {
     network  = "tcp"
     security = "reality"
     reality_settings {
-      target       = "www.apple.com:443"
-      server_names = ["www.apple.com"]
+      target       = "www.amazon.com:443"
+      server_names = ["www.amazon.com"]
     }
   }
 
@@ -88,6 +88,7 @@ resource "threexui_inbound_client" "client_a" {
 
 | Версия 3x-ui | Статус |
 | --- | --- |
+| v2.9.4 | Тестируется |
 | v2.9.3 | Тестируется |
 | v2.9.2 | Тестируется |
 | v2.9.1 | Тестируется |

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -63,8 +63,8 @@ resource "threexui_inbound" "vless" {
     network  = "tcp"
     security = "reality"
     reality_settings {
-      target       = "www.apple.com:443"
-      server_names = ["www.apple.com"]
+      target       = "www.amazon.com:443"
+      server_names = ["www.amazon.com"]
     }
   }
 
@@ -88,6 +88,7 @@ resource "threexui_inbound_client" "client_a" {
 
 | 3x-ui 版本 | 状态 |
 | --- | --- |
+| v2.9.4 | 已测试 |
 | v2.9.3 | 已测试 |
 | v2.9.2 | 已测试 |
 | v2.9.1 | 已测试 |

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -42,7 +42,7 @@ tasks:
     vars:
       TERRAFORM_PATH:
         sh: which terraform
-      THREEXUI_VERSION: '{{.THREEXUI_VERSION | default "v2.9.3"}}'
+      THREEXUI_VERSION: '{{.THREEXUI_VERSION | default "v2.9.4"}}'
     cmds:
       - echo "Running tests against 3x-ui {{.THREEXUI_VERSION}}"
       - docker compose down -v 2>/dev/null || true

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   3xui:
-    image: ghcr.io/mhsanaei/3x-ui:${THREEXUI_VERSION:-v2.9.3}
+    image: ghcr.io/mhsanaei/3x-ui:${THREEXUI_VERSION:-v2.9.4}
     ports:
       - "2053:2053" # HTTP panel
     environment:

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,8 +32,8 @@ resource "threexui_inbound" "vless" {
     network  = "tcp"
     security = "reality"
     reality_settings {
-      target       = "www.apple.com:443"
-      server_names = ["www.apple.com"]
+      target       = "www.amazon.com:443"
+      server_names = ["www.amazon.com"]
     }
   }
 

--- a/docs/resources/inbound.md
+++ b/docs/resources/inbound.md
@@ -28,8 +28,8 @@ resource "threexui_inbound" "vless" {
     network  = "tcp"
     security = "reality"
     reality_settings {
-      target       = "www.apple.com:443"
-      server_names = ["www.apple.com"]
+      target       = "www.amazon.com:443"
+      server_names = ["www.amazon.com"]
     }
     tcp_settings {
       accept_proxy_protocol = false
@@ -355,8 +355,8 @@ resource "threexui_inbound" "example" {
     network  = "tcp"
     security = "reality"
     reality_settings {
-      target       = "www.apple.com:443"
-      server_names = ["www.apple.com"]
+      target       = "www.amazon.com:443"
+      server_names = ["www.amazon.com"]
     }
   }
 

--- a/docs/resources/inbound_client.md
+++ b/docs/resources/inbound_client.md
@@ -26,8 +26,8 @@ resource "threexui_inbound" "vless" {
     network  = "tcp"
     security = "reality"
     reality_settings {
-      target       = "www.apple.com:443"
-      server_names = ["www.apple.com"]
+      target       = "www.amazon.com:443"
+      server_names = ["www.amazon.com"]
     }
   }
 }
@@ -77,6 +77,7 @@ resource "threexui_inbound_client" "hysteria_user" {
 - `security` (Optional, String) - Security type.
 - `password` (Optional, String, Sensitive) - Client password (used by trojan/shadowsocks).
 - `flow` (Optional, String) - Flow control (e.g. `xtls-rprx-vision`).
+- `reverse_tag` (Optional, String) - VLESS reverse tag. Stored in 3x-ui as `reverse.tag` and available on 3x-ui v2.9.4+.
 - `auth` (Optional, String) - Auth password for Hysteria clients. Used as client identifier instead of UUID.
 - `limit_ip` (Optional, Number) - Maximum concurrent connections.
 - `total_gb` (Optional, Number) - Traffic limit in GB.

--- a/docs/resources/panel_general.md
+++ b/docs/resources/panel_general.md
@@ -49,6 +49,7 @@ resource "threexui_panel_general" "settings" {
 
 - `external_traffic_inform_enable` (Optional, Boolean) - Enable external traffic notifications. Default is `false`.
 - `external_traffic_inform_uri` (Optional, String) - External traffic notification URI. Default is `""`.
+- `restart_xray_on_client_disable` (Optional, Boolean) - Restart Xray when clients are automatically disabled by expiry or traffic limit. Default is `true` on 3x-ui v2.9.4+.
 
 ### LDAP
 

--- a/docs/resources/xray_outbounds.md
+++ b/docs/resources/xray_outbounds.md
@@ -85,7 +85,15 @@ Each outbound should have exactly one `*_settings` block matching its `protocol`
 
 - `domain_strategy` (String, Optional) - Domain strategy (e.g. `AsIs`, `UseIP`).
 - `redirect` (String, Optional) - Redirect address.
-- `ips_blocked` (List of String, Optional) - List of IPs/CIDRs to block (e.g. `geoip:cn`).
+- `ips_blocked` (List of String, Optional) - Deprecated legacy list of IPs/CIDRs to block (e.g. `geoip:cn`). Use `final_rule` on 3x-ui v2.9.4+.
+
+##### final_rule (Block, Optional, List)
+
+- `action` (String, Optional) - Rule action, for example `block`.
+- `network` (String, Optional) - Network selector, for example `tcp`, `udp`, or `tcp,udp`.
+- `port` (String, Optional) - Port or port range.
+- `ip` (List of String, Optional) - IP/CIDR/geosite entries.
+- `block_delay` (String, Optional) - Block delay value stored as `blockDelay` in 3x-ui.
 
 ##### fragment (Block, Optional, Max: 1)
 
@@ -125,6 +133,7 @@ Each outbound should have exactly one `*_settings` block matching its `protocol`
 - `id` (String, Optional) - VLESS user ID (UUID).
 - `flow` (String, Optional) - Flow control (e.g. `xtls-rprx-vision`).
 - `encryption` (String, Optional) - Encryption method.
+- `reverse_tag` (String, Optional) - VLESS reverse tag. Stored in 3x-ui as `reverse.tag` and available on 3x-ui v2.9.4+.
 
 #### trojan_settings (Block, Optional, Max: 1)
 

--- a/docs/resources/xray_reverse.md
+++ b/docs/resources/xray_reverse.md
@@ -11,6 +11,8 @@ Manages the reverse proxy section of the Xray template configuration. Uses a **s
 
 This is a singleton resource. Deleting this resource only removes it from Terraform state; it does not reset the reverse proxy configuration.
 
+> **Compatibility note:** 3x-ui v2.9.4 removed the legacy reverse settings UI page. Keep this resource for legacy panels and existing Xray template imports. For v2.9.4+ VLESS reverse configuration, prefer `reverse_tag` on `threexui_inbound_client` and `threexui_xray_outbounds.vless_settings`.
+
 ## Example Usage
 
 ```hcl

--- a/docs/resources/xray_routing.md
+++ b/docs/resources/xray_routing.md
@@ -29,14 +29,10 @@ resource "threexui_xray_routing" "config" {
     domain       = ["geosite:category-ads"]
     outbound_tag = "blocked"
   }
-
-  rule {
-    type         = "field"
-    inbound_tag  = ["api"]
-    outbound_tag = "api"
-  }
 }
 ```
+
+> **Note:** 3x-ui v2.9.4+ manages the internal `api` inbound to `api` outbound routing rule automatically. The provider omits that internal rule from Terraform state to avoid drift.
 
 ## Argument Reference
 

--- a/examples/import-existing/main.tf
+++ b/examples/import-existing/main.tf
@@ -80,8 +80,8 @@ resource "threexui_inbound" "existing" {
     network  = "tcp"
     security = "reality"
     reality_settings {
-      target       = "www.apple.com:443"
-      server_names = ["www.apple.com"]
+      target       = "www.amazon.com:443"
+      server_names = ["www.amazon.com"]
     }
   }
 

--- a/examples/inbound-with-client/main.tf
+++ b/examples/inbound-with-client/main.tf
@@ -35,8 +35,8 @@ resource "threexui_inbound" "vless" {
     network  = "tcp"
     security = "reality"
     reality_settings {
-      target       = "www.apple.com:443"
-      server_names = ["www.apple.com"]
+      target       = "www.amazon.com:443"
+      server_names = ["www.amazon.com"]
     }
   }
 

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -12,8 +12,8 @@ resource "threexui_inbound" "vless" {
     network  = "tcp"
     security = "reality"
     reality_settings {
-      target       = "www.apple.com:443"
-      server_names = ["www.apple.com"]
+      target       = "www.amazon.com:443"
+      server_names = ["www.amazon.com"]
     }
     tcp_settings {
       accept_proxy_protocol = false

--- a/examples/multi-server/modules/server/main.tf
+++ b/examples/multi-server/modules/server/main.tf
@@ -62,8 +62,8 @@ resource "threexui_inbound" "vless" {
     network  = "tcp"
     security = "reality"
     reality_settings {
-      target       = "www.apple.com:443"
-      server_names = ["www.apple.com"]
+      target       = "www.amazon.com:443"
+      server_names = ["www.amazon.com"]
     }
     tcp_settings {
       accept_proxy_protocol = false

--- a/provider/client.go
+++ b/provider/client.go
@@ -356,7 +356,11 @@ func (c *Client) DeleteInboundClient(ctx context.Context, inboundID int, clientI
 		return errors.New("client id is required for delete client")
 	}
 	relPath := fmt.Sprintf("panel/api/inbounds/%d/delClient/%s", inboundID, clientID)
-	return c.doForm(ctx, http.MethodPost, relPath, url.Values{}, nil)
+	err := c.doForm(ctx, http.MethodPost, relPath, url.Values{}, nil)
+	if err != nil && strings.Contains(err.Error(), "Client Not Found") {
+		return nil
+	}
+	return err
 }
 
 func (c *Client) GetServerStatus(ctx context.Context) (map[string]any, error) {

--- a/provider/drift_test.go
+++ b/provider/drift_test.go
@@ -621,6 +621,7 @@ func TestDriftClientFields(t *testing.T) {
 		"auth": true, "email": true, "limitIp": true, "totalGB": true,
 		"expiryTime": true, "enable": true, "tgId": true, "subId": true,
 		"comment": true, "reset": true, "created_at": true, "updated_at": true,
+		"reverse": true,
 	}
 
 	dir := latestSnapshotDir(t)
@@ -661,7 +662,7 @@ func TestDriftAllSettingFields(t *testing.T) {
 		"remarkModel": true, "datepicker": true, "timeLocation": true,
 		"expireDiff": true, "trafficDiff": true, "webCertFile": true,
 		"webKeyFile": true, "externalTrafficInformEnable": true,
-		"externalTrafficInformURI": true,
+		"externalTrafficInformURI": true, "restartXrayOnClientDisable": true,
 		// LDAP
 		"ldapEnable": true, "ldapHost": true, "ldapPort": true,
 		"ldapUseTLS": true, "ldapBindDN": true, "ldapPassword": true,
@@ -736,6 +737,7 @@ func TestDriftXraySettingsPages(t *testing.T) {
 	// Intentionally skipped: "advanced" is not a real resource, just raw JSON.
 	providerExtras := map[string]bool{
 		"advanced": true,
+		"reverse":  true, // legacy threexui_xray_reverse; upstream UI page was removed in v2.9.4
 	}
 
 	dir := latestSnapshotDir(t)

--- a/provider/inbound_client_api_test.go
+++ b/provider/inbound_client_api_test.go
@@ -69,3 +69,15 @@ func TestClientDeleteInboundClient(t *testing.T) {
 		t.Fatalf("unexpected path: %s", gotPath)
 	}
 }
+
+func TestClientDeleteInboundClientIgnoresMissingClient(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(failResponse("Client Not Found In Inbound For ID: cid"))
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv.URL)
+	if err := client.DeleteInboundClient(context.Background(), 9, "cid"); err != nil {
+		t.Fatalf("expected missing client delete to be idempotent, got %v", err)
+	}
+}

--- a/provider/inbound_client_resource_test.go
+++ b/provider/inbound_client_resource_test.go
@@ -100,3 +100,26 @@ func TestGetClientIDFromModel(t *testing.T) {
 		}
 	})
 }
+
+func TestInboundClientReverseTagExpandFlatten(t *testing.T) {
+	model := &InboundClientResourceModel{
+		InboundID:  types.Int64Value(1),
+		ClientID:   types.StringValue("uuid"),
+		Email:      types.StringValue("user@test.com"),
+		ReverseTag: types.StringValue("reverse-a"),
+	}
+
+	expanded := expandInboundClientFromModel(model)
+	reverse, ok := expanded["reverse"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected reverse map, got %T", expanded["reverse"])
+	}
+	if reverse["tag"] != "reverse-a" {
+		t.Fatalf("unexpected reverse tag: %v", reverse["tag"])
+	}
+
+	flattened := inboundClientToModel(1, "uuid", expanded)
+	if flattened.ReverseTag.ValueString() != "reverse-a" {
+		t.Fatalf("expected reverse-a, got %q", flattened.ReverseTag.ValueString())
+	}
+}

--- a/provider/inbound_helpers_test.go
+++ b/provider/inbound_helpers_test.go
@@ -155,7 +155,7 @@ func TestEnsureRealityDefaults_DeriveFromTarget(t *testing.T) {
 func TestEnsureRealityDefaults_NoTargetNoNames(t *testing.T) {
 	reality := map[string]any{}
 	ensureRealityDefaults(reality)
-	if reality["target"] != "www.apple.com:443" {
+	if reality["target"] != "www.amazon.com:443" {
 		t.Fatalf("expected default target")
 	}
 	names := reality["serverNames"].([]any)

--- a/provider/resource_inbound.go
+++ b/provider/resource_inbound.go
@@ -895,8 +895,8 @@ func ensureRealityDefaults(reality map[string]any) {
 			return
 		}
 	}
-	reality["target"] = "www.apple.com:443"
-	reality["serverNames"] = []any{"www.apple.com", "apple.com"}
+	reality["target"] = "www.amazon.com:443"
+	reality["serverNames"] = []any{"www.amazon.com", "amazon.com"}
 }
 
 func mergeRealityFromExisting(existing *Inbound, reality map[string]any) {

--- a/provider/resource_inbound_client.go
+++ b/provider/resource_inbound_client.go
@@ -44,6 +44,7 @@ type InboundClientResourceModel struct {
 	Security   types.String `tfsdk:"security"`
 	Password   types.String `tfsdk:"password"`
 	Flow       types.String `tfsdk:"flow"`
+	ReverseTag types.String `tfsdk:"reverse_tag"`
 	Auth       types.String `tfsdk:"auth"`
 	LimitIP    types.Int64  `tfsdk:"limit_ip"`
 	TotalGB    types.Int64  `tfsdk:"total_gb"`
@@ -111,6 +112,14 @@ func (r *InboundClientResource) Schema(_ context.Context, _ resource.SchemaReque
 			"flow": schema.StringAttribute{
 				Optional: true,
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"reverse_tag": schema.StringAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: "VLESS reverse tag. Stored in 3x-ui as reverse.tag.",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
@@ -449,6 +458,11 @@ func expandInboundClientFromModel(m *InboundClientResourceModel) map[string]any 
 	if !m.Flow.IsNull() && !m.Flow.IsUnknown() {
 		client["flow"] = m.Flow.ValueString()
 	}
+	if !m.ReverseTag.IsNull() && !m.ReverseTag.IsUnknown() {
+		if tag := m.ReverseTag.ValueString(); tag != "" {
+			client["reverse"] = map[string]any{"tag": tag}
+		}
+	}
 	if !m.Auth.IsNull() && !m.Auth.IsUnknown() {
 		client["auth"] = m.Auth.ValueString()
 	}
@@ -492,6 +506,7 @@ func inboundClientToModel(inboundID int, clientID string, client map[string]any)
 		Security:   types.StringValue(stringValue(client["security"])),
 		Password:   types.StringValue(stringValue(client["password"])),
 		Flow:       types.StringValue(stringValue(client["flow"])),
+		ReverseTag: types.StringValue(reverseTagValue(client["reverse"])),
 		Auth:       types.StringValue(stringValue(client["auth"])),
 		LimitIP:    types.Int64Value(int64(intValue(client["limitIp"]))),
 		TotalGB:    types.Int64Value(int64(intValue(client["totalGB"]))),
@@ -502,6 +517,14 @@ func inboundClientToModel(inboundID int, clientID string, client map[string]any)
 		Comment:    types.StringValue(stringValue(client["comment"])),
 		Reset:      types.Int64Value(int64(intValue(client["reset"]))),
 	}
+}
+
+func reverseTagValue(raw any) string {
+	m, ok := raw.(map[string]any)
+	if !ok {
+		return ""
+	}
+	return stringValue(m["tag"])
 }
 
 func getClientIDFromModel(m *InboundClientResourceModel, client map[string]any) string {

--- a/provider/resource_settings_tabs.go
+++ b/provider/resource_settings_tabs.go
@@ -587,6 +587,7 @@ type PanelGeneralModel struct {
 	WebKeyFile                  types.String `tfsdk:"web_key_file"`
 	ExternalTrafficInformEnable types.Bool   `tfsdk:"external_traffic_inform_enable"`
 	ExternalTrafficInformURI    types.String `tfsdk:"external_traffic_inform_uri"`
+	RestartXrayOnClientDisable  types.Bool   `tfsdk:"restart_xray_on_client_disable"`
 	LDAPEnable                  types.Bool   `tfsdk:"ldap_enable"`
 	LDAPHost                    types.String `tfsdk:"ldap_host"`
 	LDAPPort                    types.Int64  `tfsdk:"ldap_port"`
@@ -678,6 +679,14 @@ func panelGeneralSchema() schema.Schema {
 			"external_traffic_inform_uri": schema.StringAttribute{
 				Optional: true, Computed: true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"restart_xray_on_client_disable": schema.BoolAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: "Restart Xray when clients are automatically disabled by expiry or traffic limit.",
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"ldap_enable": schema.BoolAttribute{
 				Optional: true, Computed: true,
@@ -816,6 +825,9 @@ func expandPanelGeneral(m *PanelGeneralModel) map[string]any {
 	if !m.ExternalTrafficInformURI.IsNull() && !m.ExternalTrafficInformURI.IsUnknown() {
 		payload["externalTrafficInformURI"] = m.ExternalTrafficInformURI.ValueString()
 	}
+	if !m.RestartXrayOnClientDisable.IsNull() && !m.RestartXrayOnClientDisable.IsUnknown() {
+		payload["restartXrayOnClientDisable"] = m.RestartXrayOnClientDisable.ValueBool()
+	}
 	if !m.LDAPEnable.IsNull() && !m.LDAPEnable.IsUnknown() {
 		payload["ldapEnable"] = m.LDAPEnable.ValueBool()
 	}
@@ -927,6 +939,9 @@ func flattenPanelGeneral(in map[string]any) *PanelGeneralModel {
 	}
 	if v, ok := in["externalTrafficInformURI"]; ok {
 		m.ExternalTrafficInformURI = types.StringValue(stringValue(v))
+	}
+	if v, ok := in["restartXrayOnClientDisable"]; ok {
+		m.RestartXrayOnClientDisable = types.BoolValue(boolValue(v))
 	}
 	if v, ok := in["ldapEnable"]; ok {
 		m.LDAPEnable = types.BoolValue(boolValue(v))

--- a/provider/settings_tabs_test.go
+++ b/provider/settings_tabs_test.go
@@ -221,10 +221,11 @@ func TestFlattenPanelSubscription(t *testing.T) {
 
 func TestFlattenPanelGeneral(t *testing.T) {
 	in := map[string]any{
-		"webListen":   "0.0.0.0",
-		"webPort":     float64(2053),
-		"webBasePath": "/panel/",
-		"pageSize":    float64(25),
+		"webListen":                  "0.0.0.0",
+		"webPort":                    float64(2053),
+		"webBasePath":                "/panel/",
+		"pageSize":                   float64(25),
+		"restartXrayOnClientDisable": true,
 	}
 	m := flattenPanelGeneral(in)
 	if m.WebListen.ValueString() != "0.0.0.0" {
@@ -235,6 +236,13 @@ func TestFlattenPanelGeneral(t *testing.T) {
 	}
 	if m.WebBasePath.ValueString() != "/panel/" {
 		t.Fatalf("unexpected web_base_path: %v", m.WebBasePath)
+	}
+	if !m.RestartXrayOnClientDisable.ValueBool() {
+		t.Fatalf("unexpected restart_xray_on_client_disable: %v", m.RestartXrayOnClientDisable)
+	}
+	expanded := expandPanelGeneral(m)
+	if expanded["restartXrayOnClientDisable"] != true {
+		t.Fatalf("unexpected expanded restartXrayOnClientDisable: %v", expanded["restartXrayOnClientDisable"])
 	}
 }
 

--- a/provider/stream_settings.go
+++ b/provider/stream_settings.go
@@ -284,8 +284,8 @@ func expandRealitySettings(list []any) map[string]any {
 		}
 	}
 	if !hasRealityServerNames(rs) {
-		rs["target"] = "www.apple.com:443"
-		rs["serverNames"] = []any{"www.apple.com", "apple.com"}
+		rs["target"] = "www.amazon.com:443"
+		rs["serverNames"] = []any{"www.amazon.com", "amazon.com"}
 	}
 	if len(rs) == 0 {
 		return nil

--- a/provider/stream_settings_test.go
+++ b/provider/stream_settings_test.go
@@ -58,7 +58,7 @@ func TestExpandRealitySettings_NoTargetDefaults(t *testing.T) {
 	if result == nil {
 		t.Fatalf("expected non-nil")
 	}
-	if result["target"] != "www.apple.com:443" {
+	if result["target"] != "www.amazon.com:443" {
 		t.Fatalf("expected default target, got %v", result["target"])
 	}
 }

--- a/provider/testdata/stream_settings_grpc.json
+++ b/provider/testdata/stream_settings_grpc.json
@@ -4,8 +4,8 @@
   "realitySettings": {
     "show": false,
     "xver": 0,
-    "target": "www.apple.com:443",
-    "serverNames": ["www.apple.com", "apple.com"],
+    "target": "www.amazon.com:443",
+    "serverNames": ["www.amazon.com", "amazon.com"],
     "privateKey": "grpc-reality-privkey",
     "shortIds": ["aabbccdd"],
     "settings": {

--- a/provider/testdata/upstream_contract.json
+++ b/provider/testdata/upstream_contract.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.9.3",
+  "version": "2.9.4",
   "protocols_go_model": [
     "dokodemo-door",
     "http",
@@ -83,6 +83,7 @@
     "id",
     "limitIp",
     "password",
+    "reverse",
     "reset",
     "security",
     "subId",
@@ -95,6 +96,7 @@
     "expireDiff",
     "externalTrafficInformEnable",
     "externalTrafficInformURI",
+    "restartXrayOnClientDisable",
     "ldapAutoCreate",
     "ldapAutoDelete",
     "ldapBaseDN",
@@ -172,7 +174,6 @@
     "basics",
     "dns",
     "outbounds",
-    "reverse",
     "routing"
   ]
 }

--- a/provider/xray_outbounds_schema.go
+++ b/provider/xray_outbounds_schema.go
@@ -45,11 +45,12 @@ type XrayOutboundMux struct {
 }
 
 type XrayFreedomSettings struct {
-	DomainStrategy types.String          `tfsdk:"domain_strategy"`
-	Redirect       types.String          `tfsdk:"redirect"`
-	Fragment       []XrayFreedomFragment `tfsdk:"fragment"`
-	Noises         []XrayFreedomNoise    `tfsdk:"noises"`
-	IPsBlocked     types.List            `tfsdk:"ips_blocked"` // list of string
+	DomainStrategy types.String           `tfsdk:"domain_strategy"`
+	Redirect       types.String           `tfsdk:"redirect"`
+	Fragment       []XrayFreedomFragment  `tfsdk:"fragment"`
+	Noises         []XrayFreedomNoise     `tfsdk:"noises"`
+	FinalRules     []XrayFreedomFinalRule `tfsdk:"final_rule"`
+	IPsBlocked     types.List             `tfsdk:"ips_blocked"` // list of string
 }
 
 type XrayFreedomFragment struct {
@@ -62,6 +63,14 @@ type XrayFreedomNoise struct {
 	Type   types.String `tfsdk:"type"`
 	Packet types.String `tfsdk:"packet"`
 	Delay  types.String `tfsdk:"delay"`
+}
+
+type XrayFreedomFinalRule struct {
+	Action     types.String `tfsdk:"action"`
+	Network    types.String `tfsdk:"network"`
+	Port       types.String `tfsdk:"port"`
+	IP         types.List   `tfsdk:"ip"` // list of string
+	BlockDelay types.String `tfsdk:"block_delay"`
 }
 
 type XrayBlackholeSettings struct {
@@ -89,6 +98,7 @@ type XrayVlessOutSettings struct {
 	ID         types.String `tfsdk:"id"`
 	Flow       types.String `tfsdk:"flow"`
 	Encryption types.String `tfsdk:"encryption"`
+	ReverseTag types.String `tfsdk:"reverse_tag"`
 }
 
 type XrayTrojanOutSettings struct {
@@ -243,7 +253,7 @@ func xrayOutboundsSchema() schema.Schema {
 										Optional:    true,
 										Computed:    true,
 										ElementType: types.StringType,
-										Description: "List of IPs/CIDRs to block (e.g. geoip:cn).",
+										Description: "Deprecated legacy list of IPs/CIDRs to block (e.g. geoip:cn). Use final_rule on 3x-ui v2.9.4+.",
 									},
 								},
 								Blocks: map[string]schema.Block{
@@ -272,6 +282,29 @@ func xrayOutboundsSchema() schema.Schema {
 													Optional: true, Computed: true,
 												},
 												"delay": schema.StringAttribute{
+													Optional: true, Computed: true,
+												},
+											},
+										},
+									},
+									"final_rule": schema.ListNestedBlock{
+										NestedObject: schema.NestedBlockObject{
+											Attributes: map[string]schema.Attribute{
+												"action": schema.StringAttribute{
+													Optional: true, Computed: true,
+												},
+												"network": schema.StringAttribute{
+													Optional: true, Computed: true,
+												},
+												"port": schema.StringAttribute{
+													Optional: true, Computed: true,
+												},
+												"ip": schema.ListAttribute{
+													Optional:    true,
+													Computed:    true,
+													ElementType: types.StringType,
+												},
+												"block_delay": schema.StringAttribute{
 													Optional: true, Computed: true,
 												},
 											},
@@ -347,6 +380,11 @@ func xrayOutboundsSchema() schema.Schema {
 									},
 									"encryption": schema.StringAttribute{
 										Optional: true, Computed: true,
+									},
+									"reverse_tag": schema.StringAttribute{
+										Optional:    true,
+										Computed:    true,
+										Description: "VLESS reverse tag. Stored in 3x-ui as reverse.tag.",
 									},
 								},
 							},
@@ -686,10 +724,39 @@ func expandFreedomSettingsFromModel(list []XrayFreedomSettings) []any {
 			}
 			entry["noises"] = noises
 		}
+		if len(fs.FinalRules) > 0 {
+			entry["final_rule"] = expandFreedomFinalRulesFromModel(fs.FinalRules)
+		}
 		if !fs.IPsBlocked.IsNull() && !fs.IPsBlocked.IsUnknown() {
 			entry["ips_blocked"] = typesListToAnySlice(fs.IPsBlocked)
 		}
 		out = append(out, entry)
+	}
+	return out
+}
+
+func expandFreedomFinalRulesFromModel(list []XrayFreedomFinalRule) []any {
+	out := make([]any, 0, len(list))
+	for _, r := range list {
+		entry := map[string]any{}
+		if !r.Action.IsNull() && !r.Action.IsUnknown() {
+			entry["action"] = r.Action.ValueString()
+		}
+		if !r.Network.IsNull() && !r.Network.IsUnknown() {
+			entry["network"] = r.Network.ValueString()
+		}
+		if !r.Port.IsNull() && !r.Port.IsUnknown() {
+			entry["port"] = r.Port.ValueString()
+		}
+		if !r.IP.IsNull() && !r.IP.IsUnknown() {
+			entry["ip"] = typesListToAnySlice(r.IP)
+		}
+		if !r.BlockDelay.IsNull() && !r.BlockDelay.IsUnknown() {
+			entry["block_delay"] = r.BlockDelay.ValueString()
+		}
+		if len(entry) > 0 {
+			out = append(out, entry)
+		}
 	}
 	return out
 }
@@ -769,6 +836,9 @@ func expandVlessSettingsFromModel(list []XrayVlessOutSettings) []any {
 		}
 		if !vs.Encryption.IsNull() && !vs.Encryption.IsUnknown() {
 			entry["encryption"] = vs.Encryption.ValueString()
+		}
+		if !vs.ReverseTag.IsNull() && !vs.ReverseTag.IsUnknown() {
+			entry["reverse_tag"] = vs.ReverseTag.ValueString()
 		}
 		out = append(out, entry)
 	}
@@ -1148,6 +1218,10 @@ func flattenFreedomSettingsToModel(list []any) []XrayFreedomSettings {
 			fs.Noises = noises
 		}
 
+		if v, ok := raw["final_rule"].([]any); ok && len(v) > 0 {
+			fs.FinalRules = flattenFreedomFinalRulesToModel(v)
+		}
+
 		if v, ok := raw["ips_blocked"]; ok {
 			fs.IPsBlocked = anySliceToTypesList(v)
 		} else {
@@ -1155,6 +1229,40 @@ func flattenFreedomSettingsToModel(list []any) []XrayFreedomSettings {
 		}
 
 		out = append(out, fs)
+	}
+	return out
+}
+
+func flattenFreedomFinalRulesToModel(list []any) []XrayFreedomFinalRule {
+	out := make([]XrayFreedomFinalRule, 0, len(list))
+	for _, item := range list {
+		raw, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		rule := XrayFreedomFinalRule{}
+		if v, ok := raw["action"].(string); ok && v != "" {
+			rule.Action = types.StringValue(v)
+		} else {
+			rule.Action = types.StringNull()
+		}
+		if v, ok := raw["network"].(string); ok && v != "" {
+			rule.Network = types.StringValue(v)
+		} else {
+			rule.Network = types.StringNull()
+		}
+		if v, ok := raw["port"].(string); ok && v != "" {
+			rule.Port = types.StringValue(v)
+		} else {
+			rule.Port = types.StringNull()
+		}
+		rule.IP = anySliceToTypesList(raw["ip"])
+		if v, ok := raw["block_delay"].(string); ok && v != "" {
+			rule.BlockDelay = types.StringValue(v)
+		} else {
+			rule.BlockDelay = types.StringNull()
+		}
+		out = append(out, rule)
 	}
 	return out
 }
@@ -1296,6 +1404,11 @@ func flattenVlessSettingsToModel(list []any) []XrayVlessOutSettings {
 			vs.Encryption = types.StringValue(v)
 		} else {
 			vs.Encryption = types.StringNull()
+		}
+		if v, ok := raw["reverse_tag"].(string); ok && v != "" {
+			vs.ReverseTag = types.StringValue(v)
+		} else {
+			vs.ReverseTag = types.StringNull()
 		}
 
 		out = append(out, vs)
@@ -1735,6 +1848,11 @@ func expandFreedomSettings(m map[string]any) map[string]any {
 			out["noises"] = n
 		}
 	}
+	if v, ok := item["final_rule"]; ok {
+		if rules, ok := v.([]any); ok && len(rules) > 0 {
+			out["finalRules"] = expandFreedomFinalRules(rules)
+		}
+	}
 	if v, ok := item["ips_blocked"]; ok {
 		if list, ok := v.([]any); ok && len(list) > 0 {
 			out["ipsBlocked"] = list
@@ -1742,6 +1860,36 @@ func expandFreedomSettings(m map[string]any) map[string]any {
 	}
 	if len(out) == 0 {
 		return nil
+	}
+	return out
+}
+
+func expandFreedomFinalRules(list []any) []any {
+	out := make([]any, 0, len(list))
+	for _, item := range list {
+		m, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		entry := map[string]any{}
+		if v, ok := m["action"].(string); ok && v != "" {
+			entry["action"] = v
+		}
+		if v, ok := m["network"].(string); ok && v != "" {
+			entry["network"] = v
+		}
+		if v, ok := m["port"].(string); ok && v != "" {
+			entry["port"] = v
+		}
+		if v, ok := m["ip"].([]any); ok && len(v) > 0 {
+			entry["ip"] = expandStringList(v)
+		}
+		if v, ok := m["block_delay"].(string); ok && v != "" {
+			entry["blockDelay"] = v
+		}
+		if len(entry) > 0 {
+			out = append(out, entry)
+		}
 	}
 	return out
 }
@@ -1904,6 +2052,9 @@ func expandVlessOutSettings(m map[string]any) map[string]any {
 	}
 	if v, ok := item["encryption"].(string); ok && v != "" {
 		user["encryption"] = v
+	}
+	if v, ok := item["reverse_tag"].(string); ok && v != "" {
+		user["reverse"] = map[string]any{"tag": v}
 	}
 	if len(user) > 0 {
 		server["users"] = []any{user}
@@ -2278,8 +2429,39 @@ func flattenFreedomSettings(in map[string]any) map[string]any {
 		}
 		out["noises"] = noises
 	}
+	if v, ok := in["finalRules"].([]any); ok && len(v) > 0 {
+		out["final_rule"] = flattenFreedomFinalRules(v)
+	}
 	if v, ok := in["ipsBlocked"].([]any); ok && len(v) > 0 {
 		out["ips_blocked"] = v
+	}
+	return out
+}
+
+func flattenFreedomFinalRules(list []any) []any {
+	out := make([]any, 0, len(list))
+	for _, item := range list {
+		m, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		entry := map[string]any{}
+		if v, ok := m["action"].(string); ok {
+			entry["action"] = v
+		}
+		if v, ok := m["network"].(string); ok {
+			entry["network"] = v
+		}
+		if v, ok := m["port"].(string); ok {
+			entry["port"] = v
+		}
+		if v, ok := m["ip"].([]any); ok {
+			entry["ip"] = v
+		}
+		if v, ok := m["blockDelay"].(string); ok {
+			entry["block_delay"] = v
+		}
+		out = append(out, entry)
 	}
 	return out
 }
@@ -2316,12 +2498,8 @@ func flattenOutboundDNSSettings(in map[string]any) map[string]any {
 
 func flattenVnextFirstUser(in map[string]any, fields ...string) map[string]any {
 	out := map[string]any{}
-	vnext, ok := in["vnext"].([]any)
-	if !ok || len(vnext) == 0 {
-		return out
-	}
-	server, ok := vnext[0].(map[string]any)
-	if !ok {
+	server := firstVnextServer(in)
+	if server == nil {
 		return out
 	}
 	if v, ok := server["address"].(string); ok {
@@ -2344,12 +2522,37 @@ func flattenVnextFirstUser(in map[string]any, fields ...string) map[string]any {
 	return out
 }
 
+func firstVnextServer(in map[string]any) map[string]any {
+	vnext, ok := in["vnext"].([]any)
+	if !ok || len(vnext) == 0 {
+		return nil
+	}
+	server, ok := vnext[0].(map[string]any)
+	if !ok {
+		return nil
+	}
+	return server
+}
+
 func flattenVmessOutSettings(in map[string]any) map[string]any {
 	return flattenVnextFirstUser(in, "id", "security")
 }
 
 func flattenVlessOutSettings(in map[string]any) map[string]any {
-	return flattenVnextFirstUser(in, "id", "flow", "encryption")
+	out := flattenVnextFirstUser(in, "id", "flow", "encryption")
+	server := firstVnextServer(in)
+	if server == nil {
+		return out
+	}
+	users, ok := server["users"].([]any)
+	if ok && len(users) > 0 {
+		if user, ok := users[0].(map[string]any); ok {
+			if tag := reverseTagValue(user["reverse"]); tag != "" {
+				out["reverse_tag"] = tag
+			}
+		}
+	}
+	return out
 }
 
 func flattenServersFirst(in map[string]any, fields ...string) map[string]any {

--- a/provider/xray_routing_schema.go
+++ b/provider/xray_routing_schema.go
@@ -393,6 +393,9 @@ func flattenRoutingRules(list []any) []any {
 		if !ok {
 			continue
 		}
+		if isInternalAPIRoutingRule(m) {
+			continue
+		}
 		entry := map[string]any{}
 
 		if v, ok := m["type"].(string); ok {
@@ -438,4 +441,32 @@ func flattenRoutingRules(list []any) []any {
 		out = append(out, entry)
 	}
 	return out
+}
+
+func isInternalAPIRoutingRule(m map[string]any) bool {
+	outboundTag, ok := m["outboundTag"].(string)
+	if !ok || outboundTag != "api" {
+		return false
+	}
+	return routingValueContainsString(m["inboundTag"], "api")
+}
+
+func routingValueContainsString(raw any, value string) bool {
+	switch v := raw.(type) {
+	case string:
+		return v == value
+	case []string:
+		for _, item := range v {
+			if item == value {
+				return true
+			}
+		}
+	case []any:
+		for _, item := range v {
+			if s, ok := item.(string); ok && s == value {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/provider/xray_settings_test.go
+++ b/provider/xray_settings_test.go
@@ -377,6 +377,32 @@ func TestFlattenXrayRoutingToMap(t *testing.T) {
 	}
 }
 
+func TestFlattenXrayRoutingToMap_SkipsInternalAPIRule(t *testing.T) {
+	data := map[string]any{
+		"rules": []any{
+			map[string]any{
+				"type":        "field",
+				"inboundTag":  []any{"api"},
+				"outboundTag": "api",
+			},
+			map[string]any{
+				"type":        "field",
+				"ip":          []any{"geoip:private"},
+				"outboundTag": "blocked",
+			},
+		},
+	}
+	result := flattenXrayRoutingToMap(data)
+	rules, ok := result["rule"].([]any)
+	if !ok || len(rules) != 1 {
+		t.Fatalf("expected only user-managed rule, got %v", result["rule"])
+	}
+	rule := rules[0].(map[string]any)
+	if rule["outbound_tag"] != "blocked" {
+		t.Fatalf("expected blocked rule to remain, got %v", rule)
+	}
+}
+
 func TestFlattenXrayBasicsToMap(t *testing.T) {
 	data := map[string]any{
 		"log": map[string]any{
@@ -1672,6 +1698,43 @@ func TestExpandOutbounds_FreedomIPsBlocked(t *testing.T) {
 	}
 }
 
+func TestExpandOutbounds_FreedomFinalRules(t *testing.T) {
+	list := []any{
+		map[string]any{
+			"tag":      "direct",
+			"protocol": "freedom",
+			"freedom_settings": []any{
+				map[string]any{
+					"domain_strategy": "AsIs",
+					"final_rule": []any{
+						map[string]any{
+							"action":      "block",
+							"network":     "tcp",
+							"port":        "443",
+							"ip":          []any{"geoip:private"},
+							"block_delay": "0",
+						},
+					},
+				},
+			},
+		},
+	}
+	result := expandOutbounds(list)
+	settings := result[0].(map[string]any)["settings"].(map[string]any)
+	finalRules, ok := settings["finalRules"].([]any)
+	if !ok || len(finalRules) != 1 {
+		t.Fatalf("expected 1 finalRules entry, got %v", settings["finalRules"])
+	}
+	rule := finalRules[0].(map[string]any)
+	if rule["blockDelay"] != "0" {
+		t.Fatalf("expected blockDelay 0, got %v", rule["blockDelay"])
+	}
+	ips, ok := rule["ip"].([]string)
+	if !ok || len(ips) != 1 || ips[0] != "geoip:private" {
+		t.Fatalf("unexpected finalRules ip: %v", rule["ip"])
+	}
+}
+
 func TestFlattenOutbounds_FreedomIPsBlocked(t *testing.T) {
 	data := []any{
 		map[string]any{
@@ -1695,6 +1758,59 @@ func TestFlattenOutbounds_FreedomIPsBlocked(t *testing.T) {
 	}
 	if ipsBlocked[0] != "geoip:cn" || ipsBlocked[1] != "10.0.0.0/8" {
 		t.Fatalf("unexpected ips_blocked values: %v", ipsBlocked)
+	}
+}
+
+func TestFlattenOutbounds_FreedomFinalRules(t *testing.T) {
+	data := []any{
+		map[string]any{
+			"tag":      "direct",
+			"protocol": "freedom",
+			"settings": map[string]any{
+				"domainStrategy": "AsIs",
+				"finalRules": []any{
+					map[string]any{
+						"action":     "block",
+						"network":    "tcp",
+						"port":       "443",
+						"ip":         []any{"geoip:private"},
+						"blockDelay": "0",
+					},
+				},
+			},
+		},
+	}
+	result := flattenXrayOutboundsToMap(data)
+	freedom := result["outbound"].([]any)[0].(map[string]any)["freedom_settings"].([]any)[0].(map[string]any)
+	finalRules, ok := freedom["final_rule"].([]any)
+	if !ok || len(finalRules) != 1 {
+		t.Fatalf("expected 1 final_rule entry, got %v", freedom["final_rule"])
+	}
+	rule := finalRules[0].(map[string]any)
+	if rule["block_delay"] != "0" {
+		t.Fatalf("expected block_delay 0, got %v", rule["block_delay"])
+	}
+}
+
+func TestOutboundsVlessReverseTagRoundtrip(t *testing.T) {
+	input := map[string]any{
+		"outbound": []any{
+			map[string]any{
+				"tag": "vless-out", "protocol": "vless",
+				"vless_settings": []any{map[string]any{
+					"address":     "example.com",
+					"port":        443,
+					"id":          "test-uuid",
+					"encryption":  "none",
+					"reverse_tag": "reverse-a",
+				}},
+			},
+		},
+	}
+	flattened := flattenXrayOutboundsToMap(buildXrayOutboundsJSON(input))
+	vless := flattened["outbound"].([]any)[0].(map[string]any)["vless_settings"].([]any)[0].(map[string]any)
+	if vless["reverse_tag"] != "reverse-a" {
+		t.Fatalf("expected reverse-a, got %v", vless["reverse_tag"])
 	}
 }
 


### PR DESCRIPTION
## Summary
- bump the local Docker/default compatibility target and CI matrix to 3x-ui v2.9.4
- add v2.9.4 schema/API support for VLESS reverse tags, panel restart-on-disable setting, freedom final_rule, and internal api routing rule filtering
- align Reality defaults, drift contract data, docs, and examples with v2.9.4 behavior

## Tests
- task test:unit
- task vet
- task lint
- task build
- git diff --check
- THREEXUI_VERSION=v2.9.4 task test:acc:compat (blocked locally: port 2053 is held by an ssh listener; compose container/network were cleaned up)
