### PR TITLE
fix: (known after apply) noise in xray_routing and xray_outbounds

### DIFF
--- a/provider/xray_dns_schema.go
+++ b/provider/xray_dns_schema.go
@@ -5,6 +5,10 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -55,32 +59,59 @@ func xrayDNSSchema() schema.Schema {
 			},
 			"query_strategy": schema.StringAttribute{
 				Optional: true, Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"tag": schema.StringAttribute{
 				Optional: true, Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"disable_cache": schema.BoolAttribute{
 				Optional: true, Computed: true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"disable_fallback": schema.BoolAttribute{
 				Optional: true, Computed: true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"disable_fallback_if_match": schema.BoolAttribute{
 				Optional: true, Computed: true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"client_ip": schema.StringAttribute{
 				Optional: true, Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"enable_parallel_query": schema.BoolAttribute{
 				Optional: true, Computed: true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"use_system_hosts": schema.BoolAttribute{
 				Optional: true, Computed: true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"hosts": schema.MapAttribute{
 				Optional:    true,
 				Computed:    true,
 				ElementType: types.StringType,
+				PlanModifiers: []planmodifier.Map{
+					mapplanmodifier.UseStateForUnknown(),
+				},
 			},
 		},
 		Blocks: map[string]schema.Block{
@@ -92,33 +123,57 @@ func xrayDNSSchema() schema.Schema {
 						},
 						"port": schema.Int64Attribute{
 							Optional: true, Computed: true,
+							PlanModifiers: []planmodifier.Int64{
+								int64planmodifier.UseStateForUnknown(),
+							},
 						},
 						"domains": schema.ListAttribute{
 							Optional:    true,
 							Computed:    true,
 							ElementType: types.StringType,
+							PlanModifiers: []planmodifier.List{
+								listplanmodifier.UseStateForUnknown(),
+							},
 						},
 						"expect_ips": schema.ListAttribute{
 							Optional:    true,
 							Computed:    true,
 							ElementType: types.StringType,
+							PlanModifiers: []planmodifier.List{
+								listplanmodifier.UseStateForUnknown(),
+							},
 						},
 						"unexpected_ips": schema.ListAttribute{
 							Optional:    true,
 							Computed:    true,
 							ElementType: types.StringType,
+							PlanModifiers: []planmodifier.List{
+								listplanmodifier.UseStateForUnknown(),
+							},
 						},
 						"skip_fallback": schema.BoolAttribute{
 							Optional: true, Computed: true,
+							PlanModifiers: []planmodifier.Bool{
+								boolplanmodifier.UseStateForUnknown(),
+							},
 						},
 						"query_strategy": schema.StringAttribute{
 							Optional: true, Computed: true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
 						},
 						"disable_cache": schema.BoolAttribute{
 							Optional: true, Computed: true,
+							PlanModifiers: []planmodifier.Bool{
+								boolplanmodifier.UseStateForUnknown(),
+							},
 						},
 						"final_query": schema.BoolAttribute{
 							Optional: true, Computed: true,
+							PlanModifiers: []planmodifier.Bool{
+								boolplanmodifier.UseStateForUnknown(),
+							},
 						},
 					},
 				},

--- a/provider/xray_outbounds_schema.go
+++ b/provider/xray_outbounds_schema.go
@@ -5,6 +5,9 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -212,6 +215,9 @@ func xrayOutboundsSchema() schema.Schema {
 					Attributes: map[string]schema.Attribute{
 						"tag": schema.StringAttribute{
 							Optional: true, Computed: true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
 						},
 						"protocol": schema.StringAttribute{
 							Required:    true,
@@ -219,6 +225,9 @@ func xrayOutboundsSchema() schema.Schema {
 						},
 						"send_through": schema.StringAttribute{
 							Optional: true, Computed: true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
 						},
 					},
 					Blocks: map[string]schema.Block{
@@ -227,15 +236,27 @@ func xrayOutboundsSchema() schema.Schema {
 								Attributes: map[string]schema.Attribute{
 									"enabled": schema.BoolAttribute{
 										Optional: true, Computed: true,
+										PlanModifiers: []planmodifier.Bool{
+											boolplanmodifier.UseStateForUnknown(),
+										},
 									},
 									"concurrency": schema.Int64Attribute{
 										Optional: true, Computed: true,
+										PlanModifiers: []planmodifier.Int64{
+											int64planmodifier.UseStateForUnknown(),
+										},
 									},
 									"xudp_concurrency": schema.Int64Attribute{
 										Optional: true, Computed: true,
+										PlanModifiers: []planmodifier.Int64{
+											int64planmodifier.UseStateForUnknown(),
+										},
 									},
 									"xudp_proxy_udp443": schema.StringAttribute{
 										Optional: true, Computed: true,
+										PlanModifiers: []planmodifier.String{
+											stringplanmodifier.UseStateForUnknown(),
+										},
 									},
 								},
 							},
@@ -245,15 +266,24 @@ func xrayOutboundsSchema() schema.Schema {
 								Attributes: map[string]schema.Attribute{
 									"domain_strategy": schema.StringAttribute{
 										Optional: true, Computed: true,
+										PlanModifiers: []planmodifier.String{
+											stringplanmodifier.UseStateForUnknown(),
+										},
 									},
 									"redirect": schema.StringAttribute{
 										Optional: true, Computed: true,
+										PlanModifiers: []planmodifier.String{
+											stringplanmodifier.UseStateForUnknown(),
+										},
 									},
 									"ips_blocked": schema.ListAttribute{
 										Optional:    true,
 										Computed:    true,
 										ElementType: types.StringType,
 										Description: "Deprecated legacy list of IPs/CIDRs to block (e.g. geoip:cn). Use final_rule on 3x-ui v2.9.4+.",
+										PlanModifiers: []planmodifier.List{
+											listplanmodifier.UseStateForUnknown(),
+										},
 									},
 								},
 								Blocks: map[string]schema.Block{
@@ -262,12 +292,21 @@ func xrayOutboundsSchema() schema.Schema {
 											Attributes: map[string]schema.Attribute{
 												"packets": schema.StringAttribute{
 													Optional: true, Computed: true,
+													PlanModifiers: []planmodifier.String{
+														stringplanmodifier.UseStateForUnknown(),
+													},
 												},
 												"length": schema.StringAttribute{
 													Optional: true, Computed: true,
+													PlanModifiers: []planmodifier.String{
+														stringplanmodifier.UseStateForUnknown(),
+													},
 												},
 												"interval": schema.StringAttribute{
 													Optional: true, Computed: true,
+													PlanModifiers: []planmodifier.String{
+														stringplanmodifier.UseStateForUnknown(),
+													},
 												},
 											},
 										},
@@ -277,12 +316,21 @@ func xrayOutboundsSchema() schema.Schema {
 											Attributes: map[string]schema.Attribute{
 												"type": schema.StringAttribute{
 													Optional: true, Computed: true,
+													PlanModifiers: []planmodifier.String{
+														stringplanmodifier.UseStateForUnknown(),
+													},
 												},
 												"packet": schema.StringAttribute{
 													Optional: true, Computed: true,
+													PlanModifiers: []planmodifier.String{
+														stringplanmodifier.UseStateForUnknown(),
+													},
 												},
 												"delay": schema.StringAttribute{
 													Optional: true, Computed: true,
+													PlanModifiers: []planmodifier.String{
+														stringplanmodifier.UseStateForUnknown(),
+													},
 												},
 											},
 										},
@@ -292,20 +340,35 @@ func xrayOutboundsSchema() schema.Schema {
 											Attributes: map[string]schema.Attribute{
 												"action": schema.StringAttribute{
 													Optional: true, Computed: true,
+													PlanModifiers: []planmodifier.String{
+														stringplanmodifier.UseStateForUnknown(),
+													},
 												},
 												"network": schema.StringAttribute{
 													Optional: true, Computed: true,
+													PlanModifiers: []planmodifier.String{
+														stringplanmodifier.UseStateForUnknown(),
+													},
 												},
 												"port": schema.StringAttribute{
 													Optional: true, Computed: true,
+													PlanModifiers: []planmodifier.String{
+														stringplanmodifier.UseStateForUnknown(),
+													},
 												},
 												"ip": schema.ListAttribute{
 													Optional:    true,
 													Computed:    true,
 													ElementType: types.StringType,
+													PlanModifiers: []planmodifier.List{
+														listplanmodifier.UseStateForUnknown(),
+													},
 												},
 												"block_delay": schema.StringAttribute{
 													Optional: true, Computed: true,
+													PlanModifiers: []planmodifier.String{
+														stringplanmodifier.UseStateForUnknown(),
+													},
 												},
 											},
 										},
@@ -318,6 +381,9 @@ func xrayOutboundsSchema() schema.Schema {
 								Attributes: map[string]schema.Attribute{
 									"response_type": schema.StringAttribute{
 										Optional: true, Computed: true,
+										PlanModifiers: []planmodifier.String{
+											stringplanmodifier.UseStateForUnknown(),
+										},
 									},
 								},
 							},
@@ -327,20 +393,35 @@ func xrayOutboundsSchema() schema.Schema {
 								Attributes: map[string]schema.Attribute{
 									"network": schema.StringAttribute{
 										Optional: true, Computed: true,
+										PlanModifiers: []planmodifier.String{
+											stringplanmodifier.UseStateForUnknown(),
+										},
 									},
 									"address": schema.StringAttribute{
 										Optional: true, Computed: true,
+										PlanModifiers: []planmodifier.String{
+											stringplanmodifier.UseStateForUnknown(),
+										},
 									},
 									"port": schema.Int64Attribute{
 										Optional: true, Computed: true,
+										PlanModifiers: []planmodifier.Int64{
+											int64planmodifier.UseStateForUnknown(),
+										},
 									},
 									"non_ip_query": schema.StringAttribute{
 										Optional: true, Computed: true,
+										PlanModifiers: []planmodifier.String{
+											stringplanmodifier.UseStateForUnknown(),
+										},
 									},
 									"block_types": schema.ListAttribute{
 										Optional:    true,
 										Computed:    true,
 										ElementType: types.Int64Type,
+										PlanModifiers: []planmodifier.List{
+											listplanmodifier.UseStateForUnknown(),
+										},
 									},
 								},
 							},
@@ -350,15 +431,27 @@ func xrayOutboundsSchema() schema.Schema {
 								Attributes: map[string]schema.Attribute{
 									"address": schema.StringAttribute{
 										Optional: true, Computed: true,
+										PlanModifiers: []planmodifier.String{
+											stringplanmodifier.UseStateForUnknown(),
+										},
 									},
 									"port": schema.Int64Attribute{
 										Optional: true, Computed: true,
+										PlanModifiers: []planmodifier.Int64{
+											int64planmodifier.UseStateForUnknown(),
+										},
 									},
 									"id": schema.StringAttribute{
 										Optional: true, Computed: true,
+										PlanModifiers: []planmodifier.String{
+											stringplanmodifier.UseStateForUnknown(),
+										},
 									},
 									"security": schema.StringAttribute{
 										Optional: true, Computed: true,
+										PlanModifiers: []planmodifier.String{
+											stringplanmodifier.UseStateForUnknown(),
+										},
 									},
 								},
 							},
@@ -368,23 +461,41 @@ func xrayOutboundsSchema() schema.Schema {
 								Attributes: map[string]schema.Attribute{
 									"address": schema.StringAttribute{
 										Optional: true, Computed: true,
+										PlanModifiers: []planmodifier.String{
+											stringplanmodifier.UseStateForUnknown(),
+										},
 									},
 									"port": schema.Int64Attribute{
 										Optional: true, Computed: true,
+										PlanModifiers: []planmodifier.Int64{
+											int64planmodifier.UseStateForUnknown(),
+										},
 									},
 									"id": schema.StringAttribute{
 										Optional: true, Computed: true,
+										PlanModifiers: []planmodifier.String{
+											stringplanmodifier.UseStateForUnknown(),
+										},
 									},
 									"flow": schema.StringAttribute{
 										Optional: true, Computed: true,
+										PlanModifiers: []planmodifier.String{
+											stringplanmodifier.UseStateForUnknown(),
+										},
 									},
 									"encryption": schema.StringAttribute{
 										Optional: true, Computed: true,
+										PlanModifiers: []planmodifier.String{
+											stringplanmodifier.UseStateForUnknown(),
+										},
 									},
 									"reverse_tag": schema.StringAttribute{
 										Optional:    true,
 										Computed:    true,
 										Description: "VLESS reverse tag. Stored in 3x-ui as reverse.tag.",
+										PlanModifiers: []planmodifier.String{
+											stringplanmodifier.UseStateForUnknown(),
+										},
 									},
 								},
 							},
@@ -394,12 +505,21 @@ func xrayOutboundsSchema() schema.Schema {
 								Attributes: map[string]schema.Attribute{
 									"address": schema.StringAttribute{
 										Optional: true, Computed: true,
+										PlanModifiers: []planmodifier.String{
+											stringplanmodifier.UseStateForUnknown(),
+										},
 									},
 									"port": schema.Int64Attribute{
 										Optional: true, Computed: true,
+										PlanModifiers: []planmodifier.Int64{
+											int64planmodifier.UseStateForUnknown(),
+										},
 									},
 									"password": schema.StringAttribute{
 										Optional: true, Computed: true, Sensitive: true,
+										PlanModifiers: []planmodifier.String{
+											stringplanmodifier.UseStateForUnknown(),
+										},
 									},
 								},
 							},
@@ -409,21 +529,39 @@ func xrayOutboundsSchema() schema.Schema {
 								Attributes: map[string]schema.Attribute{
 									"address": schema.StringAttribute{
 										Optional: true, Computed: true,
+										PlanModifiers: []planmodifier.String{
+											stringplanmodifier.UseStateForUnknown(),
+										},
 									},
 									"port": schema.Int64Attribute{
 										Optional: true, Computed: true,
+										PlanModifiers: []planmodifier.Int64{
+											int64planmodifier.UseStateForUnknown(),
+										},
 									},
 									"password": schema.StringAttribute{
 										Optional: true, Computed: true, Sensitive: true,
+										PlanModifiers: []planmodifier.String{
+											stringplanmodifier.UseStateForUnknown(),
+										},
 									},
 									"method": schema.StringAttribute{
 										Optional: true, Computed: true,
+										PlanModifiers: []planmodifier.String{
+											stringplanmodifier.UseStateForUnknown(),
+										},
 									},
 									"uot": schema.BoolAttribute{
 										Optional: true, Computed: true,
+										PlanModifiers: []planmodifier.Bool{
+											boolplanmodifier.UseStateForUnknown(),
+										},
 									},
 									"uot_version": schema.Int64Attribute{
 										Optional: true, Computed: true,
+										PlanModifiers: []planmodifier.Int64{
+											int64planmodifier.UseStateForUnknown(),
+										},
 									},
 								},
 							},
@@ -433,15 +571,27 @@ func xrayOutboundsSchema() schema.Schema {
 								Attributes: map[string]schema.Attribute{
 									"address": schema.StringAttribute{
 										Optional: true, Computed: true,
+										PlanModifiers: []planmodifier.String{
+											stringplanmodifier.UseStateForUnknown(),
+										},
 									},
 									"port": schema.Int64Attribute{
 										Optional: true, Computed: true,
+										PlanModifiers: []planmodifier.Int64{
+											int64planmodifier.UseStateForUnknown(),
+										},
 									},
 									"user": schema.StringAttribute{
 										Optional: true, Computed: true,
+										PlanModifiers: []planmodifier.String{
+											stringplanmodifier.UseStateForUnknown(),
+										},
 									},
 									"pass": schema.StringAttribute{
 										Optional: true, Computed: true, Sensitive: true,
+										PlanModifiers: []planmodifier.String{
+											stringplanmodifier.UseStateForUnknown(),
+										},
 									},
 								},
 							},
@@ -451,15 +601,27 @@ func xrayOutboundsSchema() schema.Schema {
 								Attributes: map[string]schema.Attribute{
 									"address": schema.StringAttribute{
 										Optional: true, Computed: true,
+										PlanModifiers: []planmodifier.String{
+											stringplanmodifier.UseStateForUnknown(),
+										},
 									},
 									"port": schema.Int64Attribute{
 										Optional: true, Computed: true,
+										PlanModifiers: []planmodifier.Int64{
+											int64planmodifier.UseStateForUnknown(),
+										},
 									},
 									"user": schema.StringAttribute{
 										Optional: true, Computed: true,
+										PlanModifiers: []planmodifier.String{
+											stringplanmodifier.UseStateForUnknown(),
+										},
 									},
 									"pass": schema.StringAttribute{
 										Optional: true, Computed: true, Sensitive: true,
+										PlanModifiers: []planmodifier.String{
+											stringplanmodifier.UseStateForUnknown(),
+										},
 									},
 								},
 							},
@@ -469,28 +631,49 @@ func xrayOutboundsSchema() schema.Schema {
 								Attributes: map[string]schema.Attribute{
 									"mtu": schema.Int64Attribute{
 										Optional: true, Computed: true,
+										PlanModifiers: []planmodifier.Int64{
+											int64planmodifier.UseStateForUnknown(),
+										},
 									},
 									"secret_key": schema.StringAttribute{
 										Optional: true, Computed: true, Sensitive: true,
+										PlanModifiers: []planmodifier.String{
+											stringplanmodifier.UseStateForUnknown(),
+										},
 									},
 									"address": schema.ListAttribute{
 										Optional:    true,
 										Computed:    true,
 										ElementType: types.StringType,
+										PlanModifiers: []planmodifier.List{
+											listplanmodifier.UseStateForUnknown(),
+										},
 									},
 									"workers": schema.Int64Attribute{
 										Optional: true, Computed: true,
+										PlanModifiers: []planmodifier.Int64{
+											int64planmodifier.UseStateForUnknown(),
+										},
 									},
 									"domain_strategy": schema.StringAttribute{
 										Optional: true, Computed: true,
+										PlanModifiers: []planmodifier.String{
+											stringplanmodifier.UseStateForUnknown(),
+										},
 									},
 									"reserved": schema.ListAttribute{
 										Optional:    true,
 										Computed:    true,
 										ElementType: types.Int64Type,
+										PlanModifiers: []planmodifier.List{
+											listplanmodifier.UseStateForUnknown(),
+										},
 									},
 									"no_kernel_tun": schema.BoolAttribute{
 										Optional: true, Computed: true,
+										PlanModifiers: []planmodifier.Bool{
+											boolplanmodifier.UseStateForUnknown(),
+										},
 									},
 								},
 								Blocks: map[string]schema.Block{
@@ -499,20 +682,35 @@ func xrayOutboundsSchema() schema.Schema {
 											Attributes: map[string]schema.Attribute{
 												"public_key": schema.StringAttribute{
 													Optional: true, Computed: true,
+													PlanModifiers: []planmodifier.String{
+														stringplanmodifier.UseStateForUnknown(),
+													},
 												},
 												"pre_shared_key": schema.StringAttribute{
 													Optional: true, Computed: true, Sensitive: true,
+													PlanModifiers: []planmodifier.String{
+														stringplanmodifier.UseStateForUnknown(),
+													},
 												},
 												"allowed_ips": schema.ListAttribute{
 													Optional:    true,
 													Computed:    true,
 													ElementType: types.StringType,
+													PlanModifiers: []planmodifier.List{
+														listplanmodifier.UseStateForUnknown(),
+													},
 												},
 												"endpoint": schema.StringAttribute{
 													Optional: true, Computed: true,
+													PlanModifiers: []planmodifier.String{
+														stringplanmodifier.UseStateForUnknown(),
+													},
 												},
 												"keep_alive": schema.Int64Attribute{
 													Optional: true, Computed: true,
+													PlanModifiers: []planmodifier.Int64{
+														int64planmodifier.UseStateForUnknown(),
+													},
 												},
 											},
 										},
@@ -525,12 +723,21 @@ func xrayOutboundsSchema() schema.Schema {
 								Attributes: map[string]schema.Attribute{
 									"address": schema.StringAttribute{
 										Optional: true, Computed: true,
+										PlanModifiers: []planmodifier.String{
+											stringplanmodifier.UseStateForUnknown(),
+										},
 									},
 									"port": schema.Int64Attribute{
 										Optional: true, Computed: true,
+										PlanModifiers: []planmodifier.Int64{
+											int64planmodifier.UseStateForUnknown(),
+										},
 									},
 									"version": schema.Int64Attribute{
 										Optional: true, Computed: true,
+										PlanModifiers: []planmodifier.Int64{
+											int64planmodifier.UseStateForUnknown(),
+										},
 									},
 								},
 							},

--- a/provider/xray_routing_schema.go
+++ b/provider/xray_routing_schema.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -54,10 +55,16 @@ func xrayRoutingSchema() schema.Schema {
 			"domain_strategy": schema.StringAttribute{
 				Optional: true,
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"domain_matcher": schema.StringAttribute{
 				Optional: true,
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 		},
 		Blocks: map[string]schema.Block{
@@ -67,60 +74,99 @@ func xrayRoutingSchema() schema.Schema {
 						"type": schema.StringAttribute{
 							Optional: true,
 							Computed: true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
 						},
 						"domain": schema.ListAttribute{
 							Optional:    true,
 							Computed:    true,
 							ElementType: types.StringType,
+							PlanModifiers: []planmodifier.List{
+								listplanmodifier.UseStateForUnknown(),
+							},
 						},
 						"ip": schema.ListAttribute{
 							Optional:    true,
 							Computed:    true,
 							ElementType: types.StringType,
+							PlanModifiers: []planmodifier.List{
+								listplanmodifier.UseStateForUnknown(),
+							},
 						},
 						"port": schema.StringAttribute{
 							Optional: true,
 							Computed: true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
 						},
 						"source_port": schema.StringAttribute{
 							Optional: true,
 							Computed: true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
 						},
 						"network": schema.StringAttribute{
 							Optional: true,
 							Computed: true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
 						},
 						"source": schema.ListAttribute{
 							Optional:    true,
 							Computed:    true,
 							ElementType: types.StringType,
+							PlanModifiers: []planmodifier.List{
+								listplanmodifier.UseStateForUnknown(),
+							},
 						},
 						"user": schema.ListAttribute{
 							Optional:    true,
 							Computed:    true,
 							ElementType: types.StringType,
+							PlanModifiers: []planmodifier.List{
+								listplanmodifier.UseStateForUnknown(),
+							},
 						},
 						"inbound_tag": schema.ListAttribute{
 							Optional:    true,
 							Computed:    true,
 							ElementType: types.StringType,
+							PlanModifiers: []planmodifier.List{
+								listplanmodifier.UseStateForUnknown(),
+							},
 						},
 						"protocol": schema.ListAttribute{
 							Optional:    true,
 							Computed:    true,
 							ElementType: types.StringType,
+							PlanModifiers: []planmodifier.List{
+								listplanmodifier.UseStateForUnknown(),
+							},
 						},
 						"attrs": schema.StringAttribute{
 							Optional: true,
 							Computed: true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
 						},
 						"outbound_tag": schema.StringAttribute{
 							Optional: true,
 							Computed: true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
 						},
 						"balancer_tag": schema.StringAttribute{
 							Optional: true,
 							Computed: true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
 						},
 					},
 				},


### PR DESCRIPTION
## Summary

- Add `UseStateForUnknown()` plan modifiers to all Optional+Computed fields in `xray_routing_schema.go` (14 fields) and `xray_outbounds_schema.go` (~50 fields)
- Fixes excessive `(known after apply)` noise in `terraform plan` for `threexui_xray_routing` and `threexui_xray_outbounds` resources when optional fields are empty/null

Closes #219

## Test plan

- [x] `task pre-commit` — fmt, vet, lint, build pass
- [x] `task test:unit` — all 503 unit tests pass
- [ ] `task test:acc` — acceptance tests (requires Docker)
- [ ] Manual: apply routing/outbounds config, run `terraform plan` — should show "No changes"