### PR TITLE
feat: support THREEXUI_* environment variables in provider configuration

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -45,7 +45,36 @@ resource "threexui_inbound" "vless" {
 
 ## Authentication
 
-The provider authenticates to the 3x-ui panel using username and password. These can be provided directly in the provider configuration, or indirectly through Terraform input variables such as `TF_VAR_threexui_username` and `TF_VAR_threexui_password`.
+The provider authenticates to the 3x-ui panel using username and password. These can be provided directly in the provider configuration, through environment variables, or indirectly through Terraform input variables such as `TF_VAR_threexui_username` and `TF_VAR_threexui_password`.
+
+### Environment Variables
+
+All provider attributes can be set via `THREEXUI_*` environment variables. When both HCL configuration and environment variables are present, the HCL value takes precedence.
+
+| Attribute | Environment Variable | Default |
+| --- | --- | --- |
+| `endpoint` | `THREEXUI_ENDPOINT` | _(none — required)_ |
+| `base_path` | `THREEXUI_BASE_PATH` | `/` |
+| `username` | `THREEXUI_USERNAME` | `admin` |
+| `password` | `THREEXUI_PASSWORD` | `admin` |
+| `insecure_skip_verify` | `THREEXUI_INSECURE_SKIP_VERIFY` | `false` |
+| `request_timeout` | `THREEXUI_REQUEST_TIMEOUT` | `30s` |
+| `max_retries` | `THREEXUI_MAX_RETRIES` | `1` |
+
+Minimal configuration using environment variables:
+
+```hcl
+provider "threexui" {}
+```
+
+```shell
+export THREEXUI_ENDPOINT="http://localhost:2053"
+export THREEXUI_USERNAME="admin"
+export THREEXUI_PASSWORD="secret"
+terraform apply
+```
+
+Precedence order: explicit HCL > `THREEXUI_*` environment variable > built-in default.
 
 For first-run bootstrap of a fresh panel, you can configure `bootstrap_username` and `bootstrap_password` in addition to the steady-state `username` and `password`. Use this together with `threexui_panel_user` to rotate the panel to the steady-state credentials during the same apply. On 3x-ui v2.9.x, failed logins can expose the submitted password in panel logs or Telegram login notifications, so the provider tries bootstrap credentials before the steady-state credentials. On 3x-ui v3.x, the provider tries steady-state credentials first and falls back to bootstrap credentials only if the panel rejects them. The provider does not silently try `admin`/`admin`; bootstrap credentials must be configured explicitly.
 
@@ -72,15 +101,15 @@ resource "threexui_panel_user" "admin" {
 
 ## Argument Reference
 
-- `endpoint` (Required, String) - Base URL of the 3x-ui panel, e.g. `http://localhost:2053`.
-- `base_path` (Optional, String) - Base path configured in 3x-ui (`webBasePath`). Default is `/`.
-- `username` (Optional, String) - 3x-ui username. Default is `admin`.
-- `password` (Optional, String, Sensitive) - 3x-ui password. Default is `admin`.
+- `endpoint` (Optional, String) - Base URL of the 3x-ui panel, e.g. `http://localhost:2053`. Can also be set via `THREEXUI_ENDPOINT` environment variable.
+- `base_path` (Optional, String) - Base path configured in 3x-ui (`webBasePath`). Default is `/`. Can also be set via `THREEXUI_BASE_PATH` environment variable.
+- `username` (Optional, String) - 3x-ui username. Default is `admin`. Can also be set via `THREEXUI_USERNAME` environment variable.
+- `password` (Optional, String, Sensitive) - 3x-ui password. Default is `admin`. Can also be set via `THREEXUI_PASSWORD` environment variable.
 - `bootstrap_username` (Optional, String) - Bootstrap username for explicit first-run credential rotation. On 3x-ui v2.9.x it is tried before the primary `username`/`password` to avoid exposing the desired password in failed-login logs; on 3x-ui v3.x it is tried only after the primary credentials are rejected. Must be set together with `bootstrap_password`.
 - `bootstrap_password` (Optional, String, Sensitive) - Bootstrap password for explicit first-run credential rotation. On 3x-ui v2.9.x it is tried before the primary `username`/`password` to avoid exposing the desired password in failed-login logs; on 3x-ui v3.x it is tried only after the primary credentials are rejected. Must be set together with `bootstrap_username`.
 - `two_factor_code` (Optional, String, Sensitive) - TOTP code for 2FA login. Used for the initial authentication request. See the note above about re-login limitations.
-- `insecure_skip_verify` (Optional, Boolean) - Skip TLS certificate verification (useful for self-signed certs). Default is `false`.
-- `request_timeout` (Optional, String) - HTTP request timeout (e.g. `30s`, `1m`). Default is `30s`.
-- `max_retries` (Optional, Number) - Maximum number of additional attempts on transient HTTP 5xx responses for **idempotent write endpoints only** (`UpdateInbound`, `UpdateInboundClient`, `UpdateSettings`, `UpdateXrayTemplate`, `SetXrayOutboundTestURL`). Each retry waits 500ms and emits a `Warn`-level log entry, so upstream flakiness is observable rather than silently absorbed. Set to `0` to disable retries entirely. Allowed range: `0..10`. Default is `1`.
+- `insecure_skip_verify` (Optional, Boolean) - Skip TLS certificate verification (useful for self-signed certs). Default is `false`. Can also be set via `THREEXUI_INSECURE_SKIP_VERIFY` environment variable.
+- `request_timeout` (Optional, String) - HTTP request timeout (e.g. `30s`, `1m`). Default is `30s`. Can also be set via `THREEXUI_REQUEST_TIMEOUT` environment variable.
+- `max_retries` (Optional, Number) - Maximum number of additional attempts on transient HTTP 5xx responses for **idempotent write endpoints only** (`UpdateInbound`, `UpdateInboundClient`, `UpdateSettings`, `UpdateXrayTemplate`, `SetXrayOutboundTestURL`). Each retry waits 500ms and emits a `Warn`-level log entry, so upstream flakiness is observable rather than silently absorbed. Set to `0` to disable retries entirely. Allowed range: `0..10`. Default is `1`. Can also be set via `THREEXUI_MAX_RETRIES` environment variable.
 
 -> **Why this exists:** 3x-ui's pre-v2.9.0 inbound update path was not transactional, and a panic in the panel's handler goroutine surfaced as a 5xx via `gin.Recovery`. v2.9.0 reworked the path to run inside a SQLite transaction (`buildRuntimeInboundForAPI(tx, ...)`) and is more robust, but transient upstream 5xx responses can still happen under write pressure. The retry is scoped to write endpoints whose service-level handlers replace the entire row by id (truly idempotent at the SQL level), so repeating the same request after a transient failure is safe.

--- a/examples/provider-env-config/main.tf
+++ b/examples/provider-env-config/main.tf
@@ -1,38 +1,14 @@
-# Provider configuration using Terraform variables.
+# Provider configuration using environment variables.
 #
 # Set via environment variables:
-#   export TF_VAR_threexui_endpoint="https://panel.example.com:2053"
-#   export TF_VAR_threexui_username="admin"
-#   export TF_VAR_threexui_password="s3cret"
-#   export TF_VAR_threexui_base_path="/"
+#   export THREEXUI_ENDPOINT="https://panel.example.com:2053"
+#   export THREEXUI_USERNAME="admin"
+#   export THREEXUI_PASSWORD="s3cret"
+#   export THREEXUI_BASE_PATH="/"
 #
 # Then run:
 #   terraform plan
 #   terraform apply
-
-variable "threexui_endpoint" {
-  description = "Base URL of the 3x-ui panel"
-  type        = string
-}
-
-variable "threexui_username" {
-  description = "3x-ui admin username"
-  type        = string
-  default     = "admin"
-}
-
-variable "threexui_password" {
-  description = "3x-ui admin password"
-  type        = string
-  sensitive   = true
-  default     = "admin"
-}
-
-variable "threexui_base_path" {
-  description = "Base path configured in 3x-ui (webBasePath)"
-  type        = string
-  default     = "/"
-}
 
 terraform {
   required_providers {
@@ -43,12 +19,5 @@ terraform {
   }
 }
 
-provider "threexui" {
-  endpoint  = var.threexui_endpoint
-  username  = var.threexui_username
-  password  = var.threexui_password
-  base_path = var.threexui_base_path
-
-  # Skip TLS verification for self-signed certificates
-  insecure_skip_verify = true
-}
+# All attributes are read from THREEXUI_* environment variables.
+provider "threexui" {}

--- a/provider/acc_test.go
+++ b/provider/acc_test.go
@@ -14,14 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
-const (
-	envEndpoint           = "THREEXUI_ENDPOINT"
-	envBasePath           = "THREEXUI_BASE_PATH"
-	envUsername           = "THREEXUI_USERNAME"
-	envPassword           = "THREEXUI_PASSWORD"
-	envInsecureSkipVerify = "THREEXUI_INSECURE_SKIP_VERIFY"
-)
-
 func getenvDefault(name, fallback string) string {
 	if v := os.Getenv(name); v != "" {
 		return v

--- a/provider/corpus_test.go
+++ b/provider/corpus_test.go
@@ -634,6 +634,7 @@ func TestCorpusInboundToModel_VLESSFull(t *testing.T) {
 	}
 	if model == nil {
 		t.Fatal("expected non-nil model")
+		return
 	}
 	if model.Protocol.ValueString() != "vless" {
 		t.Fatalf("expected protocol vless, got %s", model.Protocol.ValueString())
@@ -678,6 +679,7 @@ func TestCorpusInboundToModel_DokodemoFull(t *testing.T) {
 	}
 	if model == nil {
 		t.Fatal("expected non-nil model")
+		return
 	}
 	if model.Protocol.ValueString() != "dokodemo-door" {
 		t.Fatalf("expected protocol dokodemo-door, got %s", model.Protocol.ValueString())
@@ -713,6 +715,7 @@ func TestCorpusInboundToModel_ShadowsocksFull(t *testing.T) {
 	}
 	if model == nil {
 		t.Fatal("expected non-nil model")
+		return
 	}
 	if model.ShadowsocksSettings == nil {
 		t.Fatal("expected ShadowsocksSettings to be populated")

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -3,6 +3,8 @@ package provider
 import (
 	"context"
 	"fmt"
+	"os"
+	"strconv"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -44,6 +46,28 @@ const (
 	maxAllowedRetries = 10
 )
 
+const (
+	envEndpoint           = "THREEXUI_ENDPOINT"
+	envBasePath           = "THREEXUI_BASE_PATH"
+	envUsername           = "THREEXUI_USERNAME"
+	envPassword           = "THREEXUI_PASSWORD"
+	envInsecureSkipVerify = "THREEXUI_INSECURE_SKIP_VERIFY"
+	envRequestTimeout     = "THREEXUI_REQUEST_TIMEOUT"
+	envMaxRetries         = "THREEXUI_MAX_RETRIES"
+)
+
+// envString returns the first non-empty string: HCL value (if set), then
+// THREEXUI_* environment variable, then fallback.
+func envString(tfVal types.String, envKey, fallback string) string {
+	if !tfVal.IsNull() && !tfVal.IsUnknown() {
+		return tfVal.ValueString()
+	}
+	if v := os.Getenv(envKey); v != "" {
+		return v
+	}
+	return fallback
+}
+
 func New(version string) func() provider.Provider {
 	return func() provider.Provider {
 		return &ThreeXUIProvider{version: version}
@@ -59,21 +83,21 @@ func (p *ThreeXUIProvider) Schema(_ context.Context, _ provider.SchemaRequest, r
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"endpoint": schema.StringAttribute{
-				Required:    true,
-				Description: "Base URL of the 3x-ui panel, e.g. http://localhost:2053.",
+				Optional:    true,
+				Description: "Base URL of the 3x-ui panel, e.g. http://localhost:2053. Can also be set via THREEXUI_ENDPOINT environment variable.",
 			},
 			"base_path": schema.StringAttribute{
 				Optional:    true,
-				Description: "Base path configured in 3x-ui (webBasePath). Default is '/'.",
+				Description: "Base path configured in 3x-ui (webBasePath). Default is '/'. Can also be set via THREEXUI_BASE_PATH environment variable.",
 			},
 			"username": schema.StringAttribute{
 				Optional:    true,
-				Description: "3x-ui username.",
+				Description: "3x-ui username. Default is admin. Can also be set via THREEXUI_USERNAME environment variable.",
 			},
 			"password": schema.StringAttribute{
 				Optional:    true,
 				Sensitive:   true,
-				Description: "3x-ui password.",
+				Description: "3x-ui password. Default is admin. Can also be set via THREEXUI_PASSWORD environment variable.",
 			},
 			"bootstrap_username": schema.StringAttribute{
 				Optional:    true,
@@ -91,11 +115,11 @@ func (p *ThreeXUIProvider) Schema(_ context.Context, _ provider.SchemaRequest, r
 			},
 			"insecure_skip_verify": schema.BoolAttribute{
 				Optional:    true,
-				Description: "Skip TLS certificate verification (useful for self-signed certs).",
+				Description: "Skip TLS certificate verification (useful for self-signed certs). Can also be set via THREEXUI_INSECURE_SKIP_VERIFY environment variable.",
 			},
 			"request_timeout": schema.StringAttribute{
 				Optional:    true,
-				Description: "HTTP request timeout (e.g. 30s, 1m).",
+				Description: "HTTP request timeout (e.g. 30s, 1m). Can also be set via THREEXUI_REQUEST_TIMEOUT environment variable.",
 			},
 			"max_retries": schema.Int64Attribute{
 				Optional: true,
@@ -118,19 +142,15 @@ func (p *ThreeXUIProvider) Configure(ctx context.Context, req provider.Configure
 		return
 	}
 
-	endpoint := config.Endpoint.ValueString()
-	basePath := "/"
-	if !config.BasePath.IsNull() && !config.BasePath.IsUnknown() {
-		basePath = config.BasePath.ValueString()
+	endpoint := envString(config.Endpoint, envEndpoint, "")
+	if endpoint == "" {
+		resp.Diagnostics.AddError("Missing endpoint", "endpoint must be set in the provider configuration or via THREEXUI_ENDPOINT environment variable.")
+		return
 	}
-	username := "admin"
-	if !config.Username.IsNull() && !config.Username.IsUnknown() {
-		username = config.Username.ValueString()
-	}
-	password := "admin"
-	if !config.Password.IsNull() && !config.Password.IsUnknown() {
-		password = config.Password.ValueString()
-	}
+
+	basePath := envString(config.BasePath, envBasePath, "/")
+	username := envString(config.Username, envUsername, "admin")
+	password := envString(config.Password, envPassword, "admin")
 	bootstrapUsername := ""
 	bootstrapUsernameSet := false
 	if config.BootstrapUsername.IsUnknown() {
@@ -172,11 +192,16 @@ func (p *ThreeXUIProvider) Configure(ctx context.Context, req provider.Configure
 	insecureSkipVerify := false
 	if !config.InsecureSkipVerify.IsNull() && !config.InsecureSkipVerify.IsUnknown() {
 		insecureSkipVerify = config.InsecureSkipVerify.ValueBool()
+	} else if v := os.Getenv(envInsecureSkipVerify); v != "" {
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			resp.Diagnostics.AddError("Invalid THREEXUI_INSECURE_SKIP_VERIFY", fmt.Sprintf("must be true or false, got %q", v))
+			return
+		}
+		insecureSkipVerify = b
 	}
-	timeoutStr := "30s"
-	if !config.RequestTimeout.IsNull() && !config.RequestTimeout.IsUnknown() {
-		timeoutStr = config.RequestTimeout.ValueString()
-	}
+
+	timeoutStr := envString(config.RequestTimeout, envRequestTimeout, "30s")
 
 	timeout, err := time.ParseDuration(timeoutStr)
 	if err != nil {
@@ -195,6 +220,20 @@ func (p *ThreeXUIProvider) Configure(ctx context.Context, req provider.Configure
 			return
 		}
 		maxRetries = int(v)
+	} else if v := os.Getenv(envMaxRetries); v != "" {
+		n, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			resp.Diagnostics.AddError("Invalid THREEXUI_MAX_RETRIES", fmt.Sprintf("must be an integer, got %q", v))
+			return
+		}
+		if n < 0 || n > maxAllowedRetries {
+			resp.Diagnostics.AddError(
+				"Invalid THREEXUI_MAX_RETRIES",
+				fmt.Sprintf("must be between 0 and %d, got %d", maxAllowedRetries, n),
+			)
+			return
+		}
+		maxRetries = int(n)
 	}
 
 	client, err := NewClient(ClientConfig{

--- a/provider/provider_env_test.go
+++ b/provider/provider_env_test.go
@@ -1,0 +1,79 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestEnvString_TFValue(t *testing.T) {
+	got := envString(types.StringValue("from-hcl"), "THREEXUI_UNUSED_TEST", "fallback")
+	if got != "from-hcl" {
+		t.Fatalf("expected from-hcl, got %q", got)
+	}
+}
+
+func TestEnvString_EnvFallback(t *testing.T) {
+	t.Setenv("THREEXUI_TEST_STRING", "from-env")
+	got := envString(types.StringNull(), "THREEXUI_TEST_STRING", "fallback")
+	if got != "from-env" {
+		t.Fatalf("expected from-env, got %q", got)
+	}
+}
+
+func TestEnvString_Default(t *testing.T) {
+	got := envString(types.StringNull(), "THREEXUI_UNUSED_TEST", "fallback")
+	if got != "fallback" {
+		t.Fatalf("expected fallback, got %q", got)
+	}
+}
+
+func TestEnvString_TFOverrulesEnv(t *testing.T) {
+	t.Setenv("THREEXUI_TEST_STRING", "from-env")
+	got := envString(types.StringValue("from-hcl"), "THREEXUI_TEST_STRING", "fallback")
+	if got != "from-hcl" {
+		t.Fatalf("expected from-hcl (HCL takes precedence), got %q", got)
+	}
+}
+
+func TestEnvString_UnknownUsesEnv(t *testing.T) {
+	t.Setenv("THREEXUI_TEST_STRING", "from-env")
+	got := envString(types.StringUnknown(), "THREEXUI_TEST_STRING", "fallback")
+	if got != "from-env" {
+		t.Fatalf("expected from-env, got %q", got)
+	}
+}
+
+func TestEnvConstants(t *testing.T) {
+	want := map[string]string{
+		"THREEXUI_ENDPOINT":             envEndpoint,
+		"THREEXUI_BASE_PATH":            envBasePath,
+		"THREEXUI_USERNAME":             envUsername,
+		"THREEXUI_PASSWORD":             envPassword,
+		"THREEXUI_INSECURE_SKIP_VERIFY": envInsecureSkipVerify,
+		"THREEXUI_REQUEST_TIMEOUT":      envRequestTimeout,
+		"THREEXUI_MAX_RETRIES":          envMaxRetries,
+	}
+	for expected, constant := range want {
+		if constant != expected {
+			t.Errorf("expected %q, got %q", expected, constant)
+		}
+	}
+}
+
+func TestEnvString_EmptyEnvUsesDefault(t *testing.T) {
+	t.Setenv("THREEXUI_TEST_STRING", "")
+	got := envString(types.StringNull(), "THREEXUI_TEST_STRING", "fallback")
+	if got != "fallback" {
+		t.Fatalf("expected fallback (empty env ignored), got %q", got)
+	}
+}
+
+func TestEndpointRequiredWithoutEnvOrConfig(t *testing.T) {
+	// Ensure endpoint error is produced when neither HCL nor env provides it.
+	// This is tested via Configure — we just verify envString returns empty.
+	got := envString(types.StringNull(), "THREEXUI_ENDPOINT_NOT_SET_XYZ", "")
+	if got != "" {
+		t.Fatalf("expected empty, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `THREEXUI_*` environment variable fallback for all provider attributes (endpoint, base_path, username, password, insecure_skip_verify, request_timeout, max_retries)
- Precedence: explicit HCL > `THREEXUI_*` env var > built-in default
- `endpoint` changed from Required to Optional (error if neither HCL nor env provides it)
- Update docs/index.md with env var table and updated Argument Reference
- Update examples/provider-env-config to use native env vars
- Fix pre-existing staticcheck nil-pointer warnings in corpus_test.go

Closes #249

## Test plan
- [x] Unit tests pass (`task test:unit`) — 8 new env fallback tests
- [x] Pre-commit checks pass (`task pre-commit`)
- [ ] Acceptance tests pass against live 3x-ui