### PR TITLE
docs: update CLAUDE.md with missing architecture details and test patterns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,9 @@ Registry: `batonogov/threexui`. All provider code lives in `provider/`.
 | `task fmt` | `gofmt -w provider/*.go` |
 | `task vet` | `go vet ./...` |
 | `task lint` | `golangci-lint run` |
+| `task test` | Unit + acceptance tests |
 | `task test:unit` | Unit tests (no Docker/Terraform needed) |
+| `task test:unit:coverage` | Unit tests with coverage (`coverage.out`) |
 | `task test:acc` | Acceptance tests (Docker lifecycle included) |
 | `task pre-commit` | fmt + vet + lint + build |
 
@@ -61,6 +63,11 @@ Four resources — `panel_general`, `panel_security`, `panel_telegram`,
 - Each is a singleton with ID `"settings"`.
 - Shared CRUD via `settingsApplyTyped` / `settingsReadTyped`.
 - Delete only clears TF state — does not reset panel settings.
+- `settingsMu` serializes read-modify-write (separate from `xrayTemplateMu`).
+- `settingsSecrets` on Client caches secret values from GET responses (3x-ui masks them)
+  so they can be replayed in subsequent PUT requests.
+- Changing `web_base_path` in `panel_general` triggers a panel restart and updates
+  the provider client's base path via `SetBasePath` + `WaitForReady`.
 
 ### Xray settings (two modes)
 
@@ -74,6 +81,12 @@ Six xray resources share `resource_xray_settings.go`. Each section has its own
 
 `xrayTemplateMu` serializes read-modify-write to prevent race conditions.
 
+### Xray version (`resource_xray_version.go`)
+
+Separate resource — singleton with ID `"xray_version"`. Calls `InstallXray` + polls
+`waitForXrayVersion` until the version matches. Delete is a no-op with a warning
+(removing from state does NOT revert the installed version).
+
 ### Panel user (write-only)
 
 `threexui_panel_user` — no read API exists. Read is a no-op, state is preserved
@@ -84,6 +97,8 @@ previous state.
 
 Cookie auth, auto re-login on 401/404, CSRF handling for 3x-ui v3.
 Supports bootstrap credentials for first-run panel setup.
+Provider attributes: `two_factor_code` (TOTP for 2FA login), `max_retries`
+(default 1, max 10), `request_timeout`.
 Three retry layers: 5xx on idempotent writes, read-after-write for SQLite
 visibility lag, rate-limit retry for `GetXrayVersions`.
 Client API auto-detection: probes `/panel/api/clients/list` to detect v3.1.0+
@@ -112,6 +127,8 @@ These are non-obvious constraints that have caused real bugs.
 | Subscription resource does **double apply** | Workaround: `sub_json_enable` not saved on first apply with `sub_enable` |
 | Policy levels: `{"0": {...}}` ↔ `[{id=0}]` | Xray JSON uses a map, TF uses a list |
 | DNS servers: string vs object | Address-only → string; with extra fields → object |
+| `xray_version` delete is a no-op | Removing from state does NOT revert the installed xray version |
+| `web_base_path` change triggers panel restart | Must also update provider `base_path`; code auto-updates client |
 
 **Always check 3x-ui source snapshots** (`3x-ui-<version>/`) before assuming API behavior.
 Key paths: `web/service/`, `web/controller/`, `web/entity/model/`, `xray/`.
@@ -149,6 +166,12 @@ Imperative mood, concise subjects.
   `ProtoV6ProviderFactories` (not `ProviderFactories`).
 - Version-aware skipping: `requireMinVersion(t, "vX.Y.Z")` for features from
   specific 3x-ui versions. Currently supported: **v2.9.x**, **v3.0.x**, and **v3.1.x**.
+- Flaky test quarantine: `skipOnFlakyVersions(t, ...)` / `skipIfFlaky(t)` with
+  `THREEXUI_SKIP_FLAKY` env var to skip known-broken upstream versions.
+- Protocol matrix test (`resource_inbound_matrix_test.go`): comprehensive
+  create/update/import round-trip for every protocol.
+- Destroy checks use `destroyVisibilityAttempts` (60 × 500 ms) to handle
+  SQLite visibility lag after delete.
 
 ### Supply chain
 

--- a/README.ar_EG.md
+++ b/README.ar_EG.md
@@ -85,6 +85,18 @@ resource "threexui_inbound_client" "client_a" {
 }
 ```
 
+<div dir="rtl">
+
+> **لمستخدمي OpenTofu:** استخدموا العنوان الكامل للسجل:
+>
+> ```hcl
+> source = "registry.terraform.io/batonogov/threexui"
+> ```
+>
+> هذا الـprovider غير متوفر في OpenTofu Registry ([السبب](https://github.com/opentofu/registry/issues/3632)).
+
+</div>
+
 ## التوافق
 
 **سياسة الدعم:** الـ provider بيدعم رسميًا تلات سطور فرعية (minor) من 3x-ui: **2.9.x**، **3.0.x** و **3.1.x** — كل patch متنزّل من السطور دي بيتشغّل في matrix الـ acceptance في كل push على `main` و في كل pull request.

--- a/README.es_ES.md
+++ b/README.es_ES.md
@@ -83,6 +83,14 @@ resource "threexui_inbound_client" "client_a" {
 }
 ```
 
