### PR TITLE
feat: report test coverage to Codecov and add badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }} # see top-of-file note
 
       - name: Run unit tests with coverage
-        run: go test ./provider -skip '^TestAcc' -count=1 -coverprofile=coverage.out -covermode=atomic -v
+        run: task test:unit:coverage
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,8 +90,13 @@ jobs:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }} # see top-of-file note
 
-      - name: Run unit tests
-        run: task test:unit
+      - name: Run unit tests with coverage
+        run: go test ./provider -skip '^TestAcc' -count=1 -coverprofile=coverage.out -covermode=atomic -v
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   acceptance-tests:
     name: Acceptance Tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,7 @@ Use `task` for all routine work:
 - `task vet` runs `go vet ./...`.
 - `task lint` runs `golangci-lint run`.
 - `task test:unit` runs unit tests only.
+- `task test:unit:coverage` runs unit tests with Go coverage profiling (`coverage.out`, atomic mode). Used by CI to generate the coverage report uploaded to Codecov.
 - `task test:acc` starts Docker Compose and runs Terraform acceptance tests.
 - `task test:acc:compat` runs acceptance tests against a selectable 3x-ui version via `THREEXUI_VERSION` (defaults to `v3.0.2`).
 - `task test` runs both unit and acceptance suites.
@@ -436,6 +437,19 @@ retry), CI itself has three safety nets:
 - **Per-job retry** - `acceptance-tests` and `acceptance-matrix` jobs in `.github/workflows/ci.yml` use `nick-fields/retry@v4` with `max_attempts: 2`. Catches the residual flake rate from GHCR pull jitter, one-off SQLite spikes, and runner contention. A green retry should be a no-op for code; if a retry consistently changes behavior, that is a real bug. Diff the two attempt logs.
 - **Flaky test gate** - `skipIfFlaky(t, reason)` in `provider/test_helpers.go` skips when `THREEXUI_SKIP_FLAKY` env is set. Sub-day mitigation when a test starts firing falsely: gate it, push, file a follow-up. Quarantined tests must be tracked (#161 or follow-up); the gate is not a permanent home.
 - **GitHub API rate-limit mitigation** - three layers addressing 3x-ui's unauthenticated GitHub API calls (#184): (1) provider-level `GetXrayVersions` retry with exponential backoff on rate-limit errors, (2) `_warm-xray-version-cache` Taskfile task pre-populates 3x-ui's 15-minute internal cache before tests, (3) `GITHUB_TOKEN` passed to the container via `docker-compose.yaml` env var for forward-compatibility with future 3x-ui versions that may use it for authenticated API calls.
+
+### Codecov Coverage Reporting
+
+The `unit-tests` CI job runs `task test:unit:coverage` to produce a Go coverage
+profile (`coverage.out`, atomic mode) and uploads it to
+[Codecov](https://codecov.io) via `codecov/codecov-action@v6`. Upload is
+authenticated with the `CODECOV_TOKEN` repository secret.
+
+- Coverage is reported on every push to `main` and on every PR (the CI workflow
+  triggers on both).
+- The coverage badge in `README.md` (all locales) links to the Codecov dashboard.
+- `test:unit:coverage` in `Taskfile.yml` is the single source of truth for the
+  coverage command; CI calls it via `task` rather than an inline `go test` invocation.
 
 ## Releases
 

--- a/README.ar_EG.md
+++ b/README.ar_EG.md
@@ -12,6 +12,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/batonogov/terraform-provider-threexui)](https://goreportcard.com/report/github.com/batonogov/terraform-provider-threexui)
 [![Go Version](https://img.shields.io/github/go-mod/go-version/batonogov/terraform-provider-threexui)](go.mod)
 [![Last Commit](https://img.shields.io/github/last-commit/batonogov/terraform-provider-threexui)](https://github.com/batonogov/terraform-provider-threexui/commits/main)
+[![Codecov](https://codecov.io/gh/batonogov/terraform-provider-threexui/branch/main/graph/badge.svg)](https://codecov.io/gh/batonogov/terraform-provider-threexui)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 ## ليه نستخدمه

--- a/README.es_ES.md
+++ b/README.es_ES.md
@@ -10,6 +10,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/batonogov/terraform-provider-threexui)](https://goreportcard.com/report/github.com/batonogov/terraform-provider-threexui)
 [![Go Version](https://img.shields.io/github/go-mod/go-version/batonogov/terraform-provider-threexui)](go.mod)
 [![Last Commit](https://img.shields.io/github/last-commit/batonogov/terraform-provider-threexui)](https://github.com/batonogov/terraform-provider-threexui/commits/main)
+[![Codecov](https://codecov.io/gh/batonogov/terraform-provider-threexui/branch/main/graph/badge.svg)](https://codecov.io/gh/batonogov/terraform-provider-threexui)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 ## Por qué usarlo

--- a/README.fa_IR.md
+++ b/README.fa_IR.md
@@ -12,6 +12,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/batonogov/terraform-provider-threexui)](https://goreportcard.com/report/github.com/batonogov/terraform-provider-threexui)
 [![Go Version](https://img.shields.io/github/go-mod/go-version/batonogov/terraform-provider-threexui)](go.mod)
 [![Last Commit](https://img.shields.io/github/last-commit/batonogov/terraform-provider-threexui)](https://github.com/batonogov/terraform-provider-threexui/commits/main)
+[![Codecov](https://codecov.io/gh/batonogov/terraform-provider-threexui/branch/main/graph/badge.svg)](https://codecov.io/gh/batonogov/terraform-provider-threexui)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 ## چرا از این Provider استفاده کنیم

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/batonogov/terraform-provider-threexui)](https://goreportcard.com/report/github.com/batonogov/terraform-provider-threexui)
 [![Go Version](https://img.shields.io/github/go-mod/go-version/batonogov/terraform-provider-threexui)](go.mod)
 [![Last Commit](https://img.shields.io/github/last-commit/batonogov/terraform-provider-threexui)](https://github.com/batonogov/terraform-provider-threexui/commits/main)
+[![Codecov](https://codecov.io/gh/batonogov/terraform-provider-threexui/branch/main/graph/badge.svg)](https://codecov.io/gh/batonogov/terraform-provider-threexui)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 ## Why use it

--- a/README.ru_RU.md
+++ b/README.ru_RU.md
@@ -10,6 +10,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/batonogov/terraform-provider-threexui)](https://goreportcard.com/report/github.com/batonogov/terraform-provider-threexui)
 [![Go Version](https://img.shields.io/github/go-mod/go-version/batonogov/terraform-provider-threexui)](go.mod)
 [![Last Commit](https://img.shields.io/github/last-commit/batonogov/terraform-provider-threexui)](https://github.com/batonogov/terraform-provider-threexui/commits/main)
+[![Codecov](https://codecov.io/gh/batonogov/terraform-provider-threexui/branch/main/graph/badge.svg)](https://codecov.io/gh/batonogov/terraform-provider-threexui)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 ## Зачем это нужно

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -10,6 +10,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/batonogov/terraform-provider-threexui)](https://goreportcard.com/report/github.com/batonogov/terraform-provider-threexui)
 [![Go Version](https://img.shields.io/github/go-mod/go-version/batonogov/terraform-provider-threexui)](go.mod)
 [![Last Commit](https://img.shields.io/github/last-commit/batonogov/terraform-provider-threexui)](https://github.com/batonogov/terraform-provider-threexui/commits/main)
+[![Codecov](https://codecov.io/gh/batonogov/terraform-provider-threexui/branch/main/graph/badge.svg)](https://codecov.io/gh/batonogov/terraform-provider-threexui)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 ## 为什么用它

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -17,6 +17,11 @@ tasks:
     cmds:
       - go test ./provider -skip '^TestAcc' -count=1 -v
 
+  test:unit:coverage:
+    desc: Запустить unit-тесты с покрытием (coverage.out, atomic mode)
+    cmds:
+      - go test ./provider -skip '^TestAcc' -count=1 -coverprofile=coverage.out -covermode=atomic -v
+
   test:acc:
     desc: Запустить acceptance-тесты (нужен локальный 3x-ui)
     vars:


### PR DESCRIPTION
## Summary

Closes #149

- **CI coverage step**: The `unit-tests` job now runs `go test` with `-coverprofile=coverage.out -covermode=atomic` and uploads the result to Codecov via `codecov/codecov-action@v6.0.0` (pinned to SHA).
- **Codecov badge**: Added to all 6 README variants (en, ru, fa, ar, zh, es), placed before the License badge.

## Post-merge setup

1. Go to [codecov.io](https://codecov.io) and enable the `batonogov/terraform-provider-threexui` repository.
2. (Optional) Add a `CODECOV_TOKEN` repository secret in GitHub Settings > Secrets and variables > Actions. For public repos Codecov works without a token, but adding one enables PR status checks and comment bots.

## Test plan

- [x] `go build ./...` compiles
- [x] `go test ./provider -skip '^TestAcc' -count=1 -coverprofile=coverage.out -covermode=atomic -v` passes (46.2% coverage)
- [ ] CI runs and uploads coverage to Codecov after merge
- [ ] Badge renders on README after Codecov processes the first report