### PR TITLE
feat: add bootstrap provider credentials

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,6 +175,14 @@ auto re-login on 401/404. 3x-ui v3 rejects unsafe methods with 403 when CSRF is
 missing/stale; the client bootstraps `/csrf-token`, sends `X-CSRF-Token`, and
 refreshes via `/panel/csrf-token` before retrying once.
 
+### Provider authentication and bootstrap credentials
+
+- Provider config defaults `username`/`password` to `admin`/`admin` when omitted.
+- `bootstrap_username` and `bootstrap_password` are explicit opt-in credentials for first-run panel bootstrap. They must be configured together and non-empty; `bootstrap_password` is `Sensitive` and listed in `SECURITY.md`.
+- `Client.LoginWithBootstrapCredentials` uses anonymous `GET /csrf-token` as the panel-generation signal. If a token is returned (3x-ui v3.x), the client tries steady-state `username`/`password` first and falls back to bootstrap credentials only on a panel login rejection. If no token is returned (3x-ui v2.9.x), the client tries bootstrap credentials first to avoid submitting and exposing the desired steady-state password through failed-login logs or Telegram login notifications.
+- Bootstrap fallback is only for ordinary login rejection (`loginFailedError`). HTTP status errors, network errors, and CSRF bootstrap errors surface immediately and must not trigger a credential fallback.
+- Intended workflow: configure provider `username`/`password` with the desired steady-state credentials, add `bootstrap_username`/`bootstrap_password` for the initial panel credentials, and manage `threexui_panel_user` in the same apply so the panel rotates to steady-state credentials. Coverage: `TestLoginWithBootstrapCredentials*`, `TestProviderSensitiveAttributes`, `TestAccPanelUserBootstrapCredentials`.
+
 ### Retry on transient 5xx (write endpoints)
 
 - `Client.withRetry` - single retry policy. Wraps a request function with up to `maxRetries` additional attempts on `*HTTPStatusError` with code 5xx, fixed 500ms backoff, ctx-aware.
@@ -250,7 +258,7 @@ application-layer policy:
 
 - `threexui_panel_user` is a singleton (ID = `"user"`), manages admin credentials.
 - Write-only: no API for reading username/password, Read is a no-op (state preserved).
-- Create uses `r.client.username/password` as old credentials.
+- Create uses `r.client.username/password` as old credentials. In the first-run bootstrap workflow, the provider may be authenticated with bootstrap credentials for the create, then this resource rotates the panel to the steady-state provider `username`/`password`.
 - Update uses previous state as old credentials.
 - After successful `UpdateUser`, client updates its stored credentials for subsequent requests.
 - Delete only clears TF state; credentials on the panel are not reverted.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,7 +32,7 @@ The 3x-ui panel issues and stores secrets that this provider reads and writes. T
 
 | Surface | Sensitive fields |
 | --- | --- |
