### PR TITLE
feat: implement import support for panel_user resource

### DIFF
--- a/docs/resources/panel_user.md
+++ b/docs/resources/panel_user.md
@@ -36,3 +36,5 @@ resource "threexui_panel_user" "admin" {
 ```shell
 terraform import threexui_panel_user.admin user
 ```
+
+~> **Note:** Because the panel has no API to read credentials, `username` and `password` are unknown after import. You must configure both attributes in your Terraform configuration and run `terraform apply` to synchronize the state. The next `terraform plan` after import will show changes for these attributes — this is expected.

--- a/provider/acc_panel_user_test.go
+++ b/provider/acc_panel_user_test.go
@@ -181,3 +181,30 @@ func restorePanelCredentials(ctx context.Context, currentUsername, currentPasswo
 	}
 	return fmt.Errorf("panel credentials are neither current %q nor target %q", currentUsername, targetUsername)
 }
+
+func TestAccPanelUserImport(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProviderConfig() + `
+	resource "threexui_panel_user" "test" {
+	  username = "admin"
+	  password = "admin"
+	}
+	`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("threexui_panel_user.test", "id", "user"),
+					resource.TestCheckResourceAttr("threexui_panel_user.test", "username", "admin"),
+				),
+			},
+			{
+				ResourceName:            "threexui_panel_user.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"username", "password"},
+			},
+		},
+	})
+}

--- a/provider/resource_panel_user.go
+++ b/provider/resource_panel_user.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -12,8 +13,9 @@ import (
 )
 
 var (
-	_ resource.Resource              = &PanelUserResource{}
-	_ resource.ResourceWithConfigure = &PanelUserResource{}
+	_ resource.Resource                = &PanelUserResource{}
+	_ resource.ResourceWithConfigure   = &PanelUserResource{}
+	_ resource.ResourceWithImportState = &PanelUserResource{}
 )
 
 type PanelUserResource struct {
@@ -141,4 +143,8 @@ func (r *PanelUserResource) warnCredentialsChanged(diags *diag.Diagnostics) {
 		"Admin credentials changed",
 		"The panel admin credentials have been updated. Update the provider's username and password to match the new values, otherwise the provider will fail to authenticate on the next run.",
 	)
+}
+
+func (r *PanelUserResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }


### PR DESCRIPTION
## Summary
- Add `ResourceWithImportState` to `panel_user` resource with `ImportStatePassthroughID`
- After import `id = "user"`, but `username`/`password` remain null (no read API)
- Update docs with warning about write-only nature after import
- Add acceptance test `TestAccPanelUserImport`

Closes #247

## Test plan
- [x] Unit tests pass (`task test:unit`)
- [x] Pre-commit checks pass (`task pre-commit`)
- [ ] Acceptance test `TestAccPanelUserImport` passes against live 3x-ui