### PR TITLE
fix: blackhole_settings.response_type false diff on import

### DIFF
--- a/provider/xray_outbounds_schema.go
+++ b/provider/xray_outbounds_schema.go
@@ -2473,6 +2473,9 @@ func flattenBlackholeSettings(in map[string]any) map[string]any {
 			out["response_type"] = t
 		}
 	}
+	if _, ok := out["response_type"]; !ok {
+		out["response_type"] = "none"
+	}
 	return out
 }
 

--- a/provider/xray_settings_test.go
+++ b/provider/xray_settings_test.go
@@ -476,6 +476,52 @@ func TestFlattenXrayOutboundsToMap(t *testing.T) {
 	}
 }
 
+func TestFlattenBlackholeSettings_EmptyDefaultsToNone(t *testing.T) {
+	t.Parallel()
+	in := map[string]any{}
+	out := flattenBlackholeSettings(in)
+	if out["response_type"] != "none" {
+		t.Fatalf("expected response_type='none' for empty settings, got %v", out["response_type"])
+	}
+}
+
+func TestFlattenBlackholeSettings_ExplicitTypePreserved(t *testing.T) {
+	t.Parallel()
+	in := map[string]any{"response": map[string]any{"type": "http"}}
+	out := flattenBlackholeSettings(in)
+	if out["response_type"] != "http" {
+		t.Fatalf("expected response_type='http', got %v", out["response_type"])
+	}
+}
+
+func TestFlattenBlackholeSettings_ExplicitNonePreserved(t *testing.T) {
+	t.Parallel()
+	in := map[string]any{"response": map[string]any{"type": "none"}}
+	out := flattenBlackholeSettings(in)
+	if out["response_type"] != "none" {
+		t.Fatalf("expected response_type='none', got %v", out["response_type"])
+	}
+}
+
+func TestFlattenXrayOutboundsToMap_EmptyBlackholeSettings(t *testing.T) {
+	data := []any{
+		map[string]any{
+			"tag":      "blocked",
+			"protocol": "blackhole",
+			"settings": map[string]any{},
+		},
+	}
+	result := flattenXrayOutboundsToMap(data)
+	outbounds := result["outbound"].([]any)
+	if len(outbounds) != 1 {
+		t.Fatalf("expected 1 outbound, got %d", len(outbounds))
+	}
+	bh := outbounds[0].(map[string]any)["blackhole_settings"].([]any)[0].(map[string]any)
+	if bh["response_type"] != "none" {
+		t.Fatalf("expected response_type='none' for empty blackhole settings, got %v", bh["response_type"])
+	}
+}
+
 func TestExpandReverseEntries(t *testing.T) {
 	list := []any{
 		map[string]any{"tag": "b1", "domain": "test.com"},


### PR DESCRIPTION
## Summary

- When 3x-ui returns empty `settings: {}` for a blackhole outbound, the Xray core defaults `responseType` to `"none"`. The provider's flatten function did not account for this, leaving `response_type` as null in state while the user's config explicitly sets `"none"` — producing a false diff on every plan after import.
- Normalize `flattenBlackholeSettings` so that a missing `response.type` defaults to `"none"`, matching the Xray core default.

## Test plan

- [x] Added `TestFlattenBlackholeSettings_EmptyDefaultsToNone` — verifies empty settings → `"none"`
- [x] Added `TestFlattenBlackholeSettings_ExplicitTypePreserved` — verifies explicit `"http"` is preserved
- [x] Added `TestFlattenBlackholeSettings_ExplicitNonePreserved` — verifies explicit `"none"` is preserved
- [x] Added `TestFlattenXrayOutboundsToMap_EmptyBlackholeSettings` — end-to-end flatten with empty API settings
- [x] All existing unit tests pass
- [x] `golangci-lint` — 0 issues

Closes #218