+> **Usuarios de OpenTofu:** usen la dirección completa del registro:
+>
+> ```hcl
+> source = "registry.terraform.io/batonogov/threexui"
+> ```
+>
+> El provider no está disponible en el OpenTofu Registry ([motivo](https://github.com/opentofu/registry/issues/3632)).
+
 ## Compatibilidad
 
 **Política de soporte:** el proveedor soporta oficialmente tres líneas menores de 3x-ui: **2.9.x**, **3.0.x** y **3.1.x** — cada parche publicado de las tres líneas se ejecuta en la matriz de aceptación en cada push a `main` y en cada pull request.

--- a/README.fa_IR.md
+++ b/README.fa_IR.md
@@ -85,6 +85,18 @@ resource "threexui_inbound_client" "client_a" {
 }
 ```
 
+<div dir="rtl">
+
+> **برای کاربران OpenTofu:** آدرس کامل رجیستری را مشخص کنید:
+>
+> ```hcl
+> source = "registry.terraform.io/batonogov/threexui"
+> ```
+>
+> این provider در OpenTofu Registry منتشر نشده است ([دلیل](https://github.com/opentofu/registry/issues/3632)).
+
+</div>
+
 ## سازگاری
 
 **سیاست پشتیبانی:** این provider به‌طور رسمی از سه خط مینور 3x-ui پشتیبانی می‌کند: **2.9.x**، **3.0.x** و **3.1.x** — هر patch منتشرشده از هر سه خط در هر push به `main` و هر pull request توسط ماتریس acceptance اجرا می‌شود.

--- a/README.md
+++ b/README.md
@@ -83,6 +83,14 @@ resource "threexui_inbound_client" "client_a" {
 }
 ```
 
+> **OpenTofu users:** use the full registry address:
+>
+> ```hcl
+> source = "registry.terraform.io/batonogov/threexui"
+> ```
+>
+> The provider is not available in the OpenTofu Registry ([why](https://github.com/opentofu/registry/issues/3632)).
+
 ## Compatibility
 
 **Support policy:** the provider officially supports three 3x-ui minor lines: **2.9.x**, **3.0.x**, and **3.1.x** — every released patch in all three lines is exercised by the acceptance matrix on each push to `main` and every pull request.

--- a/README.ru_RU.md
+++ b/README.ru_RU.md
@@ -83,6 +83,14 @@ resource "threexui_inbound_client" "client_a" {
 }
 ```
 
+> **Для пользователей OpenTofu:** указывайте полный адрес реестра:
+>
+> ```hcl
+> source = "registry.terraform.io/batonogov/threexui"
+> ```
+>
+> Провайдер не публикуется в OpenTofu Registry ([причины](https://github.com/opentofu/registry/issues/3632)).
+
 ## Совместимость
 
 **Политика поддержки:** провайдер официально поддерживает три минорные ветки 3x-ui: **2.9.x**, **3.0.x** и **3.1.x** — каждый выпущенный патч всех трёх веток гоняется в acceptance-матрице на каждом push в `main` и на каждом pull request.

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -83,6 +83,14 @@ resource "threexui_inbound_client" "client_a" {
 }
 ```
 
+> **OpenTofu 用户：**请使用完整的 registry 地址：
+>
+> ```hcl
+> source = "registry.terraform.io/batonogov/threexui"
+> ```
+>
+> 本 provider 未发布到 OpenTofu Registry（[原因](https://github.com/opentofu/registry/issues/3632)）。
+
 ## 兼容性
 
 **支持策略:** 本 provider 正式支持三条 3x-ui 次要版本线: **2.9.x**、**3.0.x** 和 **3.1.x** —— 三条版本线下的每个已发布补丁版本都会在每次 push 到 `main` 和每个 pull request 时由 acceptance 矩阵覆盖。


### PR DESCRIPTION
## Summary

- Add missing Taskfile commands (`task test`, `task test:unit:coverage`)
- Document `settingsMu`, `settingsSecrets`, and `web_base_path` restart flow in panel settings section
- Add dedicated section for `xray_version` resource (was completely absent)
- Document provider attributes: `two_factor_code`, `max_retries`, `request_timeout`
- Add two gotchas: `xray_version` no-op delete, `web_base_path` panel restart
- Document test patterns: flaky quarantine, protocol matrix test, destroy visibility polling

## Test plan

- [x] `markdownlint` passes
- [x] `task pre-commit` succeeds