### PR TITLE
docs: refresh 3x-ui compatibility docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,7 +131,7 @@ These are non-obvious constraints that have caused real bugs.
 | `web_base_path` change triggers panel restart | Must also update provider `base_path`; code auto-updates client |
 
 **Always check 3x-ui source snapshots** (`3x-ui-<version>/`) before assuming API behavior.
-Key paths: `web/service/`, `web/controller/`, `web/entity/model/`, `xray/`.
+Key paths: `database/model/`, `web/service/`, `web/controller/`, `web/entity/`, `frontend/src/schemas/`, `xray/`.
 
 ---
 
@@ -165,7 +165,7 @@ Imperative mood, concise subjects.
 - Acceptance tests: `TestAccXxx`, `terraform-plugin-testing`,
   `ProtoV6ProviderFactories` (not `ProviderFactories`).
 - Version-aware skipping: `requireMinVersion(t, "vX.Y.Z")` for features from
-  specific 3x-ui versions. Currently supported: **v2.9.x**, **v3.0.x**, and **v3.1.x**.
+  specific 3x-ui versions. Currently supported: **v2.9.x**, **v3.0.x**, **v3.1.x**, and **v3.2.x**.
 - Flaky test quarantine: `skipOnFlakyVersions(t, ...)` / `skipIfFlaky(t)` with
   `THREEXUI_SKIP_FLAKY` env var to skip known-broken upstream versions.
 - Protocol matrix test (`resource_inbound_matrix_test.go`): comprehensive

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ This handles `docker compose up`, sets the required environment variables (`TF_A
 
 ## Project Structure
 
-All provider code lives in the `provider/` directory. See [AGENTS.md](AGENTS.md) for a detailed file-by-file breakdown.
+All provider code lives in the `provider/` directory. See [CLAUDE.md](CLAUDE.md) for project-specific implementation notes.
 
 Key patterns:
 
@@ -80,7 +80,7 @@ Key patterns:
 
 ## 3x-ui Source Snapshots
 
-The repository may contain `3x-ui-<version>/` directories (git-ignored) with 3x-ui source snapshots. These are used for diffing between versions when updating the provider to support a new 3x-ui release. See the "Updating 3x-ui Version" section in [AGENTS.md](AGENTS.md) for the full process.
+The repository may contain `3x-ui-<version>/` directories (git-ignored) with 3x-ui source snapshots. These are used for diffing between versions when updating the provider to support a new 3x-ui release. The drift tests in `provider/drift_test.go` automatically use the latest local snapshot unless `THREEXUI_SNAPSHOT_DIR` points to another checkout.
 
 ## Submitting Changes
 

--- a/README.ar_EG.md
+++ b/README.ar_EG.md
@@ -143,7 +143,7 @@ resource "threexui_inbound_client" "client_a" {
 
 | Resource | الوصف |
 | --- | --- |
-| `threexui_inbound` | inbound (vless, vmess, trojan, shadowsocks, http, socks, mixed, wireguard, dokodemo-door) |
+| `threexui_inbound` | inbound (vless, vmess, trojan, shadowsocks, http, mixed, wireguard, tunnel, hysteria؛ socks/dokodemo-door legacy قبل 3.2) |
 | `threexui_inbound_client` | عميل داخل inbound |
 | `threexui_panel_general` | إعدادات اللوحة العامة |
 | `threexui_panel_security` | إعدادات الأمان (2FA) |

--- a/README.es_ES.md
+++ b/README.es_ES.md
@@ -137,7 +137,7 @@ La documentación completa está en el [Terraform Registry](https://registry.ter
 
 | Recurso | Descripción |
 | --- | --- |
-| `threexui_inbound` | Inbound (vless, vmess, trojan, shadowsocks, http, socks, mixed, wireguard, dokodemo-door) |
+| `threexui_inbound` | Inbound (vless, vmess, trojan, shadowsocks, http, mixed, wireguard, tunnel, hysteria; socks/dokodemo-door legacy antes de 3.2) |
 | `threexui_inbound_client` | Cliente dentro de un inbound |
 | `threexui_panel_general` | Ajustes generales del panel |
 | `threexui_panel_security` | Ajustes de seguridad (2FA) |

--- a/README.fa_IR.md
+++ b/README.fa_IR.md
@@ -143,7 +143,7 @@ resource "threexui_inbound_client" "client_a" {
 
 | Resource | توضیح |
 | --- | --- |
-| `threexui_inbound` | اینباند (vless, vmess, trojan, shadowsocks, http, socks, mixed, wireguard, dokodemo-door) |
+| `threexui_inbound` | اینباند (vless, vmess, trojan, shadowsocks, http, mixed, wireguard, tunnel, hysteria؛ socks/dokodemo-door در نسخه‌های قبل از 3.2 به‌صورت legacy) |
 | `threexui_inbound_client` | کلاینت داخل اینباند |
 | `threexui_panel_general` | تنظیمات عمومی پنل |
 | `threexui_panel_security` | تنظیمات امنیت (2FA) |

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Full documentation is available on the [Terraform Registry](https://registry.ter
 
 | Resource | Description |
 | --- | --- |
-| `threexui_inbound` | Inbound proxy (vless, vmess, trojan, shadowsocks, http, socks, mixed, wireguard, dokodemo-door) |
+| `threexui_inbound` | Inbound proxy (vless, vmess, trojan, shadowsocks, http, mixed, wireguard, tunnel, hysteria; legacy socks/dokodemo-door before 3.2) |
 | `threexui_inbound_client` | Client within an inbound |
 | `threexui_panel_general` | General panel settings |
 | `threexui_panel_security` | Security settings (2FA) |

--- a/README.ru_RU.md
+++ b/README.ru_RU.md
@@ -137,7 +137,7 @@ resource "threexui_inbound_client" "client_a" {
 
 | Ресурс | Описание |
 | --- | --- |
-| `threexui_inbound` | Инбаунд (vless, vmess, trojan, shadowsocks, http, socks, mixed, wireguard, dokodemo-door) |
+| `threexui_inbound` | Инбаунд (vless, vmess, trojan, shadowsocks, http, mixed, wireguard, tunnel, hysteria; legacy socks/dokodemo-door до 3.2) |
 | `threexui_inbound_client` | Клиент внутри инбаунда |
 | `threexui_panel_general` | Общие настройки панели |
 | `threexui_panel_security` | Безопасность (2FA) |

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -137,7 +137,7 @@ resource "threexui_inbound_client" "client_a" {
 
 | Resource | 说明 |
 | --- | --- |
-| `threexui_inbound` | inbound 代理(vless、vmess、trojan、shadowsocks、http、socks、mixed、wireguard、dokodemo-door) |
+| `threexui_inbound` | inbound 代理(vless、vmess、trojan、shadowsocks、http、mixed、wireguard、tunnel、hysteria；3.2 之前兼容 legacy socks/dokodemo-door) |
 | `threexui_inbound_client` | inbound 内的客户端 |
 | `threexui_panel_general` | 面板通用设置 |
 | `threexui_panel_security` | 安全设置(2FA) |

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -27,7 +27,7 @@ tasks:
     vars:
       TERRAFORM_PATH:
         sh: which terraform
-      THREEXUI_VERSION: '{{.THREEXUI_VERSION | default "v3.1.0"}}'
+      THREEXUI_VERSION: '{{.THREEXUI_VERSION | default "v3.2.0"}}'
     cmds:
       - docker compose down -v 2>/dev/null || true
       - docker compose up --detach --wait --quiet-pull
@@ -50,7 +50,7 @@ tasks:
     vars:
       TERRAFORM_PATH:
         sh: which terraform
-      THREEXUI_VERSION: '{{.THREEXUI_VERSION | default "v3.1.0"}}'
+      THREEXUI_VERSION: '{{.THREEXUI_VERSION | default "v3.2.0"}}'
     cmds:
       - echo "Running tests against 3x-ui {{.THREEXUI_VERSION}} at http://localhost:2053"
       - docker compose down -v 2>/dev/null || true

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   3xui:
-    image: ghcr.io/mhsanaei/3x-ui:${THREEXUI_VERSION:-v3.1.0}
+    image: ghcr.io/mhsanaei/3x-ui:${THREEXUI_VERSION:-v3.2.0}
     ports:
       - "2053:2053" # HTTP panel
     environment:

--- a/docs/data-sources/online_clients.md
+++ b/docs/data-sources/online_clients.md
@@ -25,4 +25,5 @@ This data source has no arguments.
 
 ## Attribute Reference
 
+- `id` (String) - Count of online clients.
 - `clients` (List of String) - List of online client emails.

--- a/docs/data-sources/server_status.md
+++ b/docs/data-sources/server_status.md
@@ -25,4 +25,5 @@ This data source has no arguments.
 
 ## Attribute Reference
 
+- `id` (String) - Length of the JSON payload in bytes.
 - `json` (String) - Server status as a JSON string.

--- a/docs/data-sources/settings.md
+++ b/docs/data-sources/settings.md
@@ -28,4 +28,5 @@ This data source has no arguments.
 
 ## Attribute Reference
 
+- `id` (String) - Length of the JSON payload in bytes.
 - `json` (String, Sensitive) - All panel settings as a JSON string. Marked as sensitive because the payload contains Telegram bot tokens, LDAP passwords, 2FA secrets, and other panel credentials.

--- a/docs/data-sources/xray_config.md
+++ b/docs/data-sources/xray_config.md
@@ -28,4 +28,5 @@ This data source has no arguments.
 
 ## Attribute Reference
 
+- `id` (String) - Length of the JSON payload in bytes.
 - `json` (String, Sensitive) - The current Xray template configuration as a JSON string. Marked sensitive because the payload includes outbound credentials, client UUIDs, WireGuard `secretKey`, and Reality `privateKey`.

--- a/docs/data-sources/xray_versions.md
+++ b/docs/data-sources/xray_versions.md
@@ -25,4 +25,5 @@ This data source has no arguments.
 
 ## Attribute Reference
 
+- `id` (String) - Count of available Xray versions.
 - `versions` (List of String) - Available Xray versions.

--- a/docs/guides/version-compatibility.md
+++ b/docs/guides/version-compatibility.md
@@ -11,12 +11,14 @@ The 3x-ui panel evolves quickly, and some releases introduce breaking API change
 
 ## Support policy
 
-The provider officially supports the **two latest 3x-ui minor lines**. Currently that is **2.9.x** and **3.0.x** — every released patch in both lines is exercised by the acceptance matrix on each push to `main` and every pull request. When a new minor (e.g. 3.1.0) is released, the oldest supported line is dropped from the matrix and from this table.
+The provider officially supports four 3x-ui minor lines: **2.9.x**, **3.0.x**, **3.1.x**, and **3.2.x**. Every released patch in those lines is exercised by the acceptance matrix on each push to `main` and every pull request.
 
 ## Compatibility table
 
 | 3x-ui version | Status | Notes |
 | --- | --- | --- |
+| v3.2.0 | Tested | Latest supported v3.2.x release. `socks` and `dokodemo-door` are no longer available upstream; use `mixed` and `tunnel`. |
+| v3.1.0 | Tested | New client API surface; the provider detects it automatically. |
 | v3.0.2 | Tested | Latest v3.0.x patch. CSRF-protected API. |
 | v3.0.1 | Tested | CSRF-protected API. |
 | v3.0.0 | Tested | CSRF tokens introduced (see [Breaking changes](#breaking-changes)). Multi-node surface, API token endpoint. |
@@ -43,6 +45,10 @@ Starting with v3.0.0, 3x-ui requires a CSRF token for all unsafe HTTP methods (P
 3. On a 403 (stale token), the provider refreshes via `GET /panel/csrf-token` and retries once.
 
 No configuration is needed on your end. The CSRF flow is transparent.
+
+### v3.2.0+ — legacy inbound protocols removed upstream
+
+3x-ui v3.2.0 removed the legacy `socks` and `dokodemo-door` protocol entries from the current upstream UI/API surface. Use `mixed` instead of `socks`, and `tunnel` instead of `dokodemo-door`. The provider keeps compatibility paths for older supported panels and imported state, but new configurations targeting v3.2.0+ should use the current protocol names.
 
 ## Breaking changes
 
@@ -83,7 +89,12 @@ The provider's acceptance test suite uses `requireMinVersion(t, "vX.Y.Z")` to sk
 Current version gates:
 
 - **v2.9.0+**: mixed protocol inbound, WireGuard `mtu` as list, `gateway`, `dns`, sniffing `ips_excluded`/`domains_excluded`, KCP `cwnd_multiplier`/`max_sending_window`.
+- **v2.9.2+**: XHTTP padding fields and the compact subscription JSON fragment/noises format.
+- **v2.9.4+**: outbound `final_rule` and VLESS `reverse_tag`.
 - **v3.0.0+**: CSRF-protected unsafe requests, inbound `nodeId`, multi-node surface, API token endpoint.
+- **v3.0.2+**: tunnel `rewrite_address`, `rewrite_port`, and `allowed_network`; default trusted proxy CIDRs; subscription email-in-remark default.
+- **v3.1.0+**: new client API surface; the provider detects and uses it automatically.
+- **v3.2.0+**: `mixed`/`tunnel` replace legacy `socks`/`dokodemo-door`; client `group` and panel `panel_proxy` are available.
 
 Tests without `requireMinVersion` run on all supported versions (v2.9.0+).
 
@@ -93,13 +104,13 @@ The provider communicates with whatever 3x-ui version is running on your host. T
 
 ```bash
 # Set the 3x-ui image tag
-export THREEXUI_VERSION=v3.0.2
+export THREEXUI_VERSION=v3.2.0
 
 # Start the container
 docker compose up -d
 ```
 
-In `docker-compose.yaml`, the image tag is parameterized via `${THREEXUI_VERSION:-v3.0.2}`, so omitting the variable defaults to the latest tested version.
+In `docker-compose.yaml`, the image tag is parameterized via `${THREEXUI_VERSION:-v3.2.0}`, so omitting the variable defaults to the latest tested version.
 
 For the Terraform provider itself, use the latest release from the [Terraform Registry](https://registry.terraform.io/providers/batonogov/threexui). The single provider binary supports all 3x-ui versions listed in the compatibility table above.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,7 +45,7 @@ resource "threexui_inbound" "vless" {
 
 ## Authentication
 
-The provider authenticates to the 3x-ui panel using username and password. These can be provided directly in the provider configuration or via environment variables.
+The provider authenticates to the 3x-ui panel using username and password. These can be provided directly in the provider configuration, or indirectly through Terraform input variables such as `TF_VAR_threexui_username` and `TF_VAR_threexui_password`.
 
 For first-run bootstrap of a fresh panel, you can configure `bootstrap_username` and `bootstrap_password` in addition to the steady-state `username` and `password`. Use this together with `threexui_panel_user` to rotate the panel to the steady-state credentials during the same apply. On 3x-ui v2.9.x, failed logins can expose the submitted password in panel logs or Telegram login notifications, so the provider tries bootstrap credentials before the steady-state credentials. On 3x-ui v3.x, the provider tries steady-state credentials first and falls back to bootstrap credentials only if the panel rejects them. The provider does not silently try `admin`/`admin`; bootstrap credentials must be configured explicitly.
 

--- a/docs/resources/inbound.md
+++ b/docs/resources/inbound.md
@@ -7,7 +7,7 @@ description: |-
 
 # threexui_inbound (Resource)
 
-Manages an inbound proxy in the 3x-ui panel. Supports protocols: vless, vmess, trojan, shadowsocks, http, mixed, wireguard, tunnel, hysteria, and hysteria2. Note: `socks` and `dokodemo-door` are deprecated since 3x-ui v3.2.0 — use `mixed` and `tunnel` instead.
+Manages an inbound proxy in the 3x-ui panel. Supports protocols: vless, vmess, trojan, shadowsocks, http, mixed, wireguard, tunnel, and hysteria. For older panels, the provider also preserves legacy `socks`, `dokodemo-door`, and `hysteria2` values from imported state; on 3x-ui v3.2.0+ use `mixed`, `tunnel`, and `hysteria` with `version = 2` for new configurations.
 
 ## Example Usage
 
@@ -164,7 +164,7 @@ resource "threexui_inbound" "hysteria" {
 ### Top-level
 
 - `port` (Required, Number) - Port number for the inbound.
-- `protocol` (Required, String) - Protocol type (`vless`, `vmess`, `trojan`, `shadowsocks`, `http`, `mixed`, `wireguard`, `tunnel`, `hysteria`, `hysteria2`). `socks` and `dokodemo-door` are deprecated since 3x-ui v3.2.0 — use `mixed` and `tunnel` instead.
+- `protocol` (Required, String) - Protocol type (`vless`, `vmess`, `trojan`, `shadowsocks`, `http`, `mixed`, `wireguard`, `tunnel`, `hysteria`). Legacy `socks` and `dokodemo-door` are available only on panels before 3x-ui v3.2.0; use `mixed` and `tunnel` on v3.2.0+.
 - `enable` (Optional, Boolean) - Whether the inbound is enabled. Default is `true`.
 - `remark` (Optional, String) - A label/name for the inbound.
 - `listen` (Optional, String) - Listen address.

--- a/examples/import-existing/main.tf
+++ b/examples/import-existing/main.tf
@@ -43,10 +43,12 @@
 #
 # Xray settings are also singletons:
 #
-#   terraform import threexui_xray_basics.config settings
-#   terraform import threexui_xray_dns.config settings
-#   terraform import threexui_xray_routing.config settings
-#   terraform import threexui_xray_outbounds.config settings
+#   terraform import threexui_xray_basics.config xray_basics
+#   terraform import threexui_xray_dns.config xray_dns
+#   terraform import threexui_xray_routing.config xray_routing
+#   terraform import threexui_xray_balancers.config xray_balancers
+#   terraform import threexui_xray_reverse.config xray_reverse
+#   terraform import threexui_xray_outbounds.config xray_outbounds
 #
 # --------------------------------------------------------------------------
 
@@ -54,7 +56,7 @@ terraform {
   required_providers {
     threexui = {
       source  = "batonogov/threexui"
-      version = "~> 2.0"
+      version = "~> 3.0"
     }
   }
 }

--- a/examples/inbound-with-client/main.tf
+++ b/examples/inbound-with-client/main.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     threexui = {
       source  = "batonogov/threexui"
-      version = "~> 2.0"
+      version = "~> 3.0"
     }
   }
 }

--- a/examples/multi-server/modules/server/main.tf
+++ b/examples/multi-server/modules/server/main.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     threexui = {
       source  = "batonogov/threexui"
-      version = "~> 2.0"
+      version = "~> 3.0"
     }
   }
 }

--- a/examples/provider-env-config/main.tf
+++ b/examples/provider-env-config/main.tf
@@ -38,7 +38,7 @@ terraform {
   required_providers {
     threexui = {
       source  = "batonogov/threexui"
-      version = "~> 2.0"
+      version = "~> 3.0"
     }
   }
 }

--- a/examples/shadowsocks-inbound/main.tf
+++ b/examples/shadowsocks-inbound/main.tf
@@ -11,7 +11,7 @@ terraform {
   required_providers {
     threexui = {
       source  = "batonogov/threexui"
-      version = "~> 2.0"
+      version = "~> 3.0"
     }
   }
 }

--- a/examples/trojan-inbound/main.tf
+++ b/examples/trojan-inbound/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     threexui = {
       source  = "batonogov/threexui"
-      version = "~> 2.0"
+      version = "~> 3.0"
     }
   }
 }

--- a/provider/data_source_schema_test.go
+++ b/provider/data_source_schema_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 )
 
-// TestDataSourceSensitiveAttributes guards the AGENTS.md security rule that any
+// TestDataSourceSensitiveAttributes guards the project security rule that any
 // data source returning a raw JSON payload from the panel/Xray API must mark its
 // JSON attribute Sensitive. Without this assertion a future refactor could
 // silently drop the flag and re-expose client UUIDs/passwords, Reality keys,

--- a/provider/test_helpers.go
+++ b/provider/test_helpers.go
@@ -85,7 +85,7 @@ func skipOnFlakyVersions(t skipFatalHelper, reason string, versions ...string) {
 	}
 }
 
-// needs sub-day quarantine (see AGENTS.md -> CI Flake Mitigation). Removing
+// needs sub-day quarantine (see CLAUDE.md -> Testing). Removing
 // it forces every quarantine to start with a Taskfile/CI plumbing change.
 //
 // skipIfFlaky quarantines a known-flaky test when THREEXUI_SKIP_FLAKY is


### PR DESCRIPTION
## Summary
- update docs and examples for latest tested 3x-ui v3.2.0
- document current inbound protocols and legacy protocol compatibility
- refresh provider constraints, import examples, and stale project references

## Tests
- go test ./provider -run 'TestDrift|TestSemverSorting' -count=1 -v
- task test:unit
- terraform fmt -check -recursive examples
- git diff --check