### PR TITLE
feat: enable gosec linter and capture container logs on CI failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,18 @@ jobs:
           retry_on: error
           command: task test:acc
 
+      - name: Capture 3x-ui container logs
+        if: failure()
+        run: docker compose logs 3xui > 3xui-container.log 2>&1
+
+      - name: Upload container logs
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: 3xui-container-logs-acceptance
+          path: 3xui-container.log
+          retention-days: 7
+
   acceptance-matrix:
     name: Compat (${{ matrix.version }})
     runs-on: ubuntu-latest
@@ -189,3 +201,15 @@ jobs:
           max_attempts: 2
           retry_on: error
           command: task test:acc:compat
+
+      - name: Capture 3x-ui container logs
+        if: failure()
+        run: docker compose logs 3xui > 3xui-container.log 2>&1
+
+      - name: Upload container logs
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: 3xui-container-logs-${{ matrix.version }}
+          path: 3xui-container.log
+          retention-days: 7

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,6 +20,7 @@ linters:
     - gocritic
     - errname
     - errorlint
+    - gosec
 
   settings:
     errcheck:
@@ -49,6 +50,14 @@ linters:
         linters:
           - errcheck
           - gocritic
+
+      # G304 is safe in tests: paths are derived from runtime.Caller or
+      # test-controlled environment variables, not user input.
+      # G101 fixtures use realistic-looking but inert test data.
+      # G124 cookies are test-server-only, never exposed to real browsers.
+      - path: _test\.go
+        linters:
+          - gosec
 
       - path: vendor/
         linters:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -312,6 +312,35 @@ Configuration files: `.pre-commit-config.yaml`, `.golangci.yml`,
 - Glob list intentionally covers only `README.md`, `CONTRIBUTING.md`, `docs/**/*.md`. Localized READMEs (`README.<locale>.md`) are not linted because they mirror `README.md` structurally and a single lint pass is the source of truth.
 - `first-line-heading: false` is set because every README starts with the language-switcher line, not a heading.
 
+### gosec (security linter)
+
+`gosec` is enabled in `.golangci.yml` alongside the other linters. It runs as
+part of `task lint` and the CI `lint` job.
+
+**Test-file exclusions** — `gosec` is suppressed for `*_test.go` files because
+the following rules fire false positives on test code:
+
+- **G304** (file path injection) — test file paths are derived from
+  `runtime.Caller` or test-controlled environment variables, never from user
+  input.
+- **G101** (hardcoded credentials) — test fixtures contain realistic-looking
+  but inert data (e.g. placeholder UUIDs, test passwords).
+- **G124** (cookie attributes) — cookies are set on test HTTP servers only,
+  never exposed to real browsers.
+
+**`#nosec` annotations in production code** — a small number of intentional
+suppressions exist in `provider/client.go`:
+
+- `#nosec G402` on `InsecureSkipVerify` in the TLS config — the provider
+  manages self-hosted panels that frequently use self-signed certificates;
+  the user explicitly opts in via the `insecure_skip_verify` provider attribute.
+- `#nosec G104` on `resp.Body.Close()` calls in `doRequest` — these discard
+  response bodies before retrying (CSRF refresh, re-login); the Close error
+  is not actionable at these points.
+
+When adding new `#nosec` annotations, include a comment explaining why the
+finding is a false positive or intentionally accepted.
+
 ## Supply-Chain Pinning
 
 All third-party code that runs in CI or pre-commit is pinned to a commit SHA,
