### PR TITLE
fix: prevent inconsistent result when xray_basics optional blocks omitted

### DIFF
--- a/provider/resource_xray_settings.go
+++ b/provider/resource_xray_settings.go
@@ -152,15 +152,28 @@ func (r *XrayBasicsResource) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 	state := flattenXrayBasics(flat)
+	alignBasicsBlocksWithPlan(state, &plan)
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
 
-func (r *XrayBasicsResource) Read(ctx context.Context, _ resource.ReadRequest, resp *resource.ReadResponse) {
+func (r *XrayBasicsResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var prior XrayBasicsModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &prior)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	flat := xrayReadSection(ctx, &resp.Diagnostics, r.client, xraySectionBasics, flattenXrayBasicsToMap)
 	if flat == nil {
 		return
 	}
 	state := flattenXrayBasics(flat)
+	// Skip alignment during import (prior state has no blocks set).
+	if prior.ID.IsNull() || prior.ID.IsUnknown() {
+		resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+		return
+	}
+	alignBasicsBlocksWithPlan(state, &prior)
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
 
@@ -183,6 +196,7 @@ func (r *XrayBasicsResource) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 	state := flattenXrayBasics(flat)
+	alignBasicsBlocksWithPlan(state, &plan)
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
 

--- a/provider/xray_basics_schema.go
+++ b/provider/xray_basics_schema.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -81,15 +83,27 @@ func xrayBasicsSchema() schema.Schema {
 					Attributes: map[string]schema.Attribute{
 						"loglevel": schema.StringAttribute{
 							Optional: true, Computed: true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
 						},
 						"access": schema.StringAttribute{
 							Optional: true, Computed: true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
 						},
 						"error": schema.StringAttribute{
 							Optional: true, Computed: true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
 						},
 						"dns_log": schema.BoolAttribute{
 							Optional: true, Computed: true,
+							PlanModifiers: []planmodifier.Bool{
+								boolplanmodifier.UseStateForUnknown(),
+							},
 						},
 					},
 				},
@@ -102,15 +116,27 @@ func xrayBasicsSchema() schema.Schema {
 								Attributes: map[string]schema.Attribute{
 									"stats_inbound_downlink": schema.BoolAttribute{
 										Optional: true, Computed: true,
+										PlanModifiers: []planmodifier.Bool{
+											boolplanmodifier.UseStateForUnknown(),
+										},
 									},
 									"stats_inbound_uplink": schema.BoolAttribute{
 										Optional: true, Computed: true,
+										PlanModifiers: []planmodifier.Bool{
+											boolplanmodifier.UseStateForUnknown(),
+										},
 									},
 									"stats_outbound_downlink": schema.BoolAttribute{
 										Optional: true, Computed: true,
+										PlanModifiers: []planmodifier.Bool{
+											boolplanmodifier.UseStateForUnknown(),
+										},
 									},
 									"stats_outbound_uplink": schema.BoolAttribute{
 										Optional: true, Computed: true,
+										PlanModifiers: []planmodifier.Bool{
+											boolplanmodifier.UseStateForUnknown(),
+										},
 									},
 								},
 							},
@@ -123,24 +149,45 @@ func xrayBasicsSchema() schema.Schema {
 									},
 									"handshake": schema.Int64Attribute{
 										Optional: true, Computed: true,
+										PlanModifiers: []planmodifier.Int64{
+											int64planmodifier.UseStateForUnknown(),
+										},
 									},
 									"conn_idle": schema.Int64Attribute{
 										Optional: true, Computed: true,
+										PlanModifiers: []planmodifier.Int64{
+											int64planmodifier.UseStateForUnknown(),
+										},
 									},
 									"uplink_only": schema.Int64Attribute{
 										Optional: true, Computed: true,
+										PlanModifiers: []planmodifier.Int64{
+											int64planmodifier.UseStateForUnknown(),
+										},
 									},
 									"downlink_only": schema.Int64Attribute{
 										Optional: true, Computed: true,
+										PlanModifiers: []planmodifier.Int64{
+											int64planmodifier.UseStateForUnknown(),
+										},
 									},
 									"stats_user_uplink": schema.BoolAttribute{
 										Optional: true, Computed: true,
+										PlanModifiers: []planmodifier.Bool{
+											boolplanmodifier.UseStateForUnknown(),
+										},
 									},
 									"stats_user_downlink": schema.BoolAttribute{
 										Optional: true, Computed: true,
+										PlanModifiers: []planmodifier.Bool{
+											boolplanmodifier.UseStateForUnknown(),
+										},
 									},
 									"buffer_size": schema.Int64Attribute{
 										Optional: true, Computed: true,
+										PlanModifiers: []planmodifier.Int64{
+											int64planmodifier.UseStateForUnknown(),
+										},
 									},
 								},
 							},
