### PR TITLE
fix: use Reality stream settings for VLESS client tests with flow

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/batonogov/terraform-provider-threexui
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/hashicorp/terraform-plugin-framework v1.19.0

--- a/provider/acc_inbound_client_test.go
+++ b/provider/acc_inbound_client_test.go
@@ -19,6 +19,14 @@ resource "threexui_inbound" "client_host" {
   vless_settings {
     decryption = "none"
   }
+  stream_settings {
+    network  = "tcp"
+    security = "reality"
+    reality_settings {
+      target       = "google.com:443"
+      server_names = ["google.com"]
+    }
+  }
 }
 
 resource "threexui_inbound_client" "allfields" {
@@ -117,6 +125,14 @@ resource "threexui_inbound" "multi_host" {
   enable   = true
   vless_settings {
     decryption = "none"
+  }
+  stream_settings {
+    network  = "tcp"
+    security = "reality"
+    reality_settings {
+      target       = "google.com:443"
+      server_names = ["google.com"]
+    }
   }
 }
 
@@ -231,6 +247,14 @@ resource "threexui_inbound" "removal_host" {
   vless_settings {
     decryption = "none"
   }
+  stream_settings {
+    network  = "tcp"
+    security = "reality"
+    reality_settings {
+      target       = "google.com:443"
+      server_names = ["google.com"]
+    }
+  }
 }
 
 resource "threexui_inbound_client" "remove1" {
@@ -263,6 +287,14 @@ resource "threexui_inbound" "removal_host" {
   vless_settings {
     decryption = "none"
   }
+  stream_settings {
+    network  = "tcp"
+    security = "reality"
+    reality_settings {
+      target       = "google.com:443"
+      server_names = ["google.com"]
+    }
+  }
 }
 
 resource "threexui_inbound_client" "remove1" {
@@ -292,6 +324,14 @@ resource "threexui_inbound" "autouuid_host" {
   enable   = true
   vless_settings {
     decryption = "none"
+  }
+  stream_settings {
+    network  = "tcp"
+    security = "reality"
+    reality_settings {
+      target       = "google.com:443"
+      server_names = ["google.com"]
+    }
   }
 }
 
@@ -337,6 +377,14 @@ resource "threexui_inbound" "explicitid_host" {
   enable   = true
   vless_settings {
     decryption = "none"
+  }
+  stream_settings {
+    network  = "tcp"
+    security = "reality"
+    reality_settings {
+      target       = "google.com:443"
+      server_names = ["google.com"]
+    }
   }
 }
 
@@ -424,6 +472,14 @@ resource "threexui_inbound" "upd_host" {
   enable   = true
   vless_settings {
     decryption = "none"
+  }
+  stream_settings {
+    network  = "tcp"
+    security = "reality"
+    reality_settings {
+      target       = "google.com:443"
+      server_names = ["google.com"]
+    }
   }
 }
 

--- a/provider/acc_inbound_test.go
+++ b/provider/acc_inbound_test.go
@@ -592,6 +592,14 @@ resource "threexui_inbound" "dup_host" {
   vless_settings {
     decryption = "none"
   }
+  stream_settings {
+    network  = "tcp"
+    security = "reality"
+    reality_settings {
+      target       = "google.com:443"
+      server_names = ["google.com"]
+    }
+  }
 }
 
 resource "threexui_inbound_client" "dup1" {

--- a/provider/acc_test.go
+++ b/provider/acc_test.go
@@ -421,6 +421,14 @@ resource "threexui_inbound" "test" {
   vless_settings {
     decryption = "none"
   }
+  stream_settings {
+    network  = "tcp"
+    security = "reality"
+    reality_settings {
+      target       = "google.com:443"
+      server_names = ["google.com"]
+    }
+  }
 }
 
 resource "threexui_inbound_client" "test" {

--- a/provider/resource_inbound_matrix_test.go
+++ b/provider/resource_inbound_matrix_test.go
@@ -224,8 +224,8 @@ resource "threexui_inbound" "mx_vless" {
     network  = "tcp"
     security = "reality"
     reality_settings {
-      target       = "google.com:443"
-      server_names = ["google.com"]
+      target       = "github.com:443"
+      server_names = ["github.com"]
     }
   }
   sniffing {
@@ -242,6 +242,7 @@ resource "threexui_inbound" "mx_vless" {
 				resource.TestCheckResourceAttr(addr, "remark", "matrix-vless-create"),
 				resource.TestCheckResourceAttr(addr, "stream_settings.network", "tcp"),
 				resource.TestCheckResourceAttr(addr, "stream_settings.security", "reality"),
+				resource.TestCheckResourceAttr(addr, "stream_settings.reality_settings.target", "google.com:443"),
 			}
 		},
 		updateChecks: func(addr string) []resource.TestCheckFunc {
@@ -249,6 +250,7 @@ resource "threexui_inbound" "mx_vless" {
 				resource.TestCheckResourceAttr(addr, "remark", "matrix-vless-updated"),
 				resource.TestCheckResourceAttr(addr, "stream_settings.network", "tcp"),
 				resource.TestCheckResourceAttr(addr, "stream_settings.security", "reality"),
+				resource.TestCheckResourceAttr(addr, "stream_settings.reality_settings.target", "github.com:443"),
 			}
 		},
 		hasClient: true,

--- a/provider/resource_inbound_matrix_test.go
+++ b/provider/resource_inbound_matrix_test.go
@@ -195,10 +195,10 @@ resource "threexui_inbound" "mx_vless" {
   }
   stream_settings {
     network  = "tcp"
-    security = "none"
-    tcp_settings {
-      accept_proxy_protocol = false
-      header_type           = "none"
+    security = "reality"
+    reality_settings {
+      target       = "google.com:443"
+      server_names = ["google.com"]
     }
   }
   sniffing {
@@ -221,10 +221,11 @@ resource "threexui_inbound" "mx_vless" {
     decryption = "none"
   }
   stream_settings {
-    network  = "ws"
-    security = "none"
-    ws_settings {
-      path = "/vless-ws"
+    network  = "tcp"
+    security = "reality"
+    reality_settings {
+      target       = "google.com:443"
+      server_names = ["google.com"]
     }
   }
   sniffing {
@@ -240,12 +241,14 @@ resource "threexui_inbound" "mx_vless" {
 			return []resource.TestCheckFunc{
 				resource.TestCheckResourceAttr(addr, "remark", "matrix-vless-create"),
 				resource.TestCheckResourceAttr(addr, "stream_settings.network", "tcp"),
+				resource.TestCheckResourceAttr(addr, "stream_settings.security", "reality"),
 			}
 		},
 		updateChecks: func(addr string) []resource.TestCheckFunc {
 			return []resource.TestCheckFunc{
 				resource.TestCheckResourceAttr(addr, "remark", "matrix-vless-updated"),
-				resource.TestCheckResourceAttr(addr, "stream_settings.network", "ws"),
+				resource.TestCheckResourceAttr(addr, "stream_settings.network", "tcp"),
+				resource.TestCheckResourceAttr(addr, "stream_settings.security", "reality"),
 			}
 		},
 		hasClient: true,


### PR DESCRIPTION
## Summary

- Add `security = "reality"` stream settings to all VLESS inbound test configs that set `flow = "xtls-rprx-vision"`

## Why

3x-ui v3.2.5 (commit `7ea88e3e`) added `clientWithInboundFlow()` which strips the `flow` field from clients when the inbound's stream settings don't support TLS flow (e.g., `security = "none"`). All our VLESS client tests set `flow = "xtls-rprx-vision"` on inbounds without TLS/Reality, causing "Provider produced inconsistent result after apply" on v3.2.5+.

This is technically the correct behavior — `xtls-rprx-vision` requires TLS or Reality transport. The tests were always using an invalid configuration that 3x-ui happened to tolerate before v3.2.5.

## Changes

- `acc_inbound_client_test.go`: 6 tests + 1 helper — add Reality stream_settings
- `resource_inbound_matrix_test.go`: `matrixVless()` — both create/update HCL use Reality
- `acc_test.go`: `testAccInboundWithClientConfig()` — add Reality stream_settings  
- `acc_inbound_test.go`: `TestAccInboundClientDuplicateEmail` — add Reality stream_settings

## Test plan

- [x] `task pre-commit` passes (fmt + vet + lint + build)
- [x] `task test:unit` passes
- [ ] CI passes on v3.2.5 and v3.2.6