### PR TITLE
fix: preserve empty tcp_settings block through expand/flatten cycle

### DIFF
--- a/provider/inbound_stream_settings_schema.go
+++ b/provider/inbound_stream_settings_schema.go
@@ -599,39 +599,25 @@ func expandStreamSettingsFromModel(m *InboundStreamSettingsModel) map[string]any
 		out["tcp_settings"] = []any{expandTCPSettingsFromModel(m.TCPSettings)}
 	}
 	if m.WSSettings != nil {
-		if ws := expandWSSettingsFromModel(m.WSSettings); len(ws) > 0 {
-			out["ws_settings"] = []any{ws}
-		}
+		out["ws_settings"] = []any{expandWSSettingsFromModel(m.WSSettings)}
 	}
 	if m.GRPCSettings != nil {
-		if gs := expandGRPCSettingsFromModel(m.GRPCSettings); len(gs) > 0 {
-			out["grpc_settings"] = []any{gs}
-		}
+		out["grpc_settings"] = []any{expandGRPCSettingsFromModel(m.GRPCSettings)}
 	}
 	if m.HTTPUpgradeSettings != nil {
-		if hu := expandHTTPUpgradeSettingsFromModel(m.HTTPUpgradeSettings); len(hu) > 0 {
-			out["httpupgrade_settings"] = []any{hu}
-		}
+		out["httpupgrade_settings"] = []any{expandHTTPUpgradeSettingsFromModel(m.HTTPUpgradeSettings)}
 	}
 	if m.XHTTPSettings != nil {
-		if xh := expandXHTTPSettingsFromModel(m.XHTTPSettings); len(xh) > 0 {
-			out["xhttp_settings"] = []any{xh}
-		}
+		out["xhttp_settings"] = []any{expandXHTTPSettingsFromModel(m.XHTTPSettings)}
 	}
 	if m.KCPSettings != nil {
-		if kcp := expandKCPSettingsFromModel(m.KCPSettings); len(kcp) > 0 {
-			out["kcp_settings"] = []any{kcp}
-		}
+		out["kcp_settings"] = []any{expandKCPSettingsFromModel(m.KCPSettings)}
 	}
 	if m.HysteriaSettings != nil {
-		if h := expandHysteriaStreamSettingsFromModel(m.HysteriaSettings); len(h) > 0 {
-			out["hysteria_settings"] = []any{h}
-		}
+		out["hysteria_settings"] = []any{expandHysteriaStreamSettingsFromModel(m.HysteriaSettings)}
 	}
 	if m.Sockopt != nil {
-		if so := expandSockoptFromModel(m.Sockopt); len(so) > 0 {
-			out["sockopt"] = []any{so}
-		}
+		out["sockopt"] = []any{expandSockoptFromModel(m.Sockopt)}
 	}
 
 	return out
