### PR TITLE
fix: prevent perpetual plan drift from API routing rule

### DIFF
--- a/docs/resources/xray_routing.md
+++ b/docs/resources/xray_routing.md
@@ -32,7 +32,7 @@ resource "threexui_xray_routing" "config" {
 }
 ```
 
-> **Note:** 3x-ui v2.9.4+ manages the internal `api` inbound to `api` outbound routing rule automatically. The provider omits that internal rule from Terraform state to avoid drift.
+> **Note:** The internal routing rule (`inboundTag: ["api"]` → `outboundTag: "api"`) is managed automatically by the provider and must not be included in your configuration. The provider ensures this rule is always present at index 0 on write and omits it from Terraform state on read. On 3x-ui v2.9.4+ the server also preserves this rule via `EnsureStatsRouting`; on older versions the provider injects it to keep Xray stats functional.
 
 ## Argument Reference
 

--- a/provider/xray_routing_schema.go
+++ b/provider/xray_routing_schema.go
@@ -292,7 +292,13 @@ func buildXrayRoutingJSON(d map[string]any) any {
 	}
 	if v, ok := d["rule"]; ok {
 		if list, ok := v.([]any); ok {
-			payload["rules"] = expandRoutingRules(list)
+			rules := expandRoutingRules(list)
+			apiRule := map[string]any{
+				"type":        "field",
+				"inboundTag":  []string{"api"},
+				"outboundTag": "api",
+			}
+			payload["rules"] = append([]any{apiRule}, rules...)
 		}
 	}
 
@@ -304,6 +310,9 @@ func expandRoutingRules(list []any) []any {
 	for _, item := range list {
 		m, ok := item.(map[string]any)
 		if !ok {
+			continue
+		}
+		if isInternalAPIRoutingRule(m) {
 			continue
 		}
 		entry := map[string]any{}
@@ -444,11 +453,15 @@ func flattenRoutingRules(list []any) []any {
 }
 
 func isInternalAPIRoutingRule(m map[string]any) bool {
-	outboundTag, ok := m["outboundTag"].(string)
-	if !ok || outboundTag != "api" {
+	outboundTag, _ := m["outboundTag"].(string)
+	if outboundTag == "" {
+		outboundTag, _ = m["outbound_tag"].(string)
+	}
+	if outboundTag != "api" {
 		return false
 	}
-	return routingValueContainsString(m["inboundTag"], "api")
+	return routingValueContainsString(m["inboundTag"], "api") ||
+		routingValueContainsString(m["inbound_tag"], "api")
 }
 
 func routingValueContainsString(raw any, value string) bool {

--- a/provider/xray_settings_test.go
+++ b/provider/xray_settings_test.go
@@ -514,6 +514,90 @@ func TestExpandRoutingRules(t *testing.T) {
 	}
 }
 
+func TestExpandRoutingRules_SkipsInternalAPIRule(t *testing.T) {
+	list := []any{
+		map[string]any{
+			"type":         "field",
+			"inbound_tag":  []any{"api"},
+			"outbound_tag": "api",
+		},
+		map[string]any{
+			"type":         "field",
+			"ip":           []any{"geoip:private"},
+			"outbound_tag": "blocked",
+		},
+	}
+	result := expandRoutingRules(list)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 rule (api rule filtered), got %d", len(result))
+	}
+	if result[0].(map[string]any)["outboundTag"] != "blocked" {
+		t.Fatalf("expected blocked rule to remain, got %v", result[0])
+	}
+}
+
+func TestBuildXrayRoutingJSON_AlwaysIncludesAPIRule(t *testing.T) {
+	input := map[string]any{
+		"domain_strategy": "AsIs",
+		"rule": []any{
+			map[string]any{"type": "field", "ip": []any{"geoip:private"}, "outbound_tag": "blocked"},
+		},
+	}
+	result := buildXrayRoutingJSON(input).(map[string]any)
+	rules, ok := result["rules"].([]any)
+	if !ok || len(rules) != 2 {
+		t.Fatalf("expected 2 rules (api + user), got %v", result["rules"])
+	}
+	api := rules[0].(map[string]any)
+	if api["outboundTag"] != "api" {
+		t.Fatalf("expected first rule to be api rule, got %v", api)
+	}
+	if api["type"] != "field" {
+		t.Fatalf("expected api rule type field, got %v", api["type"])
+	}
+	tags, ok := api["inboundTag"].([]string)
+	if !ok || len(tags) != 1 || tags[0] != "api" {
+		t.Fatalf("expected inboundTag [api], got %v", api["inboundTag"])
+	}
+	user := rules[1].(map[string]any)
+	if user["outboundTag"] != "blocked" {
+		t.Fatalf("expected second rule to be user rule, got %v", user)
+	}
+}
+
+func TestBuildXrayRoutingJSON_APIRuleRoundtrip(t *testing.T) {
+	input := map[string]any{
+		"domain_strategy": "IPIfNonMatch",
+		"rule": []any{
+			map[string]any{"type": "field", "ip": []any{"geoip:private"}, "outbound_tag": "direct"},
+		},
+	}
+	built := buildXrayRoutingJSON(input)
+	flattened := flattenXrayRoutingToMap(built)
+
+	if flattened["domain_strategy"] != "IPIfNonMatch" {
+		t.Fatalf("expected IPIfNonMatch, got %v", flattened["domain_strategy"])
+	}
+	rules := flattened["rule"].([]any)
+	if len(rules) != 1 {
+		t.Fatalf("expected 1 user rule after flatten (api rule hidden), got %d", len(rules))
+	}
+	if rules[0].(map[string]any)["outbound_tag"] != "direct" {
+		t.Fatalf("expected direct, got %v", rules[0].(map[string]any)["outbound_tag"])
+	}
+
+	// Second build from flattened state should produce identical result
+	built2 := buildXrayRoutingJSON(flattened)
+	flattened2 := flattenXrayRoutingToMap(built2)
+	rules2 := flattened2["rule"].([]any)
+	if len(rules2) != 1 {
+		t.Fatalf("expected 1 user rule after second roundtrip, got %d", len(rules2))
+	}
+	if rules2[0].(map[string]any)["outbound_tag"] != "direct" {
+		t.Fatalf("expected direct after second roundtrip, got %v", rules2[0])
+	}
+}
+
 func TestFlattenWireguardOutSettings(t *testing.T) {
 	in := map[string]any{
 		"secretKey":      "test-key",

--- a/provider/xray_settings_test.go
+++ b/provider/xray_settings_test.go
@@ -598,6 +598,41 @@ func TestBuildXrayRoutingJSON_APIRuleRoundtrip(t *testing.T) {
 	}
 }
 
+func TestBuildXrayRoutingJSON_OnlyAPIRuleNoDrift(t *testing.T) {
+	input := map[string]any{
+		"domain_strategy": "AsIs",
+		"rule": []any{
+			map[string]any{
+				"type":         "field",
+				"inbound_tag":  []any{"api"},
+				"outbound_tag": "api",
+			},
+		},
+	}
+	built := buildXrayRoutingJSON(input).(map[string]any)
+	rules := built["rules"].([]any)
+	if len(rules) != 1 {
+		t.Fatalf("expected 1 rule (api only), got %d", len(rules))
+	}
+	if rules[0].(map[string]any)["outboundTag"] != "api" {
+		t.Fatalf("expected api rule, got %v", rules[0])
+	}
+
+	flattened := flattenXrayRoutingToMap(built)
+	flatRules, _ := flattened["rule"].([]any)
+	if len(flatRules) != 0 {
+		t.Fatalf("expected 0 rules in state after flatten, got %d", len(flatRules))
+	}
+
+	// Second cycle: build from flattened (no user rules) → flatten → should still be empty
+	built2 := buildXrayRoutingJSON(flattened)
+	flattened2 := flattenXrayRoutingToMap(built2)
+	flatRules2, _ := flattened2["rule"].([]any)
+	if len(flatRules2) != 0 {
+		t.Fatalf("expected 0 rules after second roundtrip, got %d", len(flatRules2))
+	}
+}
+
 func TestFlattenWireguardOutSettings(t *testing.T) {
 	in := map[string]any{
 		"secretKey":      "test-key",


### PR DESCRIPTION
## Summary

- Filter internal API routing rule on write (`expandRoutingRules`) in addition to the existing read filter (`flattenRoutingRules`)
- Always ensure the `{type: "field", inboundTag: ["api"], outboundTag: "api"}` rule is present at index 0 in `buildXrayRoutingJSON` output
- Extend `isInternalAPIRoutingRule` to handle both camelCase and snake_case key formats

## Why

The read-side filter in `flattenRoutingRules` hides the API routing rule from Terraform state, but the write path (`expandRoutingRules` → `buildXrayRoutingJSON`) didn't filter or inject it. This caused:

1. **Perpetual plan drift** — if a user explicitly configured the API rule, it was sent to 3x-ui on write but stripped from state on read, producing drift on every plan
2. **API rule deletion on older 3x-ui** — versions without `EnsureStatsRouting` (pre-v2.9.4) would permanently lose the rule, breaking Xray stats/traffic monitoring

Closes #175

## Test plan

- [x] `TestExpandRoutingRules_SkipsInternalAPIRule` — write-side filter strips user-configured API rule
- [x] `TestBuildXrayRoutingJSON_AlwaysIncludesAPIRule` — API rule always at index 0 in output
- [x] `TestBuildXrayRoutingJSON_APIRuleRoundtrip` — double build→flatten roundtrip without drift
- [x] All existing unit tests pass