### PR TITLE
fix: retry transient errors in read-after-write for inbound/inbound_client

### DIFF
--- a/provider/client.go
+++ b/provider/client.go
@@ -1128,18 +1128,34 @@ func (c *Client) doJSONRetryable(ctx context.Context, method, relPath string, bo
 }
 
 // WithReadAfterWriteRetry polls fn until the row is visible (found=true) or
-// the budget is exhausted. It is distinct from withRetry: that one absorbs
-// transient HTTP 5xx, this one absorbs application-layer "success but the
-// row is not visible yet" gaps. Callers pass an opName for telemetry.
+// the budget is exhausted. It handles two transient conditions:
 //
-// fn returns (found, err). A non-nil err aborts immediately (no retry — if
-// the read itself failed, the panel is in worse shape than just slow).
-// found=false triggers a backoff and another attempt.
+//   - found=false: the write succeeded but SQLite hasn't made the row visible yet.
+//   - err is a transient 5xx: the panel is temporarily unavailable under load.
+//
+// Non-transient errors (4xx, auth failures, etc.) abort immediately.
 func (c *Client) WithReadAfterWriteRetry(ctx context.Context, opName string, fn func() (bool, error)) error {
 	for attempt := 0; attempt < readAfterWriteAttempts; attempt++ {
 		found, err := fn()
 		if err != nil {
-			return err
+			if _, retryable := transient5xxStatus(err); !retryable || attempt == readAfterWriteAttempts-1 {
+				return err
+			}
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return ctxErr
+			}
+			tflog.Warn(ctx, "retrying read-after-write (transient error)", map[string]any{
+				"operation":    opName,
+				"attempt":      attempt + 1,
+				"max_attempts": readAfterWriteAttempts,
+				"backoff":      readAfterWriteBackoff.String(),
+			})
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(readAfterWriteBackoff):
+			}
+			continue
 		}
 		if found {
 			return nil

--- a/provider/client_test.go
+++ b/provider/client_test.go
@@ -1208,3 +1208,86 @@ func TestWithReadAfterWriteRetry_Transient5xxExhaustsBudget(t *testing.T) {
 		t.Fatalf("expected %d calls, got %d", readAfterWriteAttempts, calls)
 	}
 }
