### PR TITLE
fix: preserve redacted panel setting secrets

### DIFF
--- a/provider/client.go
+++ b/provider/client.go
@@ -56,15 +56,17 @@ type ClientConfig struct {
 }
 
 type Client struct {
-	baseURL    *url.URL
-	basePath   string
-	username   string
-	password   string
-	twoFactor  string
-	httpClient *http.Client
-	maxRetries int
-	authMu     sync.Mutex
-	csrfToken  string
+	baseURL          *url.URL
+	basePath         string
+	username         string
+	password         string
+	twoFactor        string
+	httpClient       *http.Client
+	maxRetries       int
+	authMu           sync.Mutex
+	csrfToken        string
+	settingsSecretMu sync.Mutex
+	settingsSecrets  map[string]string
 }
 
 // SetBasePath updates the client's base path to match a new webBasePath.

--- a/provider/resource_settings_tabs.go
+++ b/provider/resource_settings_tabs.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"strings"
 	"sync"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -1039,6 +1040,12 @@ func flattenPanelGeneral(in map[string]any) *PanelGeneralModel {
 
 var settingsMu sync.Mutex
 
+var panelSettingSecretKeys = []string{
+	"ldapPassword",
+	"twoFactorToken",
+	"tgBotToken",
+}
+
 func settingsApplyTyped(
 	ctx context.Context,
 	desired map[string]any,
@@ -1058,10 +1065,12 @@ func settingsApplyTyped(
 		return
 	}
 
-	merged := mergeSettings(existing, desired)
+	merged := mergeSettingsForUpdate(client, existing, desired)
 	if err := client.UpdateSettings(ctx, merged); err != nil {
 		diags.AddError("Failed to update settings", err.Error())
+		return
 	}
+	client.rememberConfiguredSettingSecrets(desired)
 }
 
 func settingsReadTyped(
@@ -1075,6 +1084,98 @@ func settingsReadTyped(
 		return nil
 	}
 	return settings
+}
+
+func mergeSettingsForUpdate(client *Client, existing, desired map[string]any) map[string]any {
+	if client != nil {
+		existing = client.preserveCachedSettingSecrets(existing, desired)
+	}
+	return mergeSettings(existing, desired)
+}
+
+func (c *Client) rememberConfiguredSettingSecrets(settings map[string]any) {
+	if c == nil || len(settings) == 0 {
+		return
+	}
+
+	c.settingsSecretMu.Lock()
+	defer c.settingsSecretMu.Unlock()
+
+	for _, key := range panelSettingSecretKeys {
+		value, ok := settings[key]
+		if !ok {
+			continue
+		}
+
+		secret := stringValue(value)
+		if secret == "" || isRedactedSettingSecretValue(secret) {
+			delete(c.settingsSecrets, key)
+			continue
+		}
+
+		if c.settingsSecrets == nil {
+			c.settingsSecrets = make(map[string]string)
+		}
+		c.settingsSecrets[key] = secret
+	}
+}
+
+func (c *Client) preserveCachedSettingSecrets(existing, desired map[string]any) map[string]any {
+	if c == nil || len(existing) == 0 {
+		return existing
+	}
+
+	c.settingsSecretMu.Lock()
+	defer c.settingsSecretMu.Unlock()
+
+	if len(c.settingsSecrets) == 0 {
+		return existing
+	}
+
+	out := existing
+	copied := false
+	for _, key := range panelSettingSecretKeys {
+		if _, configured := desired[key]; configured {
+			continue
+		}
+
+		cached := c.settingsSecrets[key]
+		if cached == "" || !isRedactedSettingSecret(existing[key]) {
+			continue
+		}
+
+		if !copied {
+			out = make(map[string]any, len(existing))
+			for k, v := range existing {
+				out[k] = v
+			}
+			copied = true
+		}
+		out[key] = cached
+	}
+	return out
+}
+
+func isRedactedSettingSecret(value any) bool {
+	secret, ok := value.(string)
+	if !ok {
+		return value == nil
+	}
+	return isRedactedSettingSecretValue(secret)
+}
+
+func isRedactedSettingSecretValue(secret string) bool {
+	trimmed := strings.TrimSpace(secret)
+	if trimmed == "" {
+		return true
+	}
+	if strings.EqualFold(trimmed, "redacted") || strings.EqualFold(trimmed, "<redacted>") {
+		return true
+	}
+	if len(trimmed) >= 3 && strings.Trim(trimmed, "*") == "" {
+		return true
+	}
+	return false
 }
 
 func preserveSettingSecret(observed, configured types.String) types.String {
@@ -1091,7 +1192,7 @@ func preserveSettingSecret(observed, configured types.String) types.String {
 	if configuredValue == "" && observedValue != "" {
 		return configured
 	}
-	if configuredValue != "" && observedValue == "" {
+	if configuredValue != "" && isRedactedSettingSecretValue(observedValue) {
 		return configured
 	}
 
@@ -1193,6 +1294,7 @@ func (r *PanelGeneralResource) Create(ctx context.Context, req resource.CreateRe
 		return
 	}
 	preservePanelGeneralSecrets(state, &plan)
+	r.client.rememberConfiguredSettingSecrets(expandPanelGeneral(state))
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
 
@@ -1208,6 +1310,7 @@ func (r *PanelGeneralResource) Read(ctx context.Context, req resource.ReadReques
 		return
 	}
 	preservePanelGeneralSecrets(state, &prior)
+	r.client.rememberConfiguredSettingSecrets(expandPanelGeneral(state))
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
 
@@ -1228,6 +1331,7 @@ func (r *PanelGeneralResource) Update(ctx context.Context, req resource.UpdateRe
 		return
 	}
 	preservePanelGeneralSecrets(state, &plan)
+	r.client.rememberConfiguredSettingSecrets(expandPanelGeneral(state))
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
 
@@ -1240,6 +1344,7 @@ func (r *PanelGeneralResource) ImportState(ctx context.Context, _ resource.Impor
 	if state == nil {
 		return
 	}
+	r.client.rememberConfiguredSettingSecrets(expandPanelGeneral(state))
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
 
@@ -1264,12 +1369,13 @@ func (r *PanelGeneralResource) applyPanelGeneral(ctx context.Context, plan *Pane
 		}
 
 		needRestart := panelSettingsNeedRestart(existing, desired)
-		merged := mergeSettings(existing, desired)
+		merged := mergeSettingsForUpdate(r.client, existing, desired)
 		if err := r.client.UpdateSettings(ctx, merged); err != nil {
 			settingsMu.Unlock()
 			diags.AddError("Failed to update settings", err.Error())
 			return
 		}
+		r.client.rememberConfiguredSettingSecrets(desired)
 		settingsMu.Unlock()
 
 		if needRestart {
@@ -1366,6 +1472,7 @@ func (r *PanelSecurityResource) Create(ctx context.Context, req resource.CreateR
 	}
 	state := flattenPanelSecurity(settings)
 	preservePanelSecuritySecrets(state, &plan)
+	r.client.rememberConfiguredSettingSecrets(expandPanelSecurity(state))
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
 
@@ -1382,6 +1489,7 @@ func (r *PanelSecurityResource) Read(ctx context.Context, req resource.ReadReque
 	}
 	state := flattenPanelSecurity(settings)
 	preservePanelSecuritySecrets(state, &prior)
+	r.client.rememberConfiguredSettingSecrets(expandPanelSecurity(state))
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
 
@@ -1406,6 +1514,7 @@ func (r *PanelSecurityResource) Update(ctx context.Context, req resource.UpdateR
 	}
 	state := flattenPanelSecurity(settings)
 	preservePanelSecuritySecrets(state, &plan)
+	r.client.rememberConfiguredSettingSecrets(expandPanelSecurity(state))
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
 
@@ -1419,6 +1528,7 @@ func (r *PanelSecurityResource) ImportState(ctx context.Context, _ resource.Impo
 		return
 	}
 	state := flattenPanelSecurity(settings)
+	r.client.rememberConfiguredSettingSecrets(expandPanelSecurity(state))
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
 
@@ -1488,6 +1598,7 @@ func (r *PanelTelegramResource) Create(ctx context.Context, req resource.CreateR
 	}
 	state := flattenPanelTelegram(settings)
 	preservePanelTelegramSecrets(state, &plan)
+	r.client.rememberConfiguredSettingSecrets(expandPanelTelegram(state))
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
 
@@ -1504,6 +1615,7 @@ func (r *PanelTelegramResource) Read(ctx context.Context, req resource.ReadReque
 	}
 	state := flattenPanelTelegram(settings)
 	preservePanelTelegramSecrets(state, &prior)
+	r.client.rememberConfiguredSettingSecrets(expandPanelTelegram(state))
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
 
@@ -1526,6 +1638,7 @@ func (r *PanelTelegramResource) Update(ctx context.Context, req resource.UpdateR
 	}
 	state := flattenPanelTelegram(settings)
 	preservePanelTelegramSecrets(state, &plan)
+	r.client.rememberConfiguredSettingSecrets(expandPanelTelegram(state))
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
 
@@ -1539,6 +1652,7 @@ func (r *PanelTelegramResource) ImportState(ctx context.Context, _ resource.Impo
 		return
 	}
 	state := flattenPanelTelegram(settings)
+	r.client.rememberConfiguredSettingSecrets(expandPanelTelegram(state))
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
 
@@ -1660,11 +1774,12 @@ func (r *PanelSubscriptionResource) applySubscription(ctx context.Context, plan 
 		diags.AddError("Failed to get settings", err.Error())
 		return
 	}
-	merged := mergeSettings(existing, desired)
+	merged := mergeSettingsForUpdate(r.client, existing, desired)
 	if err := r.client.UpdateSettings(ctx, merged); err != nil {
 		diags.AddError("Failed to update settings", err.Error())
 		return
 	}
+	r.client.rememberConfiguredSettingSecrets(desired)
 
 	// Second apply (workaround for 3x-ui bug).
 	existing2, err := r.client.GetSettings(ctx)
@@ -1672,11 +1787,12 @@ func (r *PanelSubscriptionResource) applySubscription(ctx context.Context, plan 
 		diags.AddError("Failed to get settings (second apply)", err.Error())
 		return
 	}
-	merged2 := mergeSettings(existing2, desired)
+	merged2 := mergeSettingsForUpdate(r.client, existing2, desired)
 	if err := r.client.UpdateSettings(ctx, merged2); err != nil {
 		diags.AddError("Failed to update settings (second apply)", err.Error())
 		return
 	}
+	r.client.rememberConfiguredSettingSecrets(desired)
 }
 
 // ---------------------------------------------------------------------------

--- a/provider/settings_mutex_test.go
+++ b/provider/settings_mutex_test.go
@@ -106,6 +106,102 @@ func TestSettingsMu_NoConcurrentReadModifyWrite(t *testing.T) {
 	}
 }
 
+func TestApplyPanelGeneralPreservesCachedRedactedSettingSecrets(t *testing.T) {
+	var updateBody map[string]any
+	state := map[string]any{
+		"pageSize":       float64(25),
+		"tgBotToken":     "",
+		"twoFactorToken": "********",
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/login":
+			http.SetCookie(w, &http.Cookie{Name: "3x-ui", Value: "sess"})
+			w.Write(okResponse(nil))
+		case "/panel/setting/all":
+			w.Write(okResponse(state))
+		case "/panel/setting/update":
+			if err := json.NewDecoder(r.Body).Decode(&updateBody); err != nil {
+				t.Errorf("decode update body: %v", err)
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			state = updateBody
+			w.Write(okResponse(nil))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv.URL)
+	client.rememberConfiguredSettingSecrets(map[string]any{
+		"tgBotToken":     "telegram-token",
+		"twoFactorToken": "totp-secret",
+	})
+
+	r := &PanelGeneralResource{client: client}
+	plan := &PanelGeneralModel{PageSize: types.Int64Value(50)}
+	var d diag.Diagnostics
+	r.applyPanelGeneral(context.Background(), plan, &d)
+	if d.HasError() {
+		t.Fatalf("applyPanelGeneral: %s", d.Errors()[0].Detail())
+	}
+
+	if updateBody["pageSize"] != float64(50) {
+		t.Fatalf("pageSize = %v, want 50", updateBody["pageSize"])
+	}
+	if updateBody["tgBotToken"] != "telegram-token" {
+		t.Fatalf("tgBotToken = %v, want cached token", updateBody["tgBotToken"])
+	}
+	if updateBody["twoFactorToken"] != "totp-secret" {
+		t.Fatalf("twoFactorToken = %v, want cached token", updateBody["twoFactorToken"])
+	}
+}
+
+func TestSettingsApplyTypedAllowsExplicitSecretClear(t *testing.T) {
+	var updateBody map[string]any
+	state := map[string]any{
+		"remarkModel": "-io",
+		"tgBotToken":  "",
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/login":
+			http.SetCookie(w, &http.Cookie{Name: "3x-ui", Value: "sess"})
+			w.Write(okResponse(nil))
+		case "/panel/setting/all":
+			w.Write(okResponse(state))
+		case "/panel/setting/update":
+			if err := json.NewDecoder(r.Body).Decode(&updateBody); err != nil {
+				t.Errorf("decode update body: %v", err)
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			state = updateBody
+			w.Write(okResponse(nil))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv.URL)
+	client.rememberConfiguredSettingSecrets(map[string]any{"tgBotToken": "telegram-token"})
+
+	var d diag.Diagnostics
+	settingsApplyTyped(context.Background(), map[string]any{"tgBotToken": ""}, &d, client)
+	if d.HasError() {
+		t.Fatalf("settingsApplyTyped: %s", d.Errors()[0].Detail())
+	}
+
+	if updateBody["tgBotToken"] != "" {
+		t.Fatalf("tgBotToken = %v, want explicit empty value", updateBody["tgBotToken"])
+	}
+}
+
 // TestXrayTemplateMu_NoConcurrentReadModifyWrite verifies that
 // xrayTemplateMu serializes concurrent xray template updates from
 // SetXrayOutboundTestURL (called by applyPanelGeneral) and

--- a/provider/settings_tabs_test.go
+++ b/provider/settings_tabs_test.go
@@ -271,10 +271,54 @@ func TestPreserveSettingSecret_ConfiguredNonEmptyObservedEmpty(t *testing.T) {
 	}
 }
 
+func TestPreserveSettingSecret_ConfiguredNonEmptyObservedRedacted(t *testing.T) {
+	got := preserveSettingSecret(types.StringValue("********"), types.StringValue("configured-secret"))
+	if got.ValueString() != "configured-secret" {
+		t.Fatalf("expected configured secret, got %q", got.ValueString())
+	}
+}
+
 func TestPreserveSettingSecret_ObservedDifferentNonEmpty(t *testing.T) {
 	got := preserveSettingSecret(types.StringValue("remote-secret"), types.StringValue("state-secret"))
 	if got.ValueString() != "remote-secret" {
 		t.Fatalf("expected observed secret, got %q", got.ValueString())
+	}
+}
+
+func TestMergeSettingsForUpdate_PreservesCachedRedactedSecret(t *testing.T) {
+	client := &Client{}
+	client.rememberConfiguredSettingSecrets(map[string]any{"tgBotToken": "configured-token"})
+
+	existing := map[string]any{
+		"pageSize":     float64(25),
+		"tgBotToken":   "",
+		"ldapPassword": "********",
+	}
+	client.rememberConfiguredSettingSecrets(map[string]any{"ldapPassword": "configured-password"})
+
+	merged := mergeSettingsForUpdate(client, existing, map[string]any{"pageSize": 50})
+	if merged["tgBotToken"] != "configured-token" {
+		t.Fatalf("expected cached tgBotToken, got %v", merged["tgBotToken"])
+	}
+	if merged["ldapPassword"] != "configured-password" {
+		t.Fatalf("expected cached ldapPassword, got %v", merged["ldapPassword"])
+	}
+	if existing["tgBotToken"] != "" {
+		t.Fatalf("mergeSettingsForUpdate mutated existing tgBotToken: %v", existing["tgBotToken"])
+	}
+}
+
+func TestMergeSettingsForUpdate_DoesNotOverrideDesiredSecret(t *testing.T) {
+	client := &Client{}
+	client.rememberConfiguredSettingSecrets(map[string]any{"tgBotToken": "configured-token"})
+
+	merged := mergeSettingsForUpdate(
+		client,
+		map[string]any{"pageSize": float64(25), "tgBotToken": ""},
+		map[string]any{"pageSize": 50, "tgBotToken": ""},
+	)
+	if merged["tgBotToken"] != "" {
+		t.Fatalf("expected desired empty tgBotToken, got %v", merged["tgBotToken"])
 	}
 }
 


### PR DESCRIPTION
## Summary
- cache known panel setting secrets in memory after reads and writes
- restore cached values before settings update payloads when 3x-ui returns empty/redacted secrets
- keep explicit empty secret values working for intentional clears
- add unit coverage for unrelated settings updates and explicit secret clearing

## Tests
- go test ./provider -run 'Test(PreserveSettingSecret|MergeSettingsForUpdate|ApplyPanelGeneralPreservesCachedRedactedSettingSecrets|SettingsApplyTypedAllowsExplicitSecretClear|SettingsMu_NoConcurrentReadModifyWrite)' -count=1\n- task build\n- commit pre-commit hooks: task fmt, task vet, task lint, task build, whitespace/EOF/conflict checks\n