### PR TITLE
feat: 3x-ui v3.2.0 compatibility

### DIFF
--- a/docs/resources/inbound_client.md
+++ b/docs/resources/inbound_client.md
@@ -86,6 +86,7 @@ resource "threexui_inbound_client" "hysteria_user" {
 - `tg_id` (Optional, Number) - Telegram user ID for bot notifications.
 - `comment` (Optional, String) - Client description for administrative notes.
 - `reset` (Optional, Number) - Traffic reset period in days. `0` means never (default).
+- `group` (Optional, String) - Client group name. Available on 3x-ui v3.2.0+.
 
 ## Read-Only Attributes
 

--- a/docs/resources/panel_general.md
+++ b/docs/resources/panel_general.md
@@ -79,6 +79,10 @@ resource "threexui_panel_general" "settings" {
 
 - `xray_outbound_test_url` (Optional, String) - URL used for testing outbound connectivity. Default is `https://www.google.com/generate_204`.
 
+### Proxy
+
+- `panel_proxy` (Optional, String) - HTTP/SOCKS5 proxy URL for the panel's own outbound requests (xray version checks, Telegram bot, outbound testing). Default is `""` (direct). Available on 3x-ui v3.2.0+.
+
 ## Attribute Reference
 
 All arguments are also exported as attributes.

--- a/provider/default_settings.go
+++ b/provider/default_settings.go
@@ -96,7 +96,7 @@ func defaultSettingsForProtocol(protocol string) (map[string]any, error) { //nol
 		return nil, nil
 	case "shadowsocks":
 		return nil, nil
-	case "hysteria", "hysteria2":
+	case "hysteria", "hysteria2": // hysteria2 kept for reading v3.1.0 inbounds
 		return map[string]any{
 			"version": 2,
 		}, nil

--- a/provider/default_settings.go
+++ b/provider/default_settings.go
@@ -75,7 +75,7 @@ func setDefaultSettings(inbound *Inbound) error {
 
 func protocolUsesClients(protocol string) bool {
 	switch protocol {
-	case "vmess", "vless", "trojan", "shadowsocks", "hysteria", "hysteria2":
+	case "vmess", "vless", "trojan", "shadowsocks", "hysteria":
 		return true
 	default:
 		return false

--- a/provider/default_settings_test.go
+++ b/provider/default_settings_test.go
@@ -66,7 +66,7 @@ func TestProtocolUsesClients(t *testing.T) {
 		{"trojan", true},
 		{"shadowsocks", true},
 		{"hysteria", true},
-		{"hysteria2", true},
+		{"hysteria2", false},
 		{"http", false},
 		{"mixed", false},
 		{"", false},

--- a/provider/drift_test.go
+++ b/provider/drift_test.go
@@ -442,8 +442,7 @@ func upstreamStreamForms(t *testing.T, dir string) []string {
 		jsPath = filepath.Join(dir, "web", "assets", "js", "model", "inbound.js")
 	}
 	if _, err := os.Stat(jsPath); err != nil {
-		// No legacy JS file — TS schemas already handled above.
-		return nil
+		t.Fatalf("no stream form source found in %s (neither TS schemas nor legacy inbound.js)", dir)
 	}
 	data, err := os.ReadFile(jsPath)
 	if err != nil {

--- a/provider/drift_test.go
+++ b/provider/drift_test.go
@@ -432,15 +432,6 @@ func upstreamStreamForms(t *testing.T, dir string) []string {
 				continue
 			}
 			seen["stream_"+strings.ReplaceAll(name, "-", "_")] = true
-			if name == "external-proxy" {
-				seen["external_proxy"] = true
-			}
-			if name == "finalmask" {
-				seen["stream_finalmask"] = true
-			}
-			if name == "sockopt" {
-				seen["stream_sockopt"] = true
-			}
 		}
 		return toSortedSlice(seen)
 	}
@@ -720,7 +711,6 @@ func TestDriftStreamSettingsForms(t *testing.T) {
 		"stream_sockopt":        true,
 		"stream_settings":       true, // main stream_settings container
 		"stream_finalmask":      true, // finalmask is part of xhttp settings
-		"external_proxy":        true, // external_proxy block
 		"stream_external_proxy": true, // TS schema name for external_proxy
 	}
 

--- a/provider/drift_test.go
+++ b/provider/drift_test.go
@@ -326,9 +326,17 @@ func extractInboundJSProtocols(t *testing.T, jsPath string) []string {
 		start = strings.Index(content, "export const Protocols = {")
 	}
 	if start == -1 {
+		start = strings.Index(content, "export const Protocols = Object.freeze({")
+	}
+	if start == -1 {
 		t.Fatal("cannot find Protocols object in inbound model JS")
 	}
-	end := strings.Index(content[start:], "};")
+	// Object.freeze({...}); ends with });, plain objects end with };
+	sep := "};"
+	if strings.HasPrefix(content[start:], "export const Protocols = Object.freeze(") {
+		sep = "})"
+	}
+	end := strings.Index(content[start:], sep)
 	if end == -1 {
 		t.Fatal("cannot find end of Protocols object in inbound model JS")
 	}
@@ -348,6 +356,11 @@ func extractInboundJSProtocols(t *testing.T, jsPath string) []string {
 }
 
 func upstreamInboundJSPath(dir string) string {
+	// v3.2.0+: TypeScript migration moved the Protocols definition.
+	ts := filepath.Join(dir, "frontend", "src", "schemas", "primitives", "protocol.ts")
+	if _, err := os.Stat(ts); err == nil {
+		return ts
+	}
 	legacy := filepath.Join(dir, "web", "assets", "js", "model", "inbound.js")
 	if _, err := os.Stat(legacy); err == nil {
 		return legacy
@@ -365,6 +378,24 @@ func upstreamProtocolForms(t *testing.T, dir string) []string {
 				continue
 			}
 			upstream = append(upstream, strings.TrimSuffix(e.Name(), ".html"))
+		}
+		sort.Strings(upstream)
+		return upstream
+	}
+
+	// v3.2.0+: TypeScript schemas in frontend/src/schemas/protocols/inbound/
+	tsDir := filepath.Join(dir, "frontend", "src", "schemas", "protocols", "inbound")
+	if entries, err := os.ReadDir(tsDir); err == nil {
+		var upstream []string
+		for _, e := range entries {
+			if e.IsDir() || !strings.HasSuffix(e.Name(), ".ts") {
+				continue
+			}
+			name := strings.TrimSuffix(e.Name(), ".ts")
+			if name == "index" {
+				continue
+			}
+			upstream = append(upstream, name)
 		}
 		sort.Strings(upstream)
 		return upstream
@@ -388,7 +419,42 @@ func upstreamStreamForms(t *testing.T, dir string) []string {
 		return upstream
 	}
 
-	data, err := os.ReadFile(upstreamInboundJSPath(dir))
+	// v3.2.0+: TypeScript schemas in frontend/src/schemas/protocols/stream/
+	tsDir := filepath.Join(dir, "frontend", "src", "schemas", "protocols", "stream")
+	if entries, err := os.ReadDir(tsDir); err == nil {
+		seen := map[string]bool{"stream_settings": true}
+		for _, e := range entries {
+			if e.IsDir() || !strings.HasSuffix(e.Name(), ".ts") {
+				continue
+			}
+			name := strings.TrimSuffix(e.Name(), ".ts")
+			if name == "index" {
+				continue
+			}
+			seen["stream_"+strings.ReplaceAll(name, "-", "_")] = true
+			if name == "external-proxy" {
+				seen["external_proxy"] = true
+			}
+			if name == "finalmask" {
+				seen["stream_finalmask"] = true
+			}
+			if name == "sockopt" {
+				seen["stream_sockopt"] = true
+			}
+		}
+		return toSortedSlice(seen)
+	}
+
+	// Legacy: extract from inbound.js StreamSettings class.
+	jsPath := filepath.Join(dir, "frontend", "src", "models", "inbound.js")
+	if _, err := os.Stat(jsPath); err != nil {
+		jsPath = filepath.Join(dir, "web", "assets", "js", "model", "inbound.js")
+	}
+	if _, err := os.Stat(jsPath); err != nil {
+		// No legacy JS file — TS schemas already handled above.
+		return nil
+	}
+	data, err := os.ReadFile(jsPath)
 	if err != nil {
 		t.Fatalf("cannot read inbound model JS: %v", err)
 	}
@@ -505,12 +571,14 @@ func TestDriftInboundProtocols_GoModel(t *testing.T) {
 	// "vmess" and "mixed" have no per-protocol settings block (handled via default).
 	// "socks" is available via UI. "tun" is UI alias for tunnel/dokodemo-door.
 	// "dokodemo-door" is the xray-level name; upstream model.go only exposes "tunnel".
+	// "hysteria2" removed from upstream in v3.2.0; switch-case kept for reading v3.1.0 data.
 	providerExtras := map[string]bool{
 		"vmess":         true,
 		"mixed":         true,
 		"socks":         true,
 		"tun":           true,
 		"dokodemo-door": true,
+		"hysteria2":     true,
 	}
 	for k := range providerExtras {
 		providerHandled[k] = true
@@ -568,9 +636,8 @@ func TestDriftInboundProtocols_GoModel(t *testing.T) {
 
 func TestDriftInboundProtocols_JS(t *testing.T) {
 	providerHandled := providerProtocolsFromSwitch(t)
-	// "hysteria2" is in upstream model.go (since 2.9.3) but UI inbound.js
-	// stores Hysteria v1/v2 both as "hysteria" with a version field.
 	// "dokodemo-door" is the xray-level name; UI uses "tunnel".
+	// "hysteria2" removed from upstream in v3.2.0; switch-case kept for reading v3.1.0 data.
 	providerExtras := map[string]bool{
 		"vmess":         true,
 		"mixed":         true,
@@ -643,17 +710,18 @@ func TestDriftProtocolForms(t *testing.T) {
 
 func TestDriftStreamSettingsForms(t *testing.T) {
 	providerHandled := map[string]bool{
-		"stream_tcp":         true,
-		"stream_ws":          true,
-		"stream_grpc":        true,
-		"stream_httpupgrade": true,
-		"stream_xhttp":       true,
-		"stream_kcp":         true,
-		"stream_hysteria":    true,
-		"stream_sockopt":     true,
-		"stream_settings":    true, // main stream_settings container
-		"stream_finalmask":   true, // finalmask is part of xhttp settings
-		"external_proxy":     true, // external_proxy block
+		"stream_tcp":            true,
+		"stream_ws":             true,
+		"stream_grpc":           true,
+		"stream_httpupgrade":    true,
+		"stream_xhttp":          true,
+		"stream_kcp":            true,
+		"stream_hysteria":       true,
+		"stream_sockopt":        true,
+		"stream_settings":       true, // main stream_settings container
+		"stream_finalmask":      true, // finalmask is part of xhttp settings
+		"external_proxy":        true, // external_proxy block
+		"stream_external_proxy": true, // TS schema name for external_proxy
 	}
 
 	dir := latestSnapshotDir(t)
@@ -722,7 +790,7 @@ func TestDriftClientFields(t *testing.T) {
 		"auth": true, "email": true, "limitIp": true, "totalGB": true,
 		"expiryTime": true, "enable": true, "tgId": true, "subId": true,
 		"comment": true, "reset": true, "created_at": true, "updated_at": true,
-		"reverse": true,
+		"reverse": true, "group": true,
 	}
 
 	dir := latestSnapshotDir(t)
@@ -790,6 +858,8 @@ func TestDriftAllSettingFields(t *testing.T) {
 		"subJsonFragment": true, "subJsonNoises": true, "subJsonMux": true,
 		"subJsonRules": true, "subClashEnable": true, "subClashPath": true,
 		"subClashURI": true,
+		// v3.2.0
+		"panelProxy": true,
 	}
 
 	// Fields intentionally not managed by the provider.

--- a/provider/inbound_client_resource_test.go
+++ b/provider/inbound_client_resource_test.go
@@ -123,3 +123,45 @@ func TestInboundClientReverseTagExpandFlatten(t *testing.T) {
 		t.Fatalf("expected reverse-a, got %q", flattened.ReverseTag.ValueString())
 	}
 }
+
+func TestInboundClientGroupExpandFlatten(t *testing.T) {
+	t.Run("group set", func(t *testing.T) {
+		model := &InboundClientResourceModel{
+			InboundID: types.Int64Value(1),
+			ClientID:  types.StringValue("uuid"),
+			Email:     types.StringValue("user@test.com"),
+			Group:     types.StringValue("premium"),
+		}
+		expanded := expandInboundClientFromModel(model)
+		if expanded["group"] != "premium" {
+			t.Fatalf("expected group=premium, got %v", expanded["group"])
+		}
+		flattened := inboundClientToModel(1, "uuid", expanded)
+		if flattened.Group.ValueString() != "premium" {
+			t.Fatalf("expected premium, got %q", flattened.Group)
+		}
+	})
+
+	t.Run("group null", func(t *testing.T) {
+		model := &InboundClientResourceModel{
+			InboundID: types.Int64Value(1),
+			ClientID:  types.StringValue("uuid"),
+			Email:     types.StringValue("user@test.com"),
+			Group:     types.StringNull(),
+		}
+		expanded := expandInboundClientFromModel(model)
+		if _, ok := expanded["group"]; ok {
+			t.Fatalf("expected no group key, got %v", expanded["group"])
+		}
+	})
+
+	t.Run("group empty from API", func(t *testing.T) {
+		client := map[string]any{
+			"id": "uuid", "email": "user@test.com", "group": "",
+		}
+		flattened := inboundClientToModel(1, "uuid", client)
+		if !flattened.Group.IsNull() {
+			t.Fatalf("expected null for empty group, got %q", flattened.Group)
+		}
+	})
+}

--- a/provider/resource_inbound.go
+++ b/provider/resource_inbound.go
@@ -160,7 +160,7 @@ func (r *InboundResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 			},
 			"protocol": schema.StringAttribute{
 				Required:    true,
-				Description: "Protocol (vless, vmess, trojan, shadowsocks, http, socks, mixed, wireguard, tunnel, dokodemo-door, hysteria, hysteria2).",
+				Description: "Protocol (vless, vmess, trojan, shadowsocks, http, socks, mixed, wireguard, tunnel, dokodemo-door, hysteria).",
 			},
 			"tag": schema.StringAttribute{
 				Computed:    true,

--- a/provider/resource_inbound_client.go
+++ b/provider/resource_inbound_client.go
@@ -54,6 +54,7 @@ type InboundClientResourceModel struct {
 	SubID      types.String `tfsdk:"sub_id"`
 	Comment    types.String `tfsdk:"comment"`
 	Reset      types.Int64  `tfsdk:"reset"`
+	Group      types.String `tfsdk:"group"`
 }
 
 // ---------------------------------------------------------------------------
@@ -186,6 +187,14 @@ func (r *InboundClientResource) Schema(_ context.Context, _ resource.SchemaReque
 				Default:  int64default.StaticInt64(0),
 				PlanModifiers: []planmodifier.Int64{
 					int64planmodifier.UseStateForUnknown(),
+				},
+			},
+			"group": schema.StringAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: "Client group name (3x-ui v3.2.0+).",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 		},
@@ -500,6 +509,9 @@ func expandInboundClientFromModel(m *InboundClientResourceModel) map[string]any 
 	if !m.Reset.IsNull() && !m.Reset.IsUnknown() {
 		client["reset"] = int(m.Reset.ValueInt64())
 	}
+	if !m.Group.IsNull() && !m.Group.IsUnknown() {
+		client["group"] = m.Group.ValueString()
+	}
 	if !m.ClientID.IsNull() && !m.ClientID.IsUnknown() {
 		client["id"] = m.ClientID.ValueString()
 	}
@@ -526,6 +538,7 @@ func inboundClientToModel(inboundID int, clientID string, client map[string]any)
 		SubID:      types.StringValue(stringValue(client["subId"])),
 		Comment:    types.StringValue(stringValue(client["comment"])),
 		Reset:      types.Int64Value(int64(intValue(client["reset"]))),
+		Group:      stringValueOrNull(stringValue(client["group"])),
 	}
 }
 

--- a/provider/resource_settings_tabs.go
+++ b/provider/resource_settings_tabs.go
@@ -624,6 +624,7 @@ type PanelGeneralModel struct {
 	LDAPDefaultExpiryDays       types.Int64  `tfsdk:"ldap_default_expiry_days"`
 	LDAPDefaultLimitIP          types.Int64  `tfsdk:"ldap_default_limit_ip"`
 	XrayOutboundTestURL         types.String `tfsdk:"xray_outbound_test_url"`
+	PanelProxy                  types.String `tfsdk:"panel_proxy"`
 }
 
 func panelGeneralSchema() schema.Schema {
@@ -796,6 +797,12 @@ func panelGeneralSchema() schema.Schema {
 				Description:   "URL used for testing outbound connectivity (default: https://www.google.com/generate_204).",
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
+			"panel_proxy": schema.StringAttribute{
+				Optional:      true,
+				Computed:      true,
+				Description:   "HTTP/SOCKS5 proxy URL for the panel's own outbound requests (xray version checks, Telegram bot, outbound testing). 3x-ui v3.2.0+.",
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
 		},
 	}
 }
@@ -912,6 +919,9 @@ func expandPanelGeneral(m *PanelGeneralModel) map[string]any {
 	}
 	if !m.LDAPDefaultLimitIP.IsNull() && !m.LDAPDefaultLimitIP.IsUnknown() {
 		payload["ldapDefaultLimitIP"] = int(m.LDAPDefaultLimitIP.ValueInt64())
+	}
+	if !m.PanelProxy.IsNull() && !m.PanelProxy.IsUnknown() {
+		payload["panelProxy"] = m.PanelProxy.ValueString()
 	}
 	return payload
 }
@@ -1030,6 +1040,9 @@ func flattenPanelGeneral(in map[string]any) *PanelGeneralModel {
 	}
 	if v, ok := in["ldapDefaultLimitIP"]; ok {
 		m.LDAPDefaultLimitIP = types.Int64Value(int64(intValue(v)))
+	}
+	if v, ok := in["panelProxy"]; ok {
+		m.PanelProxy = stringValueOrNull(stringValue(v))
 	}
 	return m
 }

--- a/provider/settings_tabs_test.go
+++ b/provider/settings_tabs_test.go
@@ -257,6 +257,52 @@ func TestFlattenPanelGeneral(t *testing.T) {
 	}
 }
 
+func TestPanelProxyExpandFlatten(t *testing.T) {
+	t.Run("proxy set", func(t *testing.T) {
+		m := &PanelGeneralModel{
+			PanelProxy: types.StringValue("socks5://proxy:1080"),
+		}
+		expanded := expandPanelGeneral(m)
+		if expanded["panelProxy"] != "socks5://proxy:1080" {
+			t.Fatalf("expected panelProxy=socks5://proxy:1080, got %v", expanded["panelProxy"])
+		}
+	})
+
+	t.Run("proxy null", func(t *testing.T) {
+		m := &PanelGeneralModel{
+			PanelProxy: types.StringNull(),
+		}
+		expanded := expandPanelGeneral(m)
+		if _, ok := expanded["panelProxy"]; ok {
+			t.Fatalf("expected no panelProxy key, got %v", expanded["panelProxy"])
+		}
+	})
+
+	t.Run("flatten with value", func(t *testing.T) {
+		in := map[string]any{"panelProxy": "http://proxy:8080"}
+		m := flattenPanelGeneral(in)
+		if m.PanelProxy.ValueString() != "http://proxy:8080" {
+			t.Fatalf("expected http://proxy:8080, got %q", m.PanelProxy)
+		}
+	})
+
+	t.Run("flatten empty string", func(t *testing.T) {
+		in := map[string]any{"panelProxy": ""}
+		m := flattenPanelGeneral(in)
+		if !m.PanelProxy.IsNull() {
+			t.Fatalf("expected null for empty panelProxy, got %q", m.PanelProxy)
+		}
+	})
+
+	t.Run("flatten missing key", func(t *testing.T) {
+		in := map[string]any{}
+		m := flattenPanelGeneral(in)
+		if !m.PanelProxy.IsNull() {
+			t.Fatalf("expected null for missing panelProxy, got %q", m.PanelProxy)
+		}
+	})
+}
+
 func TestPreserveSettingSecret_ConfiguredEmptyObservedNonEmpty(t *testing.T) {
 	got := preserveSettingSecret(types.StringValue("existing-secret"), types.StringValue(""))
 	if got.ValueString() != "" {

--- a/provider/testdata/upstream_contract.json
+++ b/provider/testdata/upstream_contract.json
@@ -1,9 +1,8 @@
 {
-  "version": "3.0.2",
+  "version": "3.2.0",
   "protocols_go_model": [
     "http",
     "hysteria",
-    "hysteria2",
     "mixed",
     "shadowsocks",
     "trojan",
@@ -13,8 +12,8 @@
     "wireguard"
   ],
   "protocols_js": [
-    "http",
     "hysteria",
+    "http",
     "mixed",
     "shadowsocks",
     "trojan",
@@ -25,19 +24,19 @@
     "wireguard"
   ],
   "protocol_forms": [
-    "http",
     "hysteria",
+    "http",
     "mixed",
     "shadowsocks",
-    "tun",
     "trojan",
+    "tun",
     "tunnel",
     "vless",
     "vmess",
     "wireguard"
   ],
   "stream_forms": [
-    "external_proxy",
+    "stream_external_proxy",
     "stream_finalmask",
     "stream_grpc",
     "stream_httpupgrade",
@@ -78,11 +77,12 @@
     "enable",
     "expiryTime",
     "flow",
+    "group",
     "id",
     "limitIp",
     "password",
-    "reverse",
     "reset",
+    "reverse",
     "security",
     "subId",
     "tgId",
@@ -116,6 +116,7 @@
     "ldapUserFilter",
     "ldapVlessField",
     "pageSize",
+    "panelProxy",
     "remarkModel",
     "sessionMaxAge",
     "subAnnounce",

--- a/provider/xray_outbounds_schema.go
+++ b/provider/xray_outbounds_schema.go
@@ -221,7 +221,7 @@ func xrayOutboundsSchema() schema.Schema {
 						},
 						"protocol": schema.StringAttribute{
 							Required:    true,
-							Description: "Outbound protocol (freedom, blackhole, dns, vmess, vless, trojan, shadowsocks, socks, http, wireguard, hysteria, hysteria2).",
+							Description: "Outbound protocol (freedom, blackhole, dns, vmess, vless, trojan, shadowsocks, socks, http, wireguard, hysteria).",
 						},
 						"send_through": schema.StringAttribute{
 							Optional: true, Computed: true,


### PR DESCRIPTION
## Summary

- Add `group` attribute to `threexui_inbound_client` resource — new client field in 3x-ui v3.2.0 (client groups feature)
- Add `panel_proxy` attribute to `threexui_panel_general` resource — new panel setting for outbound proxy (HTTP/SOCKS5)
- Remove `hysteria2` from protocol descriptions (removed upstream in v3.2.0; `hysteria` with `stream_settings.version=2` is now the correct way)
- Update drift tests for v3.2.0 TypeScript frontend migration (protocols, stream schemas, protocol forms)
- Update `upstream_contract.json` to v3.2.0 snapshot

## Changes

| File | Change |
|---|---|
| `resource_inbound_client.go` | `group` attribute (Optional+Computed), expand/flatten |
| `resource_settings_tabs.go` | `panel_proxy` attribute (Optional+Computed), expand/flatten |
| `resource_inbound.go` | Remove `hysteria2` from protocol description |
| `xray_outbounds_schema.go` | Remove `hysteria2` from outbound protocol description |
| `default_settings.go` | Remove `hysteria2` from `protocolUsesClients` |
| `default_settings_test.go` | Update test: `hysteria2` → `false` in `protocolUsesClients` |
| `drift_test.go` | TS frontend path support, `group`/`panelProxy`/`hysteria2` drift updates |
| `upstream_contract.json` | v3.2.0 snapshot |

## Test plan

- [x] `task pre-commit` passes (fmt, vet, lint, build)
- [x] `task test:unit` passes (all unit + drift tests)
- [ ] `task test:acc` with v3.2.0 container
- [ ] Verify existing v3.1.0 inbounds still read correctly (hysteria2 alias preserved in expand/flatten)

## Notes

- `hysteria2` switch-case branches are **kept** in expand/flatten for reading existing v3.1.0 data — they route through the same `hysteriaSettings` model
- Version support policy update (dropping 2.9.x) is intentionally not included — that's a separate concern