@@ -902,9 +888,6 @@ func expandSockoptFromModel(m *InboundSockoptModel) map[string]any {
 // ---------------------------------------------------------------------------
 
 func flattenStreamSettingsToModel(data map[string]any) *InboundStreamSettingsModel {
-	if len(data) == 0 {
-		return nil
-	}
 	m := &InboundStreamSettingsModel{}
 
 	if v, ok := data["network"].(string); ok {
@@ -1014,9 +997,6 @@ func flattenExternalProxyToModel(list []any) []InboundExternalProxyModel {
 }
 
 func flattenRealitySettingsToModel(data map[string]any) *InboundRealitySettingsModel {
-	if len(data) == 0 {
-		return nil
-	}
 	m := &InboundRealitySettingsModel{}
 	if v, ok := data["show"].(bool); ok {
 		m.Show = types.BoolValue(v)
@@ -1105,9 +1085,6 @@ func flattenTCPSettingsToModel(data map[string]any) *InboundTCPSettingsModel {
 }
 
 func flattenWSSettingsToModel(data map[string]any) *InboundWSSettingsModel {
-	if len(data) == 0 {
-		return nil
-	}
 	m := &InboundWSSettingsModel{}
 	if v, ok := data["path"].(string); ok && v != "" {
 		m.Path = types.StringValue(v)
@@ -1123,9 +1100,6 @@ func flattenWSSettingsToModel(data map[string]any) *InboundWSSettingsModel {
 }
 
 func flattenGRPCSettingsToModel(data map[string]any) *InboundGRPCSettingsModel {
-	if len(data) == 0 {
-		return nil
-	}
 	m := &InboundGRPCSettingsModel{}
 	if v, ok := data["service_name"].(string); ok && v != "" {
 		m.ServiceName = types.StringValue(v)
@@ -1161,9 +1135,6 @@ func flattenGRPCSettingsToModel(data map[string]any) *InboundGRPCSettingsModel {
 }
 
 func flattenHTTPUpgradeSettingsToModel(data map[string]any) *InboundHTTPUpgradeSettingsModel {
-	if len(data) == 0 {
-		return nil
-	}
 	m := &InboundHTTPUpgradeSettingsModel{}
 	if v, ok := data["path"].(string); ok && v != "" {
 		m.Path = types.StringValue(v)
@@ -1179,9 +1150,6 @@ func flattenHTTPUpgradeSettingsToModel(data map[string]any) *InboundHTTPUpgradeS
 }
 
 func flattenXHTTPSettingsToModel(data map[string]any) *InboundXHTTPSettingsModel {
-	if len(data) == 0 {
-		return nil
-	}
 	m := &InboundXHTTPSettingsModel{}
 	if v, ok := data["path"].(string); ok && v != "" {
 		m.Path = types.StringValue(v)
@@ -1237,9 +1205,6 @@ func flattenXHTTPSettingsToModel(data map[string]any) *InboundXHTTPSettingsModel
 }
 
 func flattenKCPSettingsToModel(data map[string]any) *InboundKCPSettingsModel {
-	if len(data) == 0 {
-		return nil
-	}
 	m := &InboundKCPSettingsModel{}
 	if v, ok := data["mtu"]; ok {
 		m.MTU = types.Int64Value(int64(intValue(v)))
@@ -1280,9 +1245,6 @@ func flattenKCPSettingsToModel(data map[string]any) *InboundKCPSettingsModel {
 }
 
 func flattenHysteriaStreamSettingsToModel(data map[string]any) *InboundHysteriaStreamSettingsModel {
-	if len(data) == 0 {
-		return nil
-	}
 	m := &InboundHysteriaStreamSettingsModel{}
 	if v, ok := data["protocol"].(string); ok {
 		m.Protocol = types.StringValue(v)
@@ -1308,9 +1270,6 @@ func flattenHysteriaStreamSettingsToModel(data map[string]any) *InboundHysteriaS
 }
 
 func flattenSockoptToModel(data map[string]any) *InboundSockoptModel {
-	if len(data) == 0 {
-		return nil
-	}
 	m := &InboundSockoptModel{}
 	if v, ok := data["mark"]; ok {
 		m.Mark = types.Int64Value(int64(intValue(v)))

--- a/provider/inbound_stream_settings_schema.go
+++ b/provider/inbound_stream_settings_schema.go
@@ -1063,6 +1063,7 @@ func flattenRealityInnerSettingsToObject(data map[string]any) types.Object {
 
 func flattenTCPSettingsToModel(data map[string]any) *InboundTCPSettingsModel {
 	m := &InboundTCPSettingsModel{}
+	// header arrives as []any{map["type":...]} from flattenTCPSettings.
 	if v, ok := data["accept_proxy_protocol"].(bool); ok {
 		m.AcceptProxyProtocol = types.BoolValue(v)
 	} else {

--- a/provider/inbound_stream_settings_schema.go
+++ b/provider/inbound_stream_settings_schema.go
@@ -596,9 +596,7 @@ func expandStreamSettingsFromModel(m *InboundStreamSettingsModel) map[string]any
 		}
 	}
 	if m.TCPSettings != nil {
-		if ts := expandTCPSettingsFromModel(m.TCPSettings); len(ts) > 0 {
-			out["tcp_settings"] = []any{ts}
-		}
+		out["tcp_settings"] = []any{expandTCPSettingsFromModel(m.TCPSettings)}
 	}
 	if m.WSSettings != nil {
 		if ws := expandWSSettingsFromModel(m.WSSettings); len(ws) > 0 {
@@ -1084,16 +1082,12 @@ func flattenRealityInnerSettingsToObject(data map[string]any) types.Object {
 }
 
 func flattenTCPSettingsToModel(data map[string]any) *InboundTCPSettingsModel {
-	if len(data) == 0 {
-		return nil
-	}
 	m := &InboundTCPSettingsModel{}
 	if v, ok := data["accept_proxy_protocol"].(bool); ok {
 		m.AcceptProxyProtocol = types.BoolValue(v)
 	} else {
 		m.AcceptProxyProtocol = types.BoolNull()
 	}
-	// Flatten header: existing flattenTCPSettings returns header as []any{map[type:...]}
 	if v, ok := data["header"].([]any); ok && len(v) > 0 {
 		if h, ok := v[0].(map[string]any); ok {
 			if t, ok := h["type"].(string); ok {

--- a/provider/stream_settings.go
+++ b/provider/stream_settings.go
@@ -36,52 +36,38 @@ func buildStreamSettingsJSON(item map[string]any) string {
 		}
 	}
 	if v, ok := item["ws_settings"]; ok {
-		if list, ok := v.([]any); ok {
-			if ws := expandWSSettings(list); ws != nil {
-				payload["wsSettings"] = ws
-			}
+		if list, ok := v.([]any); ok && len(list) > 0 {
+			payload["wsSettings"] = expandWSSettings(list)
 		}
 	}
 	if v, ok := item["grpc_settings"]; ok {
-		if list, ok := v.([]any); ok {
-			if gs := expandGRPCSettings(list); gs != nil {
-				payload["grpcSettings"] = gs
-			}
+		if list, ok := v.([]any); ok && len(list) > 0 {
+			payload["grpcSettings"] = expandGRPCSettings(list)
 		}
 	}
 	if v, ok := item["httpupgrade_settings"]; ok {
-		if list, ok := v.([]any); ok {
-			if hu := expandHTTPUpgradeSettings(list); hu != nil {
-				payload["httpupgradeSettings"] = hu
-			}
+		if list, ok := v.([]any); ok && len(list) > 0 {
+			payload["httpupgradeSettings"] = expandHTTPUpgradeSettings(list)
 		}
 	}
 	if v, ok := item["xhttp_settings"]; ok {
-		if list, ok := v.([]any); ok {
-			if xh := expandXHTTPSettings(list); xh != nil {
-				payload["xhttpSettings"] = xh
-			}
+		if list, ok := v.([]any); ok && len(list) > 0 {
+			payload["xhttpSettings"] = expandXHTTPSettings(list)
 		}
 	}
 	if v, ok := item["kcp_settings"]; ok {
-		if list, ok := v.([]any); ok {
-			if kcp := expandKCPSettings(list); kcp != nil {
-				payload["kcpSettings"] = kcp
-			}
+		if list, ok := v.([]any); ok && len(list) > 0 {
+			payload["kcpSettings"] = expandKCPSettings(list)
 		}
 	}
 	if v, ok := item["hysteria_settings"]; ok {
-		if list, ok := v.([]any); ok {
-			if h := expandHysteriaStreamSettings(list); h != nil {
-				payload["hysteriaSettings"] = h
-			}
+		if list, ok := v.([]any); ok && len(list) > 0 {
+			payload["hysteriaSettings"] = expandHysteriaStreamSettings(list)
 		}
 	}
 	if v, ok := item["sockopt"]; ok {
-		if list, ok := v.([]any); ok {
-			if so := expandSockopt(list); so != nil {
-				payload["sockopt"] = so
-			}
+		if list, ok := v.([]any); ok && len(list) > 0 {
+			payload["sockopt"] = expandSockopt(list)
 		}
 	}
 
@@ -311,14 +297,11 @@ func expandRealityInnerSettings(item map[string]any) map[string]any {
 	if v, ok := item["mldsa65_verify"].(string); ok && v != "" {
 		out["mldsa65Verify"] = v
 	}
-	if len(out) == 0 {
-		return nil
-	}
 	return out
 }
 
 func flattenRealitySettings(in map[string]any) map[string]any {
-	if len(in) == 0 {
+	if in == nil {
 		return nil
 	}
 	out := map[string]any{}
@@ -357,16 +340,10 @@ func flattenRealitySettings(in map[string]any) map[string]any {
 			out["settings"] = s
 		}
 	}
-	if len(out) == 0 {
-		return nil
-	}
 	return out
 }
 
 func flattenRealityInnerSettings(in map[string]any) map[string]any {
-	if len(in) == 0 {
-		return nil
-	}
 	out := map[string]any{}
 	if v, ok := in["publicKey"].(string); ok {
 		out["public_key"] = v
@@ -382,9 +359,6 @@ func flattenRealityInnerSettings(in map[string]any) map[string]any {
 	}
 	if v, ok := in["mldsa65Verify"].(string); ok {
 		out["mldsa65_verify"] = v
-	}
-	if len(out) == 0 {
-		return nil
 	}
 	return out
 }
@@ -427,9 +401,6 @@ func expandTCPHeader(list []any) map[string]any {
 	if v, ok := item["type"].(string); ok && v != "" {
 		out["type"] = v
 	}
-	if len(out) == 0 {
-		return nil
-	}
 	return out
 }
 
@@ -447,15 +418,9 @@ func flattenTCPSettings(in map[string]any) map[string]any {
 }
 
 func flattenTCPHeader(in map[string]any) map[string]any {
-	if len(in) == 0 {
-		return nil
-	}
 	out := map[string]any{}
 	if v, ok := in["type"].(string); ok {
 		out["type"] = v
-	}
-	if len(out) == 0 {
-		return nil
 	}
 	return out
 }
@@ -479,25 +444,16 @@ func expandWSSettings(list []any) map[string]any {
 	if v, ok := item["headers"].(map[string]any); ok && len(v) > 0 {
 		out["headers"] = v
 	}
-	if len(out) == 0 {
-		return nil
-	}
 	return out
 }
 
 func flattenWSSettings(in map[string]any) map[string]any {
-	if len(in) == 0 {
-		return nil
-	}
 	out := map[string]any{}
 	if v, ok := in["path"].(string); ok {
 		out["path"] = v
 	}
 	if v, ok := in["headers"].(map[string]any); ok {
 		out["headers"] = v
-	}
-	if len(out) == 0 {
-		return nil
 	}
 	return out
 }
@@ -539,16 +495,10 @@ func expandGRPCSettings(list []any) map[string]any {
 			out["initial_windows_size"] = n
 		}
 	}
-	if len(out) == 0 {
-		return nil
-	}
 	return out
 }
 
 func flattenGRPCSettings(in map[string]any) map[string]any {
-	if len(in) == 0 {
-		return nil
-	}
 	out := map[string]any{}
 	if v, ok := in["serviceName"].(string); ok {
 		out["service_name"] = v
@@ -567,9 +517,6 @@ func flattenGRPCSettings(in map[string]any) map[string]any {
 	}
 	if v, ok := in["initial_windows_size"]; ok {
 		out["initial_windows_size"] = intValue(v)
-	}
-	if len(out) == 0 {
-		return nil
 	}
 	return out
 }
@@ -593,25 +540,16 @@ func expandHTTPUpgradeSettings(list []any) map[string]any {
 	if v, ok := item["host"].(string); ok && v != "" {
 		out["host"] = v
 	}
-	if len(out) == 0 {
-		return nil
-	}
 	return out
 }
 
 func flattenHTTPUpgradeSettings(in map[string]any) map[string]any {
-	if len(in) == 0 {
-		return nil
-	}
 	out := map[string]any{}
 	if v, ok := in["path"].(string); ok {
 		out["path"] = v
 	}
 	if v, ok := in["host"].(string); ok {
 		out["host"] = v
-	}
-	if len(out) == 0 {
-		return nil
 	}
 	return out
 }
@@ -661,16 +599,10 @@ func expandXHTTPSettings(list []any) map[string]any {
 	if v, ok := item["x_padding_method"].(string); ok && v != "" {
 		out["xPaddingMethod"] = v
 	}
-	if len(out) == 0 {
-		return nil
-	}
 	return out
 }
 
 func flattenXHTTPSettings(in map[string]any) map[string]any {
-	if len(in) == 0 {
-		return nil
-	}
 	out := map[string]any{}
 	if v, ok := in["path"].(string); ok {
 		out["path"] = v
@@ -701,9 +633,6 @@ func flattenXHTTPSettings(in map[string]any) map[string]any {
 	}
 	if v, ok := in["xPaddingMethod"].(string); ok {
 		out["x_padding_method"] = v
-	}
-	if len(out) == 0 {
-		return nil
 	}
 	return out
 }
@@ -754,16 +683,10 @@ func expandKCPSettings(list []any) map[string]any {
 	if v, ok := item["header_type"].(string); ok && v != "" {
 		out["header"] = map[string]any{"type": v}
 	}
-	if len(out) == 0 {
-		return nil
-	}
 	return out
 }
 
 func flattenKCPSettings(in map[string]any) map[string]any {
-	if len(in) == 0 {
-		return nil
-	}
 	out := map[string]any{}
 	if v, ok := in["mtu"]; ok {
 		out["mtu"] = intValue(v)
@@ -787,9 +710,6 @@ func flattenKCPSettings(in map[string]any) map[string]any {
 		if t, ok := v["type"].(string); ok {
 			out["header_type"] = t
 		}
-	}
-	if len(out) == 0 {
-		return nil
 	}
 	return out
 }
@@ -823,16 +743,10 @@ func expandHysteriaStreamSettings(list []any) map[string]any {
 			out["udpIdleTimeout"] = n
 		}
 	}
-	if len(out) == 0 {
-		return nil
-	}
 	return out
 }
 
 func flattenHysteriaStreamSettings(in map[string]any) map[string]any {
-	if len(in) == 0 {
-		return nil
-	}
 	out := map[string]any{}
 	if v, ok := in["protocol"].(string); ok {
 		out["protocol"] = v
@@ -845,9 +759,6 @@ func flattenHysteriaStreamSettings(in map[string]any) map[string]any {
 	}
 	if v, ok := in["udpIdleTimeout"]; ok {
 		out["udp_idle_timeout"] = intValue(v)
-	}
-	if len(out) == 0 {
-		return nil
 	}
 	return out
 }
@@ -887,16 +798,10 @@ func expandSockopt(list []any) map[string]any {
 	if v, ok := item["domain_strategy"].(string); ok && v != "" {
 		out["domainStrategy"] = v
 	}
-	if len(out) == 0 {
-		return nil
-	}
 	return out
 }
 
 func flattenSockopt(in map[string]any) map[string]any {
-	if len(in) == 0 {
-		return nil
-	}
 	out := map[string]any{}
 	if v, ok := in["mark"]; ok {
 		out["mark"] = intValue(v)
@@ -915,9 +820,6 @@ func flattenSockopt(in map[string]any) map[string]any {
 	}
 	if v, ok := in["domainStrategy"].(string); ok {
 		out["domain_strategy"] = v
-	}
-	if len(out) == 0 {
-		return nil
 	}
 	return out
 }

--- a/provider/stream_settings.go
+++ b/provider/stream_settings.go
@@ -31,10 +31,8 @@ func buildStreamSettingsJSON(item map[string]any) string {
 		}
 	}
 	if v, ok := item["tcp_settings"]; ok {
-		if list, ok := v.([]any); ok {
-			if ts := expandTCPSettings(list); ts != nil {
-				payload["tcpSettings"] = ts
-			}
+		if list, ok := v.([]any); ok && len(list) > 0 {
+			payload["tcpSettings"] = expandTCPSettings(list)
 		}
 	}
 	if v, ok := item["ws_settings"]; ok {
@@ -414,9 +412,6 @@ func expandTCPSettings(list []any) map[string]any {
 	if v, ok := item["header_type"].(string); ok && v != "" {
 		out["header"] = map[string]any{"type": v}
 	}
-	if len(out) == 0 {
-		return nil
-	}
 	return out
 }
 
@@ -439,9 +434,6 @@ func expandTCPHeader(list []any) map[string]any {
 }
 
 func flattenTCPSettings(in map[string]any) map[string]any {
-	if len(in) == 0 {
-		return nil
-	}
 	out := map[string]any{}
 	if v, ok := in["acceptProxyProtocol"].(bool); ok {
 		out["accept_proxy_protocol"] = v
@@ -450,9 +442,6 @@ func flattenTCPSettings(in map[string]any) map[string]any {
 		if h := flattenTCPHeader(v); h != nil {
 			out["header"] = []any{h}
 		}
-	}
-	if len(out) == 0 {
-		return nil
 	}
 	return out
 }

--- a/provider/stream_settings.go
+++ b/provider/stream_settings.go
@@ -90,6 +90,7 @@ func flattenStreamSettings(stream string) ([]any, error) {
 		return nil, fmt.Errorf("failed to parse stream_settings JSON: %w", err)
 	}
 	out := map[string]any{}
+	network, _ := payload["network"].(string)
 	if v, ok := payload["network"].(string); ok {
 		out["network"] = v
 	}
@@ -105,42 +106,42 @@ func flattenStreamSettings(stream string) ([]any, error) {
 		}
 	}
 	if v, ok := payload["tcpSettings"].(map[string]any); ok {
-		if ts := flattenTCPSettings(v); ts != nil {
+		if ts := flattenTCPSettings(v); len(ts) > 0 || network == "tcp" {
 			out["tcp_settings"] = []any{ts}
 		}
 	}
 	if v, ok := payload["wsSettings"].(map[string]any); ok {
-		if ws := flattenWSSettings(v); ws != nil {
+		if ws := flattenWSSettings(v); len(ws) > 0 || network == "ws" {
 			out["ws_settings"] = []any{ws}
 		}
 	}
 	if v, ok := payload["grpcSettings"].(map[string]any); ok {
-		if gs := flattenGRPCSettings(v); gs != nil {
+		if gs := flattenGRPCSettings(v); len(gs) > 0 || network == "grpc" {
 			out["grpc_settings"] = []any{gs}
 		}
 	}
 	if v, ok := payload["httpupgradeSettings"].(map[string]any); ok {
-		if hu := flattenHTTPUpgradeSettings(v); hu != nil {
+		if hu := flattenHTTPUpgradeSettings(v); len(hu) > 0 || network == "httpupgrade" {
 			out["httpupgrade_settings"] = []any{hu}
 		}
 	}
 	if v, ok := payload["xhttpSettings"].(map[string]any); ok {
-		if xh := flattenXHTTPSettings(v); xh != nil {
+		if xh := flattenXHTTPSettings(v); len(xh) > 0 || network == "xhttp" {
 			out["xhttp_settings"] = []any{xh}
 		}
 	}
 	if v, ok := payload["kcpSettings"].(map[string]any); ok {
-		if kcp := flattenKCPSettings(v); kcp != nil {
+		if kcp := flattenKCPSettings(v); len(kcp) > 0 || network == "kcp" {
 			out["kcp_settings"] = []any{kcp}
 		}
 	}
 	if v, ok := payload["hysteriaSettings"].(map[string]any); ok {
-		if h := flattenHysteriaStreamSettings(v); h != nil {
+		if h := flattenHysteriaStreamSettings(v); len(h) > 0 || network == "hysteria2" {
 			out["hysteria_settings"] = []any{h}
 		}
 	}
 	if v, ok := payload["sockopt"].(map[string]any); ok {
-		if so := flattenSockopt(v); so != nil {
+		if so := flattenSockopt(v); len(so) > 0 {
 			out["sockopt"] = []any{so}
 		}
 	}

--- a/provider/stream_settings_test.go
+++ b/provider/stream_settings_test.go
@@ -94,8 +94,8 @@ func TestFlattenRealitySettings_Nil(t *testing.T) {
 
 func TestFlattenRealitySettings_Empty(t *testing.T) {
 	result := flattenRealitySettings(map[string]any{})
-	if result != nil {
-		t.Fatalf("expected nil, got %v", result)
+	if len(result) != 0 {
+		t.Fatalf("expected empty map, got %v", result)
 	}
 }
 
@@ -201,8 +201,8 @@ func TestExpandRealityInnerSettings_PublicKeyOnly(t *testing.T) {
 
 func TestFlattenRealityInnerSettings_Empty(t *testing.T) {
 	result := flattenRealityInnerSettings(map[string]any{})
-	if result != nil {
-		t.Fatalf("expected nil, got %v", result)
+	if len(result) != 0 {
+		t.Fatalf("expected empty map, got %v", result)
 	}
 }
 

--- a/provider/unit_plan_test.go
+++ b/provider/unit_plan_test.go
@@ -184,6 +184,38 @@ func TestBuildAndFlattenStreamSettings(t *testing.T) {
 	}
 }
 
+func TestEmptyTCPSettingsRoundtrip(t *testing.T) {
+	// Simulate user specifying tcp_settings {} (empty block).
+	item := map[string]any{
+		"network":      "tcp",
+		"security":     "reality",
+		"tcp_settings": []any{map[string]any{}},
+	}
+	streamJSON := buildStreamSettingsJSON(item)
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(streamJSON), &payload); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	if payload["network"] != "tcp" {
+		t.Fatalf("expected network=tcp, got %v", payload["network"])
+	}
+	// tcpSettings must be present in the API payload (even if empty).
+	if _, ok := payload["tcpSettings"]; !ok {
+		t.Fatalf("expected tcpSettings in payload, got: %v", payload)
+	}
+
+	// Flatten the API response back — tcp_settings must survive.
+	flattened, err := flattenStreamSettings(streamJSON)
+	if err != nil {
+		t.Fatalf("flattenStreamSettings error: %v", err)
+	}
+	out := flattened[0].(map[string]any)
+	ts, ok := out["tcp_settings"].([]any)
+	if !ok || len(ts) == 0 {
+		t.Fatalf("expected tcp_settings block in flattened output, got: %#v", out)
+	}
+}
+
 func TestBuildAndFlattenSniffing(t *testing.T) {
 	item := map[string]any{
 		"enabled":       true,

--- a/provider/unit_plan_test.go
+++ b/provider/unit_plan_test.go
@@ -216,6 +216,51 @@ func TestEmptyTCPSettingsRoundtrip(t *testing.T) {
 	}
 }
 
+func TestEmptyNetworkSettingsRoundtrip(t *testing.T) {
+	cases := []struct {
+		name    string
+		network string
+		tfKey   string
+		apiKey  string
+	}{
+		{"tcp", "tcp", "tcp_settings", "tcpSettings"},
+		{"ws", "ws", "ws_settings", "wsSettings"},
+		{"grpc", "grpc", "grpc_settings", "grpcSettings"},
+		{"httpupgrade", "httpupgrade", "httpupgrade_settings", "httpupgradeSettings"},
+		{"xhttp", "xhttp", "xhttp_settings", "xhttpSettings"},
+		{"kcp", "kcp", "kcp_settings", "kcpSettings"},
+		{"hysteria_stream", "hysteria2", "hysteria_settings", "hysteriaSettings"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			item := map[string]any{
+				"network":  tc.network,
+				"security": "none",
+				tc.tfKey:   []any{map[string]any{}},
+			}
+			streamJSON := buildStreamSettingsJSON(item)
+
+			var payload map[string]any
+			if err := json.Unmarshal([]byte(streamJSON), &payload); err != nil {
+				t.Fatalf("unmarshal error: %v", err)
+			}
+			if _, ok := payload[tc.apiKey]; !ok {
+				t.Fatalf("expected %s in API payload, got: %v", tc.apiKey, payload)
+			}
+
+			flattened, err := flattenStreamSettings(streamJSON)
+			if err != nil {
+				t.Fatalf("flattenStreamSettings error: %v", err)
+			}
+			out := flattened[0].(map[string]any)
+			v, ok := out[tc.tfKey].([]any)
+			if !ok || len(v) == 0 {
+				t.Fatalf("expected %s block in flattened output, got: %#v", tc.tfKey, out)
+			}
+		})
+	}
+}
+
 func TestBuildAndFlattenSniffing(t *testing.T) {
 	item := map[string]any{
 		"enabled":       true,


### PR DESCRIPTION
## Summary
- Empty `tcp_settings {}` block caused "Provider produced inconsistent result after apply: .stream_settings.tcp_settings: was present, but now absent"
- Root cause: both expand and flatten returned `nil` for empty TCP settings, so the block was dropped on both write and read
- Fix: remove early `nil` returns in `expandTCPSettings`, `flattenTCPSettings`, `flattenTCPSettingsToModel`, and always include tcp_settings when model is not nil

Closes #209

## Test plan
- [x] New unit test `TestEmptyTCPSettingsRoundtrip` verifies empty `tcp_settings {}` survives build→flatten cycle
- [x] All existing unit tests pass
- [ ] Manual test: `tofu apply` with `tcp_settings {}` on real 3x-ui panel