### PR TITLE
fix: reject API routing rules in threexui_xray_routing

### DIFF
--- a/provider/resource_xray_settings.go
+++ b/provider/resource_xray_settings.go
@@ -352,6 +352,11 @@ func (r *XrayRoutingResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
+	if msg := validateNoAPIRoutingRules(plan.Rule); msg != "" {
+		resp.Diagnostics.AddError("Invalid routing rule", msg)
+		return
+	}
+
 	input := expandXrayRouting(&plan)
 	desired := buildXrayRoutingJSON(input)
 	xrayApplyTyped(ctx, desired, &resp.Diagnostics, r.client, xraySectionRouting)
@@ -380,6 +385,11 @@ func (r *XrayRoutingResource) Update(ctx context.Context, req resource.UpdateReq
 	var plan XrayRoutingModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if msg := validateNoAPIRoutingRules(plan.Rule); msg != "" {
+		resp.Diagnostics.AddError("Invalid routing rule", msg)
 		return
 	}
 

--- a/provider/resource_xray_settings.go
+++ b/provider/resource_xray_settings.go
@@ -352,8 +352,8 @@ func (r *XrayRoutingResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
-	if msg := validateNoAPIRoutingRules(plan.Rule); msg != "" {
-		resp.Diagnostics.AddError("Invalid routing rule", msg)
+	ensureNoAPIRoutingRules(plan.Rule, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -388,8 +388,8 @@ func (r *XrayRoutingResource) Update(ctx context.Context, req resource.UpdateReq
 		return
 	}
 
-	if msg := validateNoAPIRoutingRules(plan.Rule); msg != "" {
-		resp.Diagnostics.AddError("Invalid routing rule", msg)
+	ensureNoAPIRoutingRules(plan.Rule, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/provider/xray_routing_schema.go
+++ b/provider/xray_routing_schema.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -482,4 +483,20 @@ func routingValueContainsString(raw any, value string) bool {
 		}
 	}
 	return false
+}
+
+func validateNoAPIRoutingRules(rules []XrayRoutingRule) string {
+	for _, r := range rules {
+		if r.OutboundTag.ValueString() != "api" {
+			continue
+		}
+		var tags []string
+		r.InboundTag.ElementsAs(context.Background(), &tags, false)
+		for _, tag := range tags {
+			if tag == "api" {
+				return "API routing rules (inbound_tag containing \"api\" with outbound_tag \"api\") are automatically managed by the `api` block in `threexui_xray_basics`. Remove this rule from `threexui_xray_routing`."
+			}
+		}
+	}
+	return ""
 }

--- a/provider/xray_routing_schema.go
+++ b/provider/xray_routing_schema.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -502,4 +503,10 @@ func validateNoAPIRoutingRules(rules []XrayRoutingRule) string {
 		}
 	}
 	return ""
+}
+
+func ensureNoAPIRoutingRules(rules []XrayRoutingRule, diags *diag.Diagnostics) {
+	if msg := validateNoAPIRoutingRules(rules); msg != "" {
+		diags.AddError("Invalid routing rule", msg)
+	}
 }

--- a/provider/xray_routing_schema.go
+++ b/provider/xray_routing_schema.go
@@ -490,6 +490,9 @@ func validateNoAPIRoutingRules(rules []XrayRoutingRule) string {
 		if r.OutboundTag.ValueString() != "api" {
 			continue
 		}
+		if r.InboundTag.IsNull() || r.InboundTag.IsUnknown() {
+			continue
+		}
 		var tags []string
 		r.InboundTag.ElementsAs(context.Background(), &tags, false)
 		for _, tag := range tags {

--- a/provider/xray_settings_test.go
+++ b/provider/xray_settings_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -2265,5 +2266,29 @@ func TestValidateNoAPIRoutingRules(t *testing.T) {
 				t.Errorf("validateNoAPIRoutingRules() = %q, wantErr %v", msg, tt.wantErr)
 			}
 		})
+	}
+}
+
+func TestEnsureNoAPIRoutingRules(t *testing.T) {
+	var diags diag.Diagnostics
+	ensureNoAPIRoutingRules([]XrayRoutingRule{
+		{
+			OutboundTag: types.StringValue("api"),
+			InboundTag:  types.ListValueMust(types.StringType, []attr.Value{types.StringValue("api")}),
+		},
+	}, &diags)
+	if !diags.HasError() {
+		t.Fatal("expected error diagnostic for API routing rule")
+	}
+
+	diags = nil
+	ensureNoAPIRoutingRules([]XrayRoutingRule{
+		{
+			OutboundTag: types.StringValue("blocked"),
+			InboundTag:  types.ListValueMust(types.StringType, []attr.Value{types.StringValue("http")}),
+		},
+	}, &diags)
+	if diags.HasError() {
+		t.Fatalf("expected no error, got %v", diags)
 	}
 }

--- a/provider/xray_settings_test.go
+++ b/provider/xray_settings_test.go
@@ -2234,6 +2234,28 @@ func TestValidateNoAPIRoutingRules(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "API outbound with null inbound_tag",
+			rules: []XrayRoutingRule{
+				{
+					Type:        types.StringValue("field"),
+					OutboundTag: types.StringValue("api"),
+					InboundTag:  types.ListNull(types.StringType),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "API outbound with api mixed in inbound_tag",
+			rules: []XrayRoutingRule{
+				{
+					Type:        types.StringValue("field"),
+					OutboundTag: types.StringValue("api"),
+					InboundTag:  types.ListValueMust(types.StringType, []attr.Value{types.StringValue("http"), types.StringValue("api")}),
+				},
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/provider/xray_settings_test.go
+++ b/provider/xray_settings_test.go
@@ -2173,3 +2173,75 @@ func TestAlignBasicsBlocksWithPlan_NilsNestedPolicyBlocks(t *testing.T) {
 		t.Fatal("expected policy.level to be nil")
 	}
 }
+
+func TestValidateNoAPIRoutingRules(t *testing.T) {
+	tests := []struct {
+		name    string
+		rules   []XrayRoutingRule
+		wantErr bool
+	}{
+		{
+			name:    "no rules",
+			rules:   []XrayRoutingRule{},
+			wantErr: false,
+		},
+		{
+			name: "normal rule",
+			rules: []XrayRoutingRule{
+				{
+					Type:        types.StringValue("field"),
+					OutboundTag: types.StringValue("blocked"),
+					InboundTag:  types.ListValueMust(types.StringType, []attr.Value{types.StringValue("http")}),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "API routing rule",
+			rules: []XrayRoutingRule{
+				{
+					Type:        types.StringValue("field"),
+					OutboundTag: types.StringValue("api"),
+					InboundTag:  types.ListValueMust(types.StringType, []attr.Value{types.StringValue("api")}),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "API outbound with non-api inbound",
+			rules: []XrayRoutingRule{
+				{
+					Type:        types.StringValue("field"),
+					OutboundTag: types.StringValue("api"),
+					InboundTag:  types.ListValueMust(types.StringType, []attr.Value{types.StringValue("something-else")}),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "API rule mixed with normal rules",
+			rules: []XrayRoutingRule{
+				{
+					Type:        types.StringValue("field"),
+					OutboundTag: types.StringValue("blocked"),
+					InboundTag:  types.ListValueMust(types.StringType, []attr.Value{types.StringValue("http")}),
+				},
+				{
+					Type:        types.StringValue("field"),
+					OutboundTag: types.StringValue("api"),
+					InboundTag:  types.ListValueMust(types.StringType, []attr.Value{types.StringValue("api")}),
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := validateNoAPIRoutingRules(tt.rules)
+			if (msg != "") != tt.wantErr {
+				t.Errorf("validateNoAPIRoutingRules() = %q, wantErr %v", msg, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add validation that rejects routing rules with `inbound_tag` containing `"api"` and `outbound_tag = "api"` in `threexui_xray_routing`
- Returns a clear error message explaining that API routing rules are auto-managed by the `api` block in `threexui_xray_basics`

## Why

When a user declares an API routing rule in their config, the provider silently dropped it during apply (via `expandRoutingRules` filter), then re-injected it (via `buildXrayRoutingJSON`), but the read-back filtered it out again — causing rule count mismatch and `Provider produced inconsistent result after apply`.

Instead of silently dropping, the provider now validates upfront and tells the user what to do.

## Test plan

- [x] Unit tests pass (`task test:unit`)
- [x] Pre-commit hooks pass (`task pre-commit`)
- [x] New `TestValidateNoAPIRoutingRules` covers: no rules, normal rule, API rule, API outbound with non-api inbound, mixed rules

Closes #216