@@ -436,6 +465,7 @@ retry), CI itself has three safety nets:
 - **Per-job retry** - `acceptance-tests` and `acceptance-matrix` jobs in `.github/workflows/ci.yml` use `nick-fields/retry@v4` with `max_attempts: 2`. Catches the residual flake rate from GHCR pull jitter, one-off SQLite spikes, and runner contention. A green retry should be a no-op for code; if a retry consistently changes behavior, that is a real bug. Diff the two attempt logs.
 - **Flaky test gate** - `skipIfFlaky(t, reason)` in `provider/test_helpers.go` skips when `THREEXUI_SKIP_FLAKY` env is set. Sub-day mitigation when a test starts firing falsely: gate it, push, file a follow-up. Quarantined tests must be tracked (#161 or follow-up); the gate is not a permanent home.
 - **GitHub API rate-limit mitigation** - three layers addressing 3x-ui's unauthenticated GitHub API calls (#184): (1) provider-level `GetXrayVersions` retry with exponential backoff on rate-limit errors, (2) `_warm-xray-version-cache` Taskfile task pre-populates 3x-ui's 15-minute internal cache before tests, (3) `GITHUB_TOKEN` passed to the container via `docker-compose.yaml` env var for forward-compatibility with future 3x-ui versions that may use it for authenticated API calls.
+- **Container logs artifact on failure** - both `acceptance-tests` and `acceptance-matrix` jobs capture `docker compose logs 3xui` when a step fails and upload the log as a GitHub Actions artifact (7-day retention). Artifact names: `3xui-container-logs-acceptance` (single job), `3xui-container-logs-<version>` (matrix job). Useful for diagnosing panel-side errors (xray crashes, startup failures, API errors) without re-running the job locally. Uses `actions/upload-artifact` pinned to SHA per the supply-chain policy.
 
 ## Releases
 

--- a/provider/client.go
+++ b/provider/client.go
@@ -108,6 +108,9 @@ func NewClient(cfg ClientConfig) (*Client, error) {
 	}
 
 	transport := http.DefaultTransport.(*http.Transport).Clone()
+	// #nosec G402 -- InsecureSkipVerify is intentional: the provider manages
+	// self-hosted panels that frequently use self-signed certificates. The
+	// user explicitly opts in via the insecure_skip_verify provider attribute.
 	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: cfg.InsecureSkipVerify}
 
 	client := &http.Client{
@@ -886,6 +889,7 @@ func (c *Client) doRequest(ctx context.Context, method, endpoint, contentType st
 	}
 
 	if resp.StatusCode == http.StatusForbidden && requiresCSRF(method) {
+		// #nosec G104 -- discarding body before retry; Close error is not actionable
 		resp.Body.Close()
 		refreshed, refreshErr := c.refreshCSRFToken(ctx)
 		if refreshErr != nil {
@@ -900,6 +904,7 @@ func (c *Client) doRequest(ctx context.Context, method, endpoint, contentType st
 		}
 	}
 	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusNotFound {
+		// #nosec G104 -- discarding body before re-login; Close error is not actionable
 		resp.Body.Close()
 		if err := c.Login(ctx); err != nil {
 			return err
@@ -909,6 +914,7 @@ func (c *Client) doRequest(ctx context.Context, method, endpoint, contentType st
 			return err
 		}
 		if resp.StatusCode == http.StatusForbidden && requiresCSRF(method) {
+			// #nosec G104 -- discarding body before retry; Close error is not actionable
 			resp.Body.Close()
 			refreshed, refreshErr := c.refreshCSRFToken(ctx)
 			if refreshErr != nil {


### PR DESCRIPTION
## Summary

- **Enable gosec linter** in golangci-lint configuration (`.golangci.yml`)
  - Added `gosec` to the enabled linters list
  - Suppressed gosec findings in test files via linter exclusions (G304 file inclusion, G101 hardcoded credentials, G124 cookie attributes — all false positives in test code)
  - Added `#nosec G402` annotation for `InsecureSkipVerify` in TLS config — this is intentional, user opts in via the `insecure_skip_verify` provider attribute
  - Added `#nosec G104` annotations for `resp.Body.Close()` calls in `doRequest` — these discard response bodies before retrying requests, where the Close error is not actionable

- **Capture 3x-ui container logs as CI artifacts** on failure
  - Added post-test steps to both `acceptance-tests` and `acceptance-matrix` jobs
  - Runs `docker compose logs 3xui` and uploads the log file as a GitHub Actions artifact
  - Uses `actions/upload-artifact` pinned to SHA `ea165f8d65b6e75b540449e92b4886f43607fa02` (v4.6.2)
  - Artifacts retained for 7 days, with version-specific names in the matrix job

Closes #148, Closes #165

## Test plan

- [x] `go build ./...` compiles successfully
- [x] `task test:unit` passes all unit tests
- [x] `golangci-lint run` passes with 0 issues (gosec enabled)
- [ ] CI lint job passes with gosec enabled
- [ ] CI acceptance tests produce container log artifacts on failure (manual verification by checking workflow runs)