### PR TITLE
docs: add OpenTofu registry note to all README locales

### DIFF
--- a/README.ar_EG.md
+++ b/README.ar_EG.md
@@ -85,6 +85,18 @@ resource "threexui_inbound_client" "client_a" {
 }
 ```
 
+<div dir="rtl">
+
+> **لمستخدمي OpenTofu:** استخدموا العنوان الكامل للسجل:
+>
+> ```hcl
+> source = "registry.terraform.io/batonogov/threexui"
+> ```
+>
+> هذا الـprovider غير متوفر في OpenTofu Registry ([السبب](https://github.com/opentofu/registry/issues/3632)).
+
+</div>
+
 ## التوافق
 
 **سياسة الدعم:** الـ provider بيدعم رسميًا تلات سطور فرعية (minor) من 3x-ui: **2.9.x**، **3.0.x** و **3.1.x** — كل patch متنزّل من السطور دي بيتشغّل في matrix الـ acceptance في كل push على `main` و في كل pull request.

--- a/README.es_ES.md
+++ b/README.es_ES.md
@@ -83,6 +83,14 @@ resource "threexui_inbound_client" "client_a" {
 }
 ```
 
+> **Usuarios de OpenTofu:** usen la dirección completa del registro:
+>
+> ```hcl
+> source = "registry.terraform.io/batonogov/threexui"
+> ```
+>
+> El provider no está disponible en el OpenTofu Registry ([motivo](https://github.com/opentofu/registry/issues/3632)).
+
 ## Compatibilidad
 
 **Política de soporte:** el proveedor soporta oficialmente tres líneas menores de 3x-ui: **2.9.x**, **3.0.x** y **3.1.x** — cada parche publicado de las tres líneas se ejecuta en la matriz de aceptación en cada push a `main` y en cada pull request.

--- a/README.fa_IR.md
+++ b/README.fa_IR.md
@@ -85,6 +85,18 @@ resource "threexui_inbound_client" "client_a" {
 }
 ```
 
+<div dir="rtl">
+
+> **برای کاربران OpenTofu:** آدرس کامل رجیستری را مشخص کنید:
+>
+> ```hcl
+> source = "registry.terraform.io/batonogov/threexui"
+> ```
+>
+> این provider در OpenTofu Registry منتشر نشده است ([دلیل](https://github.com/opentofu/registry/issues/3632)).
+
+</div>
+
 ## سازگاری
 
 **سیاست پشتیبانی:** این provider به‌طور رسمی از سه خط مینور 3x-ui پشتیبانی می‌کند: **2.9.x**، **3.0.x** و **3.1.x** — هر patch منتشرشده از هر سه خط در هر push به `main` و هر pull request توسط ماتریس acceptance اجرا می‌شود.

--- a/README.md
+++ b/README.md
@@ -83,6 +83,14 @@ resource "threexui_inbound_client" "client_a" {
 }
 ```
 
+> **OpenTofu users:** use the full registry address:
+>
+> ```hcl
+> source = "registry.terraform.io/batonogov/threexui"
+> ```
+>
+> The provider is not available in the OpenTofu Registry ([why](https://github.com/opentofu/registry/issues/3632)).
+
 ## Compatibility
 
 **Support policy:** the provider officially supports three 3x-ui minor lines: **2.9.x**, **3.0.x**, and **3.1.x** — every released patch in all three lines is exercised by the acceptance matrix on each push to `main` and every pull request.

--- a/README.ru_RU.md
+++ b/README.ru_RU.md
@@ -83,6 +83,14 @@ resource "threexui_inbound_client" "client_a" {
 }
 ```
 
+> **Для пользователей OpenTofu:** указывайте полный адрес реестра:
+>
+> ```hcl
+> source = "registry.terraform.io/batonogov/threexui"
+> ```
+>
+> Провайдер не публикуется в OpenTofu Registry ([причины](https://github.com/opentofu/registry/issues/3632)).
+
 ## Совместимость
 
 **Политика поддержки:** провайдер официально поддерживает три минорные ветки 3x-ui: **2.9.x**, **3.0.x** и **3.1.x** — каждый выпущенный патч всех трёх веток гоняется в acceptance-матрице на каждом push в `main` и на каждом pull request.

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -83,6 +83,14 @@ resource "threexui_inbound_client" "client_a" {
 }
 ```
 
+> **OpenTofu 用户：**请使用完整的 registry 地址：
+>
+> ```hcl
+> source = "registry.terraform.io/batonogov/threexui"
+> ```
+>
+> 本 provider 未发布到 OpenTofu Registry（[原因](https://github.com/opentofu/registry/issues/3632)）。
+
 ## 兼容性
 
 **支持策略:** 本 provider 正式支持三条 3x-ui 次要版本线: **2.9.x**、**3.0.x** 和 **3.1.x** —— 三条版本线下的每个已发布补丁版本都会在每次 push 到 `main` 和每个 pull request 时由 acceptance 矩阵覆盖。


### PR DESCRIPTION
## Summary

- Add a note in all 6 README locales telling OpenTofu users to specify the full registry address `registry.terraform.io/batonogov/threexui`
- Link to [opentofu/registry#3632](https://github.com/opentofu/registry/issues/3632) explaining why the provider is not in the OpenTofu Registry

## Test plan

- [x] `markdownlint` passes on all README files
- [x] `task build` succeeds