### PR TITLE
fix: skip socks/dokodemo-door tests on 3x-ui v3.2.0+

### DIFF
--- a/docs/resources/inbound.md
+++ b/docs/resources/inbound.md
@@ -7,7 +7,7 @@ description: |-
 
 # threexui_inbound (Resource)
 
-Manages an inbound proxy in the 3x-ui panel. Supports protocols: vless, vmess, trojan, shadowsocks, http, socks, mixed, wireguard, tunnel, dokodemo-door, hysteria, and hysteria2.
+Manages an inbound proxy in the 3x-ui panel. Supports protocols: vless, vmess, trojan, shadowsocks, http, mixed, wireguard, tunnel, hysteria, and hysteria2. Note: `socks` and `dokodemo-door` are deprecated since 3x-ui v3.2.0 — use `mixed` and `tunnel` instead.
 
 ## Example Usage
 
@@ -164,7 +164,7 @@ resource "threexui_inbound" "hysteria" {
 ### Top-level
 
 - `port` (Required, Number) - Port number for the inbound.
-- `protocol` (Required, String) - Protocol type (`vless`, `vmess`, `trojan`, `shadowsocks`, `http`, `socks`, `mixed`, `wireguard`, `tunnel`, `dokodemo-door`, `hysteria`, `hysteria2`).
+- `protocol` (Required, String) - Protocol type (`vless`, `vmess`, `trojan`, `shadowsocks`, `http`, `mixed`, `wireguard`, `tunnel`, `hysteria`, `hysteria2`). `socks` and `dokodemo-door` are deprecated since 3x-ui v3.2.0 — use `mixed` and `tunnel` instead.
 - `enable` (Optional, Boolean) - Whether the inbound is enabled. Default is `true`.
 - `remark` (Optional, String) - A label/name for the inbound.
 - `listen` (Optional, String) - Listen address.

--- a/provider/acc_inbound_test.go
+++ b/provider/acc_inbound_test.go
@@ -179,6 +179,8 @@ resource "threexui_inbound" "wg" {
 // --- Dokodemo-door (tunnel) ---
 
 func TestAccInboundDokodemo(t *testing.T) {
+	requireBelowVersion(t, "v3.2.0") // dokodemo-door renamed to "tunnel" in v3.2.0
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),

--- a/provider/resource_inbound.go
+++ b/provider/resource_inbound.go
@@ -160,7 +160,7 @@ func (r *InboundResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 			},
 			"protocol": schema.StringAttribute{
 				Required:    true,
-				Description: "Protocol (vless, vmess, trojan, shadowsocks, http, socks, mixed, wireguard, tunnel, dokodemo-door, hysteria).",
+				Description: "Protocol (vless, vmess, trojan, shadowsocks, http, mixed, wireguard, tunnel, hysteria). socks and dokodemo-door are deprecated since 3x-ui v3.2.0 — use mixed and tunnel instead.",
 			},
 			"tag": schema.StringAttribute{
 				Computed:    true,
@@ -232,7 +232,11 @@ func (r *InboundResource) Create(ctx context.Context, req resource.CreateRequest
 
 	created, err := r.client.AddInbound(ctx, inbound)
 	if err != nil {
-		resp.Diagnostics.AddError("Failed to create inbound", err.Error())
+		if hint := deprecatedProtocolHint(inbound.Protocol); hint != "" {
+			resp.Diagnostics.AddError("Failed to create inbound", err.Error()+"\n\n"+hint)
+		} else {
+			resp.Diagnostics.AddError("Failed to create inbound", err.Error())
+		}
 		return
 	}
 
@@ -391,7 +395,11 @@ func (r *InboundResource) Update(ctx context.Context, req resource.UpdateRequest
 
 	_, err = r.client.UpdateInbound(ctx, inbound)
 	if err != nil {
-		resp.Diagnostics.AddError("Failed to update inbound", err.Error())
+		if hint := deprecatedProtocolHint(inbound.Protocol); hint != "" {
+			resp.Diagnostics.AddError("Failed to update inbound", err.Error()+"\n\n"+hint)
+		} else {
+			resp.Diagnostics.AddError("Failed to update inbound", err.Error())
+		}
 		return
 	}
 
@@ -1118,5 +1126,18 @@ func isSubset(desired, actual any) bool {
 		return true
 	default:
 		return reflect.DeepEqual(desired, actual)
+	}
+}
+
+// deprecatedProtocolHint returns a user-facing hint when a protocol
+// was removed in 3x-ui v3.2.0.
+func deprecatedProtocolHint(protocol string) string {
+	switch protocol {
+	case "socks":
+		return `Protocol "socks" is not supported by 3x-ui v3.2.0+. Use protocol "mixed" instead.`
+	case "dokodemo-door":
+		return `Protocol "dokodemo-door" is not supported by 3x-ui v3.2.0+. Use protocol "tunnel" instead.`
+	default:
+		return ""
 	}
 }

--- a/provider/resource_inbound_matrix_test.go
+++ b/provider/resource_inbound_matrix_test.go
@@ -29,6 +29,9 @@ type protocolMatrixEntry struct {
 	port int
 	// minVersion is the minimum 3x-ui version required (e.g. "v2.9.0"). Empty means all versions.
 	minVersion string
+	// maxVersion is the maximum 3x-ui version (exclusive). Empty means no upper bound.
+	// Use for protocols removed upstream (e.g. "v3.2.0" means not available on v3.2.0+).
+	maxVersion string
 	// createHCL returns the HCL for the initial create step.
 	createHCL func(port int) string
 	// updateHCL returns the HCL for the update step (must change at least one
@@ -74,6 +77,9 @@ func TestAccInboundProtocolMatrix(t *testing.T) {
 		t.Run(entry.protocol, func(t *testing.T) {
 			if entry.minVersion != "" {
 				requireMinVersion(t, entry.minVersion)
+			}
+			if entry.maxVersion != "" {
+				requireBelowVersion(t, entry.maxVersion)
 			}
 
 			inboundAddr := fmt.Sprintf("threexui_inbound.%s", entry.tfName)
@@ -527,9 +533,10 @@ resource "threexui_inbound" "mx_http" {
 
 func matrixSocks() protocolMatrixEntry {
 	return protocolMatrixEntry{
-		protocol: "socks",
-		tfName:   "mx_socks",
-		port:     26006,
+		protocol:   "socks",
+		tfName:     "mx_socks",
+		port:       26006,
+		maxVersion: "v3.2.0", // socks removed upstream; use "mixed" instead
 		createHCL: func(port int) string {
 			return fmt.Sprintf(`
 resource "threexui_inbound" "mx_socks" {
@@ -706,9 +713,10 @@ resource "threexui_inbound" "mx_wg" {
 
 func matrixDokodemo() protocolMatrixEntry {
 	return protocolMatrixEntry{
-		protocol: "dokodemo-door",
-		tfName:   "mx_dokodemo",
-		port:     26008,
+		protocol:   "dokodemo-door",
+		tfName:     "mx_dokodemo",
+		port:       26008,
+		maxVersion: "v3.2.0", // dokodemo-door renamed to "tunnel" upstream
 		createHCL: func(port int) string {
 			return fmt.Sprintf(`
 resource "threexui_inbound" "mx_dokodemo" {

--- a/provider/test_helpers.go
+++ b/provider/test_helpers.go
@@ -1,7 +1,6 @@
 package provider
 
 import (
-	"fmt"
 	"os"
 	"testing"
 
@@ -10,7 +9,7 @@ import (
 
 // requireMinVersion skips the test if THREEXUI_VERSION is set and is older than min.
 // Both values must use "v" prefix (e.g. "v2.9.0").
-func requireMinVersion(t *testing.T, min string) {
+func requireMinVersion(t skipFatalHelper, min string) {
 	t.Helper()
 
 	v := os.Getenv("THREEXUI_VERSION")
@@ -23,7 +22,7 @@ func requireMinVersion(t *testing.T, min string) {
 	}
 
 	if !semver.IsValid(min) {
-		t.Fatalf("invalid min version %q", min)
+		t.Fatal("invalid min version " + min)
 	}
 
 	if semver.Compare(v, min) < 0 {
@@ -47,7 +46,7 @@ func requireBelowVersion(t skipFatalHelper, max string) {
 	}
 
 	if !semver.IsValid(max) {
-		t.Fatal(fmt.Sprintf("invalid max version %q", max))
+		t.Fatal("invalid max version " + max)
 	}
 
 	if semver.Compare(v, max) >= 0 {

--- a/provider/test_helpers.go
+++ b/provider/test_helpers.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -27,6 +28,30 @@ func requireMinVersion(t *testing.T, min string) {
 
 	if semver.Compare(v, min) < 0 {
 		t.Skipf("requires 3x-ui >= %s, running %s", min, v)
+	}
+}
+
+// requireBelowVersion skips the test if THREEXUI_VERSION is set and is >= max.
+// Use for protocol features removed in a specific 3x-ui version.
+// Both values must use "v" prefix (e.g. "v3.2.0").
+func requireBelowVersion(t skipFatalHelper, max string) {
+	t.Helper()
+
+	v := os.Getenv("THREEXUI_VERSION")
+	if v == "" {
+		return // no version constraint, run the test
+	}
+
+	if !semver.IsValid(v) {
+		return // can't parse, don't skip
+	}
+
+	if !semver.IsValid(max) {
+		t.Fatal(fmt.Sprintf("invalid max version %q", max))
+	}
+
+	if semver.Compare(v, max) >= 0 {
+		t.Skipf("removed in 3x-ui >= %s, running %s", max, v)
 	}
 }
 

--- a/provider/test_helpers_test.go
+++ b/provider/test_helpers_test.go
@@ -74,3 +74,41 @@ func contains(s, sub string) bool {
 	}
 	return false
 }
+
+func TestRequireBelowVersion(t *testing.T) {
+	t.Run("no env runs the test", func(t *testing.T) {
+		t.Setenv("THREEXUI_VERSION", "")
+		ft := &fakeT{}
+		requireBelowVersion(ft, "v3.2.0")
+		if ft.skipped {
+			t.Fatalf("should not skip when THREEXUI_VERSION is empty (msg=%q)", ft.skipMsg)
+		}
+	})
+
+	t.Run("version at max skips", func(t *testing.T) {
+		t.Setenv("THREEXUI_VERSION", "v3.2.0")
+		ft := &fakeT{}
+		requireBelowVersion(ft, "v3.2.0")
+		if !ft.skipped {
+			t.Fatal("should skip when version equals max")
+		}
+	})
+
+	t.Run("version above max skips", func(t *testing.T) {
+		t.Setenv("THREEXUI_VERSION", "v3.3.0")
+		ft := &fakeT{}
+		requireBelowVersion(ft, "v3.2.0")
+		if !ft.skipped {
+			t.Fatal("should skip when version above max")
+		}
+	})
+
+	t.Run("version below max runs the test", func(t *testing.T) {
+		t.Setenv("THREEXUI_VERSION", "v3.1.0")
+		ft := &fakeT{}
+		requireBelowVersion(ft, "v3.2.0")
+		if ft.skipped {
+			t.Fatalf("should not skip when version below max (msg=%q)", ft.skipMsg)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- 3x-ui v3.2.0 added strict protocol validation that rejects `socks` and `dokodemo-door` protocol names (replaced by `mixed` and `tunnel` respectively)
- Add `requireBelowVersion` test helper to skip tests on versions where features are removed upstream
- Add `maxVersion` field to `protocolMatrixEntry` for the protocol round-trip test

## Test plan

- [x] Unit tests for `requireBelowVersion` pass
- [x] `task pre-commit` passes (fmt + vet + lint + build)
- [ ] CI compat jobs pass on all 3x-ui versions