@@ -153,6 +200,9 @@ func xrayBasicsSchema() schema.Schema {
 					Attributes: map[string]schema.Attribute{
 						"tag": schema.StringAttribute{
 							Optional: true, Computed: true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
 						},
 						"services": schema.ListAttribute{
 							Optional:    true,
@@ -168,6 +218,36 @@ func xrayBasicsSchema() schema.Schema {
 				},
 			},
 		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// alignBasicsBlocksWithPlan nils out blocks on the state that were not present
+// in the plan. This prevents the "was absent, but now present" inconsistency
+// error that Terraform raises when 3x-ui returns default values for omitted
+// optional blocks.
+// ---------------------------------------------------------------------------
+
+func alignBasicsBlocksWithPlan(state, plan *XrayBasicsModel) {
+	if len(plan.Policy) == 0 {
+		state.Policy = nil
+	} else {
+		planPol := plan.Policy[0]
+		if len(state.Policy) > 0 {
+			statePol := &state.Policy[0]
+			if len(planPol.System) == 0 {
+				statePol.System = nil
+			}
+			if len(planPol.Level) == 0 {
+				statePol.Level = nil
+			}
+		}
+	}
+	if len(plan.API) == 0 {
+		state.API = nil
+	}
+	if len(plan.Stats) == 0 {
+		state.Stats = nil
 	}
 }
 

--- a/provider/xray_settings_test.go
+++ b/provider/xray_settings_test.go
@@ -2065,3 +2065,111 @@ func TestFreedomIPsBlocked_NullHandling(t *testing.T) {
 		t.Fatalf("expected null ips_blocked when key is missing, got %v", flatFS.IPsBlocked)
 	}
 }
+
+func TestAlignBasicsBlocksWithPlan_NilsMissingBlocks(t *testing.T) {
+	state := &XrayBasicsModel{
+		ID: types.StringValue("xray_basics"),
+		Log: []XrayBasicsLog{{
+			Loglevel: types.StringValue("warning"),
+			DNSLog:   types.BoolValue(false),
+		}},
+		Policy: []XrayBasicsPolicy{{
+			System: []XrayBasicsPolicySystem{{
+				StatsInboundDownlink: types.BoolValue(false),
+			}},
+			Level: []XrayBasicsPolicyLevel{{
+				ID:           types.Int64Value(0),
+				Handshake:    types.Int64Value(4),
+				ConnIdle:     types.Int64Value(300),
+				UplinkOnly:   types.Int64Value(2),
+				DownlinkOnly: types.Int64Value(5),
+				BufferSize:   types.Int64Value(4),
+			}},
+		}},
+		API:   []XrayBasicsAPI{{Tag: types.StringValue("api")}},
+		Stats: []XrayBasicsStats{{}},
+	}
+
+	plan := &XrayBasicsModel{
+		ID: types.StringValue("xray_basics"),
+		Log: []XrayBasicsLog{{
+			Loglevel: types.StringValue("warning"),
+			DNSLog:   types.BoolValue(false),
+		}},
+	}
+
+	alignBasicsBlocksWithPlan(state, plan)
+
+	if state.Policy != nil {
+		t.Fatal("expected policy to be nil after alignment")
+	}
+	if state.API != nil {
+		t.Fatal("expected api to be nil after alignment")
+	}
+	if state.Stats != nil {
+		t.Fatal("expected stats to be nil after alignment")
+	}
+	if len(state.Log) != 1 {
+		t.Fatal("expected log to remain")
+	}
+}
+
+func TestAlignBasicsBlocksWithPlan_PreservesPresentBlocks(t *testing.T) {
+	state := &XrayBasicsModel{
+		ID:  types.StringValue("xray_basics"),
+		Log: []XrayBasicsLog{{Loglevel: types.StringValue("warning")}},
+		Policy: []XrayBasicsPolicy{{
+			System: []XrayBasicsPolicySystem{{StatsInboundDownlink: types.BoolValue(false)}},
+			Level:  []XrayBasicsPolicyLevel{{ID: types.Int64Value(0), Handshake: types.Int64Value(4)}},
+		}},
+		API:   []XrayBasicsAPI{{Tag: types.StringValue("api")}},
+		Stats: []XrayBasicsStats{{}},
+	}
+
+	plan := &XrayBasicsModel{
+		ID:     types.StringValue("xray_basics"),
+		Log:    []XrayBasicsLog{{Loglevel: types.StringValue("warning")}},
+		Policy: []XrayBasicsPolicy{{System: []XrayBasicsPolicySystem{{}}, Level: []XrayBasicsPolicyLevel{{ID: types.Int64Value(0)}}}},
+		API:    []XrayBasicsAPI{{Tag: types.StringValue("api")}},
+		Stats:  []XrayBasicsStats{{}},
+	}
+
+	alignBasicsBlocksWithPlan(state, plan)
+
+	if state.Policy == nil {
+		t.Fatal("expected policy to be preserved")
+	}
+	if state.API == nil {
+		t.Fatal("expected api to be preserved")
+	}
+	if state.Stats == nil {
+		t.Fatal("expected stats to be preserved")
+	}
+}
+
+func TestAlignBasicsBlocksWithPlan_NilsNestedPolicyBlocks(t *testing.T) {
+	state := &XrayBasicsModel{
+		ID: types.StringValue("xray_basics"),
+		Policy: []XrayBasicsPolicy{{
+			System: []XrayBasicsPolicySystem{{StatsInboundDownlink: types.BoolValue(false)}},
+			Level:  []XrayBasicsPolicyLevel{{ID: types.Int64Value(0), Handshake: types.Int64Value(4)}},
+		}},
+	}
+
+	plan := &XrayBasicsModel{
+		ID:     types.StringValue("xray_basics"),
+		Policy: []XrayBasicsPolicy{{}},
+	}
+
+	alignBasicsBlocksWithPlan(state, plan)
+
+	if len(state.Policy) == 0 {
+		t.Fatal("expected policy block to remain")
+	}
+	if state.Policy[0].System != nil {
+		t.Fatal("expected policy.system to be nil")
+	}
+	if state.Policy[0].Level != nil {
+		t.Fatal("expected policy.level to be nil")
+	}
+}


### PR DESCRIPTION
## Summary

- Add `UseStateForUnknown()` plan modifiers to all `Optional+Computed` attributes in `xray_basics` schema
- Add `alignBasicsBlocksWithPlan` to nil out blocks not present in the plan (same pattern as `alignBlocksWithPlan` in the inbound resource)
- Apply alignment in Create, Read, and Update handlers (skip during import)

## Problem

3x-ui returns default values for `policy`, `stats`, and `api` blocks even when the user doesn't specify them. This caused Terraform to error with "Provider produced inconsistent result after apply" because block count changed from 0 to 1.

## Test plan

- [x] Unit tests for `alignBasicsBlocksWithPlan` (3 test cases: missing blocks, preserved blocks, nested policy blocks)
- [x] `task pre-commit` passes (fmt, vet, lint, build)
- [ ] Acceptance test with minimal config (only `log {}` block)

Closes #208