+
+func TestWithReadAfterWriteRetry_Transient5xxRespectsPreCancelledContext(t *testing.T) {
+	client := newTestClient(t, "http://localhost")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var calls int
+	err := client.WithReadAfterWriteRetry(ctx, "test-op", func() (bool, error) {
+		calls++
+		return false, &HTTPStatusError{StatusCode: 500, Body: "internal error"}
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 call, got %d", calls)
+	}
+}
+
+func TestWithReadAfterWriteRetry_Transient5xxRespectsCtxCancelDuringBackoff(t *testing.T) {
+	client := newTestClient(t, "http://localhost")
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var calls int
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- client.WithReadAfterWriteRetry(ctx, "test-op", func() (bool, error) {
+			calls++
+			return false, &HTTPStatusError{StatusCode: 500, Body: "internal error"}
+		})
+	}()
+
+	// Cancel during the first backoff (500ms).
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("expected error")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for retry to return")
+	}
+}
+
+func TestWithReadAfterWriteRetry_NotFoundRespectsCancelledContext(t *testing.T) {
+	client := newTestClient(t, "http://localhost")
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var calls int
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+
+	err := client.WithReadAfterWriteRetry(ctx, "test-op", func() (bool, error) {
+		calls++
+		return false, nil
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestWithReadAfterWriteRetry_Transient5xxOnLastAttemptReturnsErr(t *testing.T) {
+	client := newTestClient(t, "http://localhost")
+	var calls int
+
+	err := client.WithReadAfterWriteRetry(context.Background(), "test-op", func() (bool, error) {
+		calls++
+		if calls < readAfterWriteAttempts {
+			return false, nil
+		}
+		return false, &HTTPStatusError{StatusCode: 500, Body: "late 5xx"}
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if calls != readAfterWriteAttempts {
+		t.Fatalf("expected %d calls, got %d", readAfterWriteAttempts, calls)
+	}
+}

--- a/provider/client_test.go
+++ b/provider/client_test.go
@@ -1122,3 +1122,89 @@ func TestResolvePathWithBasePath(t *testing.T) {
 		t.Fatalf("unexpected path: %s", parsed.Path)
 	}
 }
+
+func TestWithReadAfterWriteRetry_RetriesTransient5xx(t *testing.T) {
+	client := newTestClient(t, "http://localhost")
+	var calls int
+
+	err := client.WithReadAfterWriteRetry(context.Background(), "test-op", func() (bool, error) {
+		calls++
+		if calls < 3 {
+			return false, &HTTPStatusError{StatusCode: 500, Body: "internal error"}
+		}
+		return true, nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 3 {
+		t.Fatalf("expected 3 calls, got %d", calls)
+	}
+}
+
+func TestWithReadAfterWriteRetry_AbortsOnNonTransientError(t *testing.T) {
+	client := newTestClient(t, "http://localhost")
+	var calls int
+
+	err := client.WithReadAfterWriteRetry(context.Background(), "test-op", func() (bool, error) {
+		calls++
+		return false, &HTTPStatusError{StatusCode: 401, Body: "unauthorized"}
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 call, got %d", calls)
+	}
+}
+
+func TestWithReadAfterWriteRetry_RetriesNotFoundThenFound(t *testing.T) {
+	client := newTestClient(t, "http://localhost")
+	var calls int
+
+	err := client.WithReadAfterWriteRetry(context.Background(), "test-op", func() (bool, error) {
+		calls++
+		if calls < 2 {
+			return false, nil // row not visible yet
+		}
+		return true, nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("expected 2 calls, got %d", calls)
+	}
+}
+
+func TestWithReadAfterWriteRetry_ExhaustsBudget(t *testing.T) {
+	client := newTestClient(t, "http://localhost")
+	var calls int
+
+	err := client.WithReadAfterWriteRetry(context.Background(), "test-op", func() (bool, error) {
+		calls++
+		return false, nil // always not found
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if calls != readAfterWriteAttempts {
+		t.Fatalf("expected %d calls, got %d", readAfterWriteAttempts, calls)
+	}
+}
+
+func TestWithReadAfterWriteRetry_Transient5xxExhaustsBudget(t *testing.T) {
+	client := newTestClient(t, "http://localhost")
+	var calls int
+
+	err := client.WithReadAfterWriteRetry(context.Background(), "test-op", func() (bool, error) {
+		calls++
+		return false, &HTTPStatusError{StatusCode: 502, Body: "bad gateway"}
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if calls != readAfterWriteAttempts {
+		t.Fatalf("expected %d calls, got %d", readAfterWriteAttempts, calls)
+	}
+}

--- a/provider/resource_inbound.go
+++ b/provider/resource_inbound.go
@@ -265,9 +265,16 @@ func (r *InboundResource) Create(ctx context.Context, req resource.CreateRequest
 
 	// Re-read the inbound via GET to ensure consistent state (#131).
 	// The add endpoint may return incomplete data under SQLite pressure.
-	created, err = r.client.GetInbound(ctx, created.ID)
-	if err != nil {
-		resp.Diagnostics.AddError("Failed to read created inbound", err.Error())
+	// Retry on transient errors — the row may not be committed yet (#223).
+	if retryErr := r.client.WithReadAfterWriteRetry(ctx, fmt.Sprintf("read created inbound %d", created.ID), func() (bool, error) {
+		got, getErr := r.client.GetInbound(ctx, created.ID)
+		if getErr != nil {
+			return false, getErr
+		}
+		created = got
+		return true, nil
+	}); retryErr != nil {
+		resp.Diagnostics.AddError("Failed to read created inbound", retryErr.Error())
 		return
 	}
 


### PR DESCRIPTION
## Summary

Closes #223

- **`WithReadAfterWriteRetry` now retries transient 5xx errors** instead of aborting immediately. Previously, any non-nil error from the callback caused an instant abort — but under SQLite contention, `GetInbound` can return 5xx errors that are transient and should be retried.
- **Inbound Create wraps its final `GetInbound` call with `WithReadAfterWriteRetry`**. This was the only post-write read path that had no retry at all.

### What changed

| File | Change |
|---|---|
| `provider/client.go` | `WithReadAfterWriteRetry` retries on transient 5xx (detected via `transient5xxStatus`), non-transient errors still abort immediately |
| `provider/resource_inbound.go` | `Create` now uses `WithReadAfterWriteRetry` for the post-add `GetInbound` call |
| `provider/client_test.go` | 5 new tests covering: 5xx retry, non-transient abort, not-found→found, budget exhaustion, 5xx exhaustion |

### Why this fixes the flaky tests

The CI failures in #223 show errors like "Failed to read updated inbound" and "Failed to read created inbound client". These occur when `GetInbound` returns a transient error (5xx) after a write, and the existing retry mechanism didn't cover that case. Now it does.

## Test plan

- [x] `task test:unit` — all 77 tests pass including 5 new ones
- [x] `task vet` — clean
- [x] `task lint` — 0 issues
- [x] `task build` — compiles
- [ ] `task test:acc` — acceptance tests (requires Docker)