### PR TITLE
feat: add restart_xray attribute to inbound and inbound_client

### DIFF
--- a/docs/resources/inbound.md
+++ b/docs/resources/inbound.md
@@ -174,6 +174,7 @@ resource "threexui_inbound" "hysteria" {
 - `expiry_time` (Optional, Number) - Expiry time as Unix timestamp in milliseconds.
 - `traffic_reset` (Optional, String) - Traffic reset period. Default is `never`.
 - `node_id` (Optional, Number) - 3x-ui v3 node ID for multi-node deployments. Leave unset for the local panel. Changing this value recreates the inbound because 3x-ui v3 does not support moving an existing inbound between nodes.
+- `restart_xray` (Optional, Boolean) - Restart Xray core after create, update, or delete operations. Default is `false`.
 
 ### Per-protocol Settings Blocks
 

--- a/docs/resources/inbound_client.md
+++ b/docs/resources/inbound_client.md
@@ -87,6 +87,7 @@ resource "threexui_inbound_client" "hysteria_user" {
 - `comment` (Optional, String) - Client description for administrative notes.
 - `reset` (Optional, Number) - Traffic reset period in days. `0` means never (default).
 - `group` (Optional, String) - Client group name. Available on 3x-ui v3.2.0+.
+- `restart_xray` (Optional, Boolean) - Restart Xray core after create, update, or delete operations. Default is `false`.
 
 ## Read-Only Attributes
 

--- a/provider/client.go
+++ b/provider/client.go
@@ -872,6 +872,11 @@ func (c *Client) RestartPanel(ctx context.Context) error {
 	return c.WaitForReady(ctx)
 }
 
+// RestartXrayService restarts the Xray core via the 3x-ui API.
+func (c *Client) RestartXrayService(ctx context.Context) error {
+	return c.doJSON(ctx, http.MethodPost, "panel/api/server/restartXrayService", nil, nil)
+}
+
 // WaitForReady polls the panel until it responds successfully or the context
 // is cancelled. The panel needs a few seconds to come back after a restart.
 func (c *Client) WaitForReady(ctx context.Context) error {

--- a/provider/resource_inbound.go
+++ b/provider/resource_inbound.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -50,6 +51,7 @@ type InboundResourceModel struct {
 	Protocol             types.String `tfsdk:"protocol"`
 	Tag                  types.String `tfsdk:"tag"`
 	NodeID               types.Int64  `tfsdk:"node_id"`
+	RestartXray          types.Bool   `tfsdk:"restart_xray"`
 
 	// Per-protocol settings (typed blocks)
 	VlessSettings       *InboundVlessSettingsModel       `tfsdk:"vless_settings"`
@@ -178,6 +180,10 @@ func (r *InboundResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 					int64planmodifier.RequiresReplace(),
 				},
 			},
+			"restart_xray": schema.BoolAttribute{
+				Optional:    true,
+				Description: "Restart Xray core after create, update, or delete operations. Default is false.",
+			},
 		},
 		Blocks: func() map[string]schema.Block {
 			blocks := inboundSettingsBlockSchemas()
@@ -289,6 +295,7 @@ func (r *InboundResource) Create(ctx context.Context, req resource.CreateRequest
 	// the "was absent, but now present" inconsistency error from Terraform.
 	alignBlocksWithPlan(state, &plan)
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+	r.maybeRestartXray(ctx, &plan)
 }
 
 func (r *InboundResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -432,6 +439,7 @@ func (r *InboundResource) Update(ctx context.Context, req resource.UpdateRequest
 		newState.Tag = plan.Tag
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, newState)...)
+	r.maybeRestartXray(ctx, &plan)
 }
 
 func (r *InboundResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
@@ -440,6 +448,7 @@ func (r *InboundResource) Delete(ctx context.Context, req resource.DeleteRequest
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	r.maybeRestartXray(ctx, &state)
 
 	id, err := parseID(state.ID.ValueString())
 	if err != nil {
@@ -1126,6 +1135,16 @@ func isSubset(desired, actual any) bool {
 		return true
 	default:
 		return reflect.DeepEqual(desired, actual)
+	}
+}
+
+// maybeRestartXray restarts the Xray core if the resource's restart_xray
+// attribute is set to true.
+func (r *InboundResource) maybeRestartXray(ctx context.Context, plan *InboundResourceModel) {
+	if plan.RestartXray.ValueBool() {
+		if err := r.client.RestartXrayService(ctx); err != nil {
+			tflog.Warn(ctx, "restartXrayService failed", map[string]any{"error": err.Error()})
+		}
 	}
 }
 

--- a/provider/resource_inbound_client.go
+++ b/provider/resource_inbound_client.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var inboundClientMu sync.Mutex
@@ -37,24 +38,25 @@ var (
 // ---------------------------------------------------------------------------
 
 type InboundClientResourceModel struct {
-	ID         types.String `tfsdk:"id"`
-	InboundID  types.Int64  `tfsdk:"inbound_id"`
-	ClientID   types.String `tfsdk:"client_id"`
-	Email      types.String `tfsdk:"email"`
-	Security   types.String `tfsdk:"security"`
-	Password   types.String `tfsdk:"password"`
-	Flow       types.String `tfsdk:"flow"`
-	ReverseTag types.String `tfsdk:"reverse_tag"`
-	Auth       types.String `tfsdk:"auth"`
-	LimitIP    types.Int64  `tfsdk:"limit_ip"`
-	TotalGB    types.Int64  `tfsdk:"total_gb"`
-	ExpiryTime types.Int64  `tfsdk:"expiry_time"`
-	Enable     types.Bool   `tfsdk:"enable"`
-	TgID       types.Int64  `tfsdk:"tg_id"`
-	SubID      types.String `tfsdk:"sub_id"`
-	Comment    types.String `tfsdk:"comment"`
-	Reset      types.Int64  `tfsdk:"reset"`
-	Group      types.String `tfsdk:"group"`
+	ID          types.String `tfsdk:"id"`
+	InboundID   types.Int64  `tfsdk:"inbound_id"`
+	ClientID    types.String `tfsdk:"client_id"`
+	Email       types.String `tfsdk:"email"`
+	Security    types.String `tfsdk:"security"`
+	Password    types.String `tfsdk:"password"`
+	Flow        types.String `tfsdk:"flow"`
+	ReverseTag  types.String `tfsdk:"reverse_tag"`
+	Auth        types.String `tfsdk:"auth"`
+	LimitIP     types.Int64  `tfsdk:"limit_ip"`
+	TotalGB     types.Int64  `tfsdk:"total_gb"`
+	ExpiryTime  types.Int64  `tfsdk:"expiry_time"`
+	Enable      types.Bool   `tfsdk:"enable"`
+	TgID        types.Int64  `tfsdk:"tg_id"`
+	SubID       types.String `tfsdk:"sub_id"`
+	Comment     types.String `tfsdk:"comment"`
+	Reset       types.Int64  `tfsdk:"reset"`
+	Group       types.String `tfsdk:"group"`
+	RestartXray types.Bool   `tfsdk:"restart_xray"`
 }
 
 // ---------------------------------------------------------------------------
@@ -197,6 +199,10 @@ func (r *InboundClientResource) Schema(_ context.Context, _ resource.SchemaReque
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
+			"restart_xray": schema.BoolAttribute{
+				Optional:    true,
+				Description: "Restart Xray core after create, update, or delete operations. Default is false.",
+			},
 		},
 	}
 }
@@ -283,6 +289,7 @@ func (r *InboundClientResource) Create(ctx context.Context, req resource.CreateR
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+	r.maybeRestartXrayClient(ctx, &plan)
 }
 
 func (r *InboundClientResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -353,6 +360,7 @@ func (r *InboundClientResource) Update(ctx context.Context, req resource.UpdateR
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+	r.maybeRestartXrayClient(ctx, &plan)
 }
 
 func (r *InboundClientResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
@@ -386,6 +394,16 @@ func (r *InboundClientResource) Delete(ctx context.Context, req resource.DeleteR
 	}
 
 	resp.State.RemoveResource(ctx)
+	r.maybeRestartXrayClient(ctx, &cur)
+}
+
+// maybeRestartXrayClient restarts the Xray core if restart_xray is true.
+func (r *InboundClientResource) maybeRestartXrayClient(ctx context.Context, m *InboundClientResourceModel) {
+	if m.RestartXray.ValueBool() {
+		if err := r.client.RestartXrayService(ctx); err != nil {
+			tflog.Warn(ctx, "restartXrayService failed", map[string]any{"error": err.Error()})
+		}
+	}
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds optional `restart_xray` (Bool, default false) attribute to `threexui_inbound` and `threexui_inbound_client`
- When true, calls `POST /panel/api/server/restartXrayService` after create, update, or delete
- New `Client.RestartXrayService()` method in client.go
- Documentation updated for both resources

## Test plan
- [x] `task pre-commit` (fmt + vet + lint + build) passes
- [x] All unit + drift tests pass
- [ ] CI matrix against all supported versions

Closes #214