-| Provider config | `password`, `two_factor_code` |
+| Provider config | `password`, `bootstrap_password`, `two_factor_code` |
 | `threexui_inbound` (`stream_settings.reality_settings`) | `private_key`, auto-generated short IDs |
 | `threexui_inbound` (`wireguard_settings`) | `secret_key`, peer `private_key` |
 | `threexui_inbound_client` | client `id` (UUID), `password` (trojan/ss), `auth` (hysteria) |

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,6 +48,25 @@ resource "threexui_inbound" "vless" {
 
 The provider authenticates to the 3x-ui panel using username and password. These can be provided directly in the provider configuration or via environment variables.
 
+For first-run bootstrap of a fresh panel, you can configure `bootstrap_username` and `bootstrap_password` in addition to the steady-state `username` and `password`. Use this together with `threexui_panel_user` to rotate the panel to the steady-state credentials during the same apply. On 3x-ui v2.9.x, failed logins can expose the submitted password in panel logs or Telegram login notifications, so the provider tries bootstrap credentials before the steady-state credentials. On 3x-ui v3.x, the provider tries steady-state credentials first and falls back to bootstrap credentials only if the panel rejects them. The provider does not silently try `admin`/`admin`; bootstrap credentials must be configured explicitly.
+
+```hcl
+provider "threexui" {
+  endpoint = "http://localhost:2053"
+
+  username = var.threexui_username
+  password = var.threexui_password
+
+  bootstrap_username = "admin"
+  bootstrap_password = "admin"
+}
+
+resource "threexui_panel_user" "admin" {
+  username = var.threexui_username
+  password = var.threexui_password
+}
+```
+
 3x-ui v3 protects login and unsafe API requests with CSRF tokens. The provider fetches and refreshes those tokens automatically; no additional configuration is required.
 
 -> **Note:** The provider has **partial** 2FA support. You can supply a TOTP code via the `two_factor_code` attribute, and it will be sent with the initial login request. However, TOTP codes expire every 30 seconds. Because the provider performs automatic re-login when the session expires (on HTTP 401/404), subsequent logins will fail once the original code is no longer valid. For short-lived operations (a single `terraform apply`) this may work, but long-running or repeated runs will require a fresh code each time.
@@ -58,6 +77,8 @@ The provider authenticates to the 3x-ui panel using username and password. These
 - `base_path` (Optional, String) - Base path configured in 3x-ui (`webBasePath`). Default is `/`.
 - `username` (Optional, String) - 3x-ui username. Default is `admin`.
 - `password` (Optional, String, Sensitive) - 3x-ui password. Default is `admin`.
+- `bootstrap_username` (Optional, String) - Bootstrap username for explicit first-run credential rotation. On 3x-ui v2.9.x it is tried before the primary `username`/`password` to avoid exposing the desired password in failed-login logs; on 3x-ui v3.x it is tried only after the primary credentials are rejected. Must be set together with `bootstrap_password`.
+- `bootstrap_password` (Optional, String, Sensitive) - Bootstrap password for explicit first-run credential rotation. On 3x-ui v2.9.x it is tried before the primary `username`/`password` to avoid exposing the desired password in failed-login logs; on 3x-ui v3.x it is tried only after the primary credentials are rejected. Must be set together with `bootstrap_username`.
 - `two_factor_code` (Optional, String, Sensitive) - TOTP code for 2FA login. Used for the initial authentication request. See the note above about re-login limitations.
 - `insecure_skip_verify` (Optional, Boolean) - Skip TLS certificate verification (useful for self-signed certs). Default is `false`.
 - `request_timeout` (Optional, String) - HTTP request timeout (e.g. `30s`, `1m`). Default is `30s`.

--- a/docs/resources/panel_user.md
+++ b/docs/resources/panel_user.md
@@ -11,7 +11,7 @@ Manages the admin username and password for the 3x-ui panel.
 
 This is a singleton resource -- only one instance should exist per provider. Deleting this resource only removes it from Terraform state; it does not revert the credentials.
 
-~> **Warning:** After applying changes, update the provider's `username` and `password` to match the new values, otherwise the provider will fail to authenticate on the next run.
+~> **Warning:** After applying changes, keep the provider's steady-state `username` and `password` in sync with this resource. For first-run bootstrap of a fresh panel, the provider-level `bootstrap_username` and `bootstrap_password` arguments can authenticate with the initial credentials once, then this resource can rotate the panel to the steady-state credentials during the same apply.
 
 ## Example Usage
 

--- a/provider/acc_panel_user_test.go
+++ b/provider/acc_panel_user_test.go
@@ -2,9 +2,11 @@ package provider
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 // TestAccPanelUser verifies the resource lifecycle (create, update, idempotency)
@@ -37,6 +39,60 @@ resource "threexui_panel_user" "test" {
   password = "admin"
 }
 `,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+// TestAccPanelUserBootstrapCredentials verifies the full first-run bootstrap
+// workflow: provider authentication can start from bootstrap credentials, the
+// panel_user resource rotates the panel to the steady-state credentials, and a
+// follow-up plan can authenticate with the steady-state credentials without
+// editing the provider block.
+func TestAccPanelUserBootstrapCredentials(t *testing.T) {
+	testAccPreCheck(t)
+
+	ctx := context.Background()
+	bootstrapUsername, bootstrapPassword := testAccCredentialsFromEnv()
+	desiredUsername := "bootstrap-admin"
+	desiredPassword := "bootstrap-test-pass"
+
+	t.Cleanup(func() {
+		if err := restorePanelCredentials(ctx, desiredUsername, desiredPassword, bootstrapUsername, bootstrapPassword); err != nil {
+			t.Logf("restore panel credentials after bootstrap test: %s", err)
+		}
+	})
+
+	config := testAccProviderConfigWithBootstrap(
+		desiredUsername,
+		desiredPassword,
+		bootstrapUsername,
+		bootstrapPassword,
+	) + fmt.Sprintf(`
+resource "threexui_panel_user" "bootstrap" {
+  username = %q
+  password = %q
+}
+`, desiredUsername, desiredPassword)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		CheckDestroy: func(_ *terraform.State) error {
+			return restorePanelCredentials(ctx, desiredUsername, desiredPassword, bootstrapUsername, bootstrapPassword)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("threexui_panel_user.bootstrap", "id", "user"),
+					resource.TestCheckResourceAttr("threexui_panel_user.bootstrap", "username", desiredUsername),
+				),
+			},
+			{
+				Config:             config,
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
 			},
@@ -94,4 +150,34 @@ func TestAccPanelUserCredentialChange(t *testing.T) {
 
 func restoreCredentials(ctx context.Context, client *Client) error {
 	return client.UpdateUser(ctx, "testuser", "testpass", "admin", "admin")
+}
+
+func testAccCredentialsFromEnv() (string, string) {
+	username := getenvDefault(envUsername, "admin")
+	password := getenvDefault(envPassword, "admin")
+	return username, password
+}
+
+func restorePanelCredentials(ctx context.Context, currentUsername, currentPassword, targetUsername, targetPassword string) error {
+	currentClient, currentErr := testAccClientWithCredentials(currentUsername, currentPassword)
+	if currentErr == nil {
+		if loginErr := currentClient.Login(ctx); loginErr == nil {
+			return currentClient.UpdateUser(ctx, currentUsername, currentPassword, targetUsername, targetPassword)
+		}
+	}
+
+	targetClient, targetErr := testAccClientWithCredentials(targetUsername, targetPassword)
+	if targetErr == nil {
+		if loginErr := targetClient.Login(ctx); loginErr == nil {
+			return nil
+		}
+	}
+
+	if currentErr != nil {
+		return fmt.Errorf("current credential client init failed: %w", currentErr)
+	}
+	if targetErr != nil {
+		return fmt.Errorf("target credential client init failed: %w", targetErr)
+	}
+	return fmt.Errorf("panel credentials are neither current %q nor target %q", currentUsername, targetUsername)
 }

--- a/provider/acc_test.go
+++ b/provider/acc_test.go
@@ -22,6 +22,13 @@ const (
 	envInsecureSkipVerify = "THREEXUI_INSECURE_SKIP_VERIFY"
 )
 
+func getenvDefault(name, fallback string) string {
+	if v := os.Getenv(name); v != "" {
+		return v
+	}
+	return fallback
+}
+
 func testAccProtoV6ProviderFactories() map[string]func() (tfprotov6.ProviderServer, error) {
 	return map[string]func() (tfprotov6.ProviderServer, error){
 		"threexui": providerserver.NewProtocol6WithError(New("test")()),
@@ -82,6 +89,45 @@ provider "threexui" {
 	return config + "\n"
 }
 
+func testAccProviderConfigWithBootstrap(username, password, bootstrapUsername, bootstrapPassword string) string {
+	endpoint := os.Getenv(envEndpoint)
+	basePath := os.Getenv(envBasePath)
+	insecure := os.Getenv(envInsecureSkipVerify)
+
+	namespace := os.Getenv("TF_ACC_PROVIDER_NAMESPACE")
+	host := os.Getenv("TF_ACC_PROVIDER_HOST")
+	if namespace == "" {
+		namespace = "hashicorp"
+	}
+	if host == "" {
+		host = "registry.terraform.io"
+	}
+
+	config := fmt.Sprintf(`terraform {
+  required_providers {
+    threexui = {
+      source = "%s/%s/threexui"
+    }
+  }
+}
+
+provider "threexui" {
+  endpoint           = %q
+  username           = %q
+  password           = %q
+  bootstrap_username = %q
+  bootstrap_password = %q
+`, host, namespace, endpoint, username, password, bootstrapUsername, bootstrapPassword)
+	if basePath != "" {
+		config += fmt.Sprintf("  base_path          = %q\n", basePath)
+	}
+	if insecure != "" {
+		config += fmt.Sprintf("  insecure_skip_verify = %s\n", insecure)
+	}
+	config += "}\n"
+	return config + "\n"
+}
+
 func testAccClientFromEnv() (*Client, error) {
 	endpoint := os.Getenv(envEndpoint)
 	basePath := os.Getenv(envBasePath)
@@ -119,17 +165,22 @@ func testAccClientFromEnv() (*Client, error) {
 }
 
 func testAccClientFromEnvNoLogin() (*Client, error) {
-	endpoint := os.Getenv(envEndpoint)
-	basePath := os.Getenv(envBasePath)
 	username := os.Getenv(envUsername)
 	password := os.Getenv(envPassword)
-	insecure := os.Getenv(envInsecureSkipVerify)
 	if username == "" {
 		username = "admin"
 	}
 	if password == "" {
 		password = "admin"
 	}
+
+	return testAccClientWithCredentials(username, password)
+}
+
+func testAccClientWithCredentials(username, password string) (*Client, error) {
+	endpoint := os.Getenv(envEndpoint)
+	basePath := os.Getenv(envBasePath)
+	insecure := os.Getenv(envInsecureSkipVerify)
 	insecureBool := false
 	if insecure != "" {
 		if v, err := strconv.ParseBool(insecure); err == nil {

--- a/provider/client.go
+++ b/provider/client.go
@@ -80,6 +80,14 @@ type apiResponse struct {
 	Obj     json.RawMessage `json:"obj"`
 }
 
+type loginFailedError struct {
+	message string
+}
+
+func (e *loginFailedError) Error() string {
+	return e.message
+}
+
 func NewClient(cfg ClientConfig) (*Client, error) {
 	if cfg.Endpoint == "" {
 		return nil, errors.New("endpoint is required")
@@ -128,6 +136,92 @@ func (c *Client) Login(ctx context.Context) error {
 	c.authMu.Lock()
 	defer c.authMu.Unlock()
 	return c.loginLocked(ctx)
+}
+
+type loginCredentialAttempt struct {
+	username  string
+	password  string
+	bootstrap bool
+	label     string
+}
+
+// LoginWithBootstrapCredentials tries primary and opt-in bootstrap credentials
+// in the safest order for the detected panel generation. 3x-ui v2.9 logs the
+// password from failed login attempts, so panels without anonymous CSRF support
+// try bootstrap credentials first and avoid probing with the desired steady
+// state password during fresh-panel bootstrap. 3x-ui v3 has anonymous CSRF
+// bootstrap and redacted failed-login logs, so it keeps the steady-state
+// primary-first behavior.
+func (c *Client) LoginWithBootstrapCredentials(ctx context.Context, bootstrapUsername, bootstrapPassword string) (bool, error) {
+	c.authMu.Lock()
+	defer c.authMu.Unlock()
+
+	primaryUsername := c.username
+	primaryPassword := c.password
+
+	csrfToken, err := c.fetchCSRFToken(ctx, "csrf-token", true)
+	if err != nil {
+		return false, err
+	}
+	c.csrfToken = csrfToken
+
+	primary := loginCredentialAttempt{
+		username: primaryUsername,
+		password: primaryPassword,
+		label:    "primary",
+	}
+	bootstrap := loginCredentialAttempt{
+		username:  bootstrapUsername,
+		password:  bootstrapPassword,
+		bootstrap: true,
+		label:     "bootstrap",
+	}
+
+	attempts := []loginCredentialAttempt{primary, bootstrap}
+	if csrfToken == "" {
+		attempts = []loginCredentialAttempt{bootstrap, primary}
+	}
+
+	usedBootstrap, err := c.loginWithCredentialOrderLocked(ctx, attempts)
+	if err != nil {
+		c.username = primaryUsername
+		c.password = primaryPassword
+		return false, err
+	}
+
+	return usedBootstrap, nil
+}
+
+func (c *Client) loginWithCredentialOrderLocked(ctx context.Context, attempts []loginCredentialAttempt) (bool, error) {
+	var firstErr error
+	var firstLabel string
+	var lastErr error
+
+	for _, attempt := range attempts {
+		c.username = attempt.username
+		c.password = attempt.password
+
+		err := c.loginLocked(ctx)
+		if err == nil {
+			return attempt.bootstrap, nil
+		}
+		if firstErr == nil {
+			firstErr = err
+			firstLabel = attempt.label
+		}
+		lastErr = err
+
+		var loginErr *loginFailedError
+		if !errors.As(err, &loginErr) {
+			return false, err
+		}
+	}
+
+	if len(attempts) == 0 {
+		return false, errors.New("no login credentials configured")
+	}
+	lastLabel := attempts[len(attempts)-1].label
+	return false, fmt.Errorf("%s login failed; %s login also failed: %w", firstLabel, lastLabel, lastErr)
 }
 
 func (c *Client) loginLocked(ctx context.Context) error {
@@ -181,9 +275,9 @@ func (c *Client) loginLocked(ctx context.Context) error {
 	}
 	if !apiResp.Success {
 		if apiResp.Msg == "" {
-			return errors.New("login failed")
+			return &loginFailedError{message: "login failed"}
 		}
-		return errors.New(apiResp.Msg)
+		return &loginFailedError{message: apiResp.Msg}
 	}
 	return nil
 }

--- a/provider/client_test.go
+++ b/provider/client_test.go
@@ -267,6 +267,178 @@ func TestLoginFailure(t *testing.T) {
 	}
 }
 
+func TestLoginWithBootstrapCredentialsUsesBootstrapFirstWithoutCSRF(t *testing.T) {
+	var loginCalls int32
+	var attempts []string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/login" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		atomic.AddInt32(&loginCalls, 1)
+		r.ParseForm()
+		attempts = append(attempts, r.FormValue("username")+":"+r.FormValue("password"))
+		if r.FormValue("username") == "admin" && r.FormValue("password") == "admin" {
+			w.Write(okResponse(nil))
+			return
+		}
+
+		w.Write(failResponse("unexpected credentials"))
+	}))
+	defer srv.Close()
+
+	client, err := NewClient(ClientConfig{
+		Endpoint: srv.URL,
+		BasePath: "/",
+		Username: "desired-admin",
+		Password: "desired-pass",
+		Timeout:  time.Second,
+	})
+	if err != nil {
+		t.Fatalf("NewClient error: %v", err)
+	}
+
+	used, err := client.LoginWithBootstrapCredentials(context.Background(), "admin", "admin")
+	if err != nil {
+		t.Fatalf("LoginWithBootstrapCredentials failed: %v", err)
+	}
+	if !used {
+		t.Fatal("expected bootstrap credentials to be used")
+	}
+	if got := atomic.LoadInt32(&loginCalls); got != 1 {
+		t.Fatalf("expected only the bootstrap login attempt, got %d", got)
+	}
+	if len(attempts) != 1 || attempts[0] != "admin:admin" {
+		t.Fatalf("expected bootstrap credentials first without probing desired password, got %v", attempts)
+	}
+	if client.username != "admin" || client.password != "admin" {
+		t.Fatalf("expected active client credentials to switch to bootstrap credentials")
+	}
+}
+
+func TestLoginWithBootstrapCredentialsPrefersPrimaryWithCSRF(t *testing.T) {
+	var loginCalls int32
+	var attempts []string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/csrf-token":
+			w.Write(okResponse("csrf-token"))
+		case "/login":
+			atomic.AddInt32(&loginCalls, 1)
+			r.ParseForm()
+			attempts = append(attempts, r.FormValue("username")+":"+r.FormValue("password"))
+			if r.Header.Get(csrfHeaderName) != "csrf-token" || r.FormValue("_csrf") != "csrf-token" {
+				w.WriteHeader(http.StatusForbidden)
+				return
+			}
+			if r.FormValue("username") == "desired-admin" && r.FormValue("password") == "desired-pass" {
+				w.Write(okResponse(nil))
+				return
+			}
+			w.Write(failResponse("unexpected credentials"))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	client, err := NewClient(ClientConfig{
+		Endpoint: srv.URL,
+		BasePath: "/",
+		Username: "desired-admin",
+		Password: "desired-pass",
+		Timeout:  time.Second,
+	})
+	if err != nil {
+		t.Fatalf("NewClient error: %v", err)
+	}
+
+	used, err := client.LoginWithBootstrapCredentials(context.Background(), "admin", "admin")
+	if err != nil {
+		t.Fatalf("LoginWithBootstrapCredentials failed: %v", err)
+	}
+	if used {
+		t.Fatal("bootstrap credentials should not be used when primary credentials work")
+	}
+	if got := atomic.LoadInt32(&loginCalls); got != 1 {
+		t.Fatalf("expected only the primary login attempt, got %d", got)
+	}
+	if len(attempts) != 1 || attempts[0] != "desired-admin:desired-pass" {
+		t.Fatalf("expected primary credentials first with CSRF support, got %v", attempts)
+	}
+	if client.username != "desired-admin" || client.password != "desired-pass" {
+		t.Fatalf("expected active client credentials to remain primary credentials")
+	}
+}
+
+func TestLoginWithBootstrapCredentialsDoesNotFallbackOnHTTPError(t *testing.T) {
+	var loginCalls int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/login" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		atomic.AddInt32(&loginCalls, 1)
+		http.Error(w, "temporary failure", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv.URL)
+	used, err := client.LoginWithBootstrapCredentials(context.Background(), "admin", "admin")
+	if err == nil {
+		t.Fatal("expected HTTP 500 login error")
+	}
+	if used {
+		t.Fatal("bootstrap credentials must not be used for HTTP errors")
+	}
+	if got := atomic.LoadInt32(&loginCalls); got != 1 {
+		t.Fatalf("expected exactly 1 login attempt, got %d", got)
+	}
+}
+
+func TestLoginWithBootstrapCredentialsRestoresPrimaryWhenBootstrapFails(t *testing.T) {
+	var loginCalls int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/login" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		atomic.AddInt32(&loginCalls, 1)
+		w.Write(failResponse("wrongUsernameOrPassword"))
+	}))
+	defer srv.Close()
+
+	client, err := NewClient(ClientConfig{
+		Endpoint: srv.URL,
+		BasePath: "/",
+		Username: "desired-admin",
+		Password: "desired-pass",
+		Timeout:  time.Second,
+	})
+	if err != nil {
+		t.Fatalf("NewClient error: %v", err)
+	}
+
+	used, err := client.LoginWithBootstrapCredentials(context.Background(), "admin", "admin")
+	if err == nil {
+		t.Fatal("expected bootstrap login error")
+	}
+	if used {
+		t.Fatal("bootstrap should not be reported as used when it failed")
+	}
+	if got := atomic.LoadInt32(&loginCalls); got != 2 {
+		t.Fatalf("expected bootstrap+primary login attempts, got %d", got)
+	}
+	if client.username != "desired-admin" || client.password != "desired-pass" {
+		t.Fatalf("expected primary credentials to be restored after failed bootstrap login")
+	}
+}
+
 func TestUpdateInboundMaxRetriesZeroDisablesRetry(t *testing.T) {
 	// Operators must be able to opt out of retry entirely (max_retries=0)
 	// so a transient 5xx surfaces immediately without any silent retry.

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -23,6 +23,8 @@ type ThreeXUIProviderModel struct {
 	BasePath           types.String `tfsdk:"base_path"`
 	Username           types.String `tfsdk:"username"`
 	Password           types.String `tfsdk:"password"`
+	BootstrapUsername  types.String `tfsdk:"bootstrap_username"`
+	BootstrapPassword  types.String `tfsdk:"bootstrap_password"`
 	TwoFactorCode      types.String `tfsdk:"two_factor_code"`
 	InsecureSkipVerify types.Bool   `tfsdk:"insecure_skip_verify"`
 	RequestTimeout     types.String `tfsdk:"request_timeout"`
@@ -73,6 +75,15 @@ func (p *ThreeXUIProvider) Schema(_ context.Context, _ provider.SchemaRequest, r
 				Sensitive:   true,
 				Description: "3x-ui password.",
 			},
+			"bootstrap_username": schema.StringAttribute{
+				Optional:    true,
+				Description: "Bootstrap username for explicit first-run credential rotation. On 3x-ui v2.9.x it is tried before the primary username/password to avoid exposing the desired password in failed-login logs; on 3x-ui v3.x it is tried only after the primary credentials are rejected. Must be set together with bootstrap_password.",
+			},
+			"bootstrap_password": schema.StringAttribute{
+				Optional:    true,
+				Sensitive:   true,
+				Description: "Bootstrap password for explicit first-run credential rotation. On 3x-ui v2.9.x it is tried before the primary username/password to avoid exposing the desired password in failed-login logs; on 3x-ui v3.x it is tried only after the primary credentials are rejected. Must be set together with bootstrap_username.",
+			},
 			"two_factor_code": schema.StringAttribute{
 				Optional:    true,
 				Sensitive:   true,
@@ -119,6 +130,40 @@ func (p *ThreeXUIProvider) Configure(ctx context.Context, req provider.Configure
 	password := "admin"
 	if !config.Password.IsNull() && !config.Password.IsUnknown() {
 		password = config.Password.ValueString()
+	}
+	bootstrapUsername := ""
+	bootstrapUsernameSet := false
+	if config.BootstrapUsername.IsUnknown() {
+		resp.Diagnostics.AddError("Invalid bootstrap_username", "bootstrap_username must be known during provider configuration.")
+		return
+	}
+	if !config.BootstrapUsername.IsNull() {
+		bootstrapUsername = config.BootstrapUsername.ValueString()
+		bootstrapUsernameSet = true
+	}
+	bootstrapPassword := ""
+	bootstrapPasswordSet := false
+	if config.BootstrapPassword.IsUnknown() {
+		resp.Diagnostics.AddError("Invalid bootstrap_password", "bootstrap_password must be known during provider configuration.")
+		return
+	}
+	if !config.BootstrapPassword.IsNull() {
+		bootstrapPassword = config.BootstrapPassword.ValueString()
+		bootstrapPasswordSet = true
+	}
+	if bootstrapUsernameSet != bootstrapPasswordSet {
+		resp.Diagnostics.AddError(
+			"Invalid bootstrap credentials",
+			"bootstrap_username and bootstrap_password must be configured together.",
+		)
+		return
+	}
+	if bootstrapUsernameSet && (bootstrapUsername == "" || bootstrapPassword == "") {
+		resp.Diagnostics.AddError(
+			"Invalid bootstrap credentials",
+			"bootstrap_username and bootstrap_password must be non-empty when configured.",
+		)
+		return
 	}
 	twoFactorCode := ""
 	if !config.TwoFactorCode.IsNull() && !config.TwoFactorCode.IsUnknown() {
@@ -167,9 +212,23 @@ func (p *ThreeXUIProvider) Configure(ctx context.Context, req provider.Configure
 		return
 	}
 
-	if err := client.Login(ctx); err != nil {
-		resp.Diagnostics.AddError("Login failed", err.Error())
-		return
+	if bootstrapUsernameSet {
+		usedBootstrap, err := client.LoginWithBootstrapCredentials(ctx, bootstrapUsername, bootstrapPassword)
+		if err != nil {
+			resp.Diagnostics.AddError("Login failed", err.Error())
+			return
+		}
+		if usedBootstrap {
+			resp.Diagnostics.AddWarning(
+				"Bootstrap credentials used",
+				"The provider authenticated with bootstrap_username/bootstrap_password for this run. Rotate the panel to the primary credentials with threexui_panel_user so future runs do not need the bootstrap credentials.",
+			)
+		}
+	} else {
+		if err := client.Login(ctx); err != nil {
+			resp.Diagnostics.AddError("Login failed", err.Error())
+			return
+		}
 	}
 
 	resp.DataSourceData = client

--- a/provider/provider_config_test.go
+++ b/provider/provider_config_test.go
@@ -1,8 +1,11 @@
 package provider
 
 import (
+	"context"
 	"testing"
 	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/provider"
 )
 
 func TestNewClientInvalidEndpoint(t *testing.T) {
@@ -30,5 +33,20 @@ func TestNewClientBasePathNormalization(t *testing.T) {
 	}
 	if client.basePath != "/xui/" {
 		t.Fatalf("expected normalized base path '/xui/', got %q", client.basePath)
+	}
+}
+
+func TestProviderSensitiveAttributes(t *testing.T) {
+	var resp provider.SchemaResponse
+	(&ThreeXUIProvider{}).Schema(context.Background(), provider.SchemaRequest{}, &resp)
+
+	for _, name := range []string{"password", "bootstrap_password", "two_factor_code"} {
+		attr, ok := resp.Schema.Attributes[name]
+		if !ok {
+			t.Fatalf("attribute %q missing on provider", name)
+		}
+		if !attr.IsSensitive() {
+			t.Fatalf("attribute %q must be Sensitive", name)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- add explicit `bootstrap_username` and `bootstrap_password` provider arguments for first-run panel credential bootstrap
- use CSRF detection to keep v3 primary-first while using bootstrap-first on v2.9.x to avoid exposing the desired password through failed login logs/notifications
- warn when bootstrap credentials are used and document the workflow with `threexui_panel_user`
- add unit and acceptance coverage for the first-run bootstrap workflow

Closes discussion context: https://github.com/batonogov/terraform-provider-threexui/discussions/178

## Tests
- task fmt
- task test:unit
- task vet
- task lint
- task build
- git diff --check
- TF_ACC=1 TF_ACC_TERRAFORM_PATH=/opt/homebrew/bin/terraform TF_ACC_PROVIDER_NAMESPACE=batonogov TF_ACC_PROVIDER_HOST=registry.terraform.io THREEXUI_ENDPOINT=http://localhost:2053 THREEXUI_USERNAME=admin THREEXUI_PASSWORD=admin THREEXUI_VERSION=v3.0.2 go test ./provider -run "^TestAccPanelUserBootstrapCredentials$" -count=1 -timeout 180s -v
- TF_ACC=1 TF_ACC_TERRAFORM_PATH=/opt/homebrew/bin/terraform TF_ACC_PROVIDER_NAMESPACE=batonogov TF_ACC_PROVIDER_HOST=registry.terraform.io THREEXUI_ENDPOINT=http://localhost:2053 THREEXUI_USERNAME=admin THREEXUI_PASSWORD=admin THREEXUI_VERSION=v2.9.4 go test ./provider -run "^TestAccPanelUserBootstrapCredentials$" -count=1 -timeout 180s -v
- commit pre-commit hooks
