### PR TITLE
feat: add schema validators for provider config and core resources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.4
 
 require (
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
+	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0
 	github.com/hashicorp/terraform-plugin-go v0.31.0
 	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/hashicorp/terraform-plugin-testing v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -86,6 +86,8 @@ github.com/hashicorp/terraform-json v0.27.2 h1:BwGuzM6iUPqf9JYM/Z4AF1OJ5VVJEEzoK
 github.com/hashicorp/terraform-json v0.27.2/go.mod h1:GzPLJ1PLdUG5xL6xn1OXWIjteQRT2CNT9o/6A9mi9hE=
 github.com/hashicorp/terraform-plugin-framework v1.19.0 h1:q0bwyhxAOR3vfdgbk9iplv3MlTv/dhBHTXjQOtQDoBA=
 github.com/hashicorp/terraform-plugin-framework v1.19.0/go.mod h1:YRXOBu0jvs7xp4AThBbX4mAzYaMJ1JgtFH//oGKxwLc=
+github.com/hashicorp/terraform-plugin-framework-validators v0.19.0 h1:Zz3iGgzxe/1XBkooZCewS0nJAaCFPFPHdNJd8FgE4Ow=
+github.com/hashicorp/terraform-plugin-framework-validators v0.19.0/go.mod h1:GBKTNGbGVJohU03dZ7U8wHqc2zYnMUawgCN+gC0itLc=
 github.com/hashicorp/terraform-plugin-go v0.31.0 h1:0Fz2r9DQ+kNNl6bx8HRxFd1TfMKUvnrOtvJPmp3Z0q8=
 github.com/hashicorp/terraform-plugin-go v0.31.0/go.mod h1:A88bDhd/cW7FnwqxQRz3slT+QY6yzbHKc6AOTtmdeS8=
 github.com/hashicorp/terraform-plugin-log v0.10.0 h1:eu2kW6/QBVdN4P3Ju2WiB2W3ObjkAsyfBsL3Wh1fj3g=

--- a/provider/inbound_stream_settings_schema.go
+++ b/provider/inbound_stream_settings_schema.go
@@ -134,6 +134,7 @@ func inboundStreamSettingsBlockSchema() schema.SingleNestedBlock {
 			"network": schema.StringAttribute{
 				Optional: true, Computed: true,
 				Description: "Transport network (tcp, ws, grpc, httpupgrade, xhttp, kcp).",
+				Validators:  networkValidators(),
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
@@ -141,6 +142,7 @@ func inboundStreamSettingsBlockSchema() schema.SingleNestedBlock {
 			"security": schema.StringAttribute{
 				Optional: true, Computed: true,
 				Description: "Security type (none, reality, tls).",
+				Validators:  securityValidators(),
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
@@ -282,6 +284,7 @@ func inboundStreamSettingsBlockSchema() schema.SingleNestedBlock {
 					"header_type": schema.StringAttribute{
 						Optional: true, Computed: true,
 						Description: "Header type (e.g. 'none', 'http').",
+						Validators:  tcpHeaderTypeValidators(),
 						PlanModifiers: []planmodifier.String{
 							stringplanmodifier.UseStateForUnknown(),
 						},
@@ -377,6 +380,7 @@ func inboundStreamSettingsBlockSchema() schema.SingleNestedBlock {
 					},
 					"mode": schema.StringAttribute{
 						Optional: true, Computed: true,
+						Validators: xhttpModeValidators(),
 						PlanModifiers: []planmodifier.String{
 							stringplanmodifier.UseStateForUnknown(),
 						},
@@ -483,6 +487,7 @@ func inboundStreamSettingsBlockSchema() schema.SingleNestedBlock {
 					"header_type": schema.StringAttribute{
 						Optional: true, Computed: true,
 						Description: "Header type (e.g. 'none', 'srtp', 'utp', 'wechat-video', 'dtls', 'wireguard').",
+						Validators:  kcpHeaderTypeValidators(),
 						PlanModifiers: []planmodifier.String{
 							stringplanmodifier.UseStateForUnknown(),
 						},
@@ -555,12 +560,14 @@ func inboundStreamSettingsBlockSchema() schema.SingleNestedBlock {
 					},
 					"tproxy": schema.StringAttribute{
 						Optional: true, Computed: true,
+						Validators: tproxyValidators(),
 						PlanModifiers: []planmodifier.String{
 							stringplanmodifier.UseStateForUnknown(),
 						},
 					},
 					"domain_strategy": schema.StringAttribute{
 						Optional: true, Computed: true,
+						Validators: domainStrategyValidators(),
 						PlanModifiers: []planmodifier.String{
 							stringplanmodifier.UseStateForUnknown(),
 						},

--- a/provider/inbound_stream_settings_schema.go
+++ b/provider/inbound_stream_settings_schema.go
@@ -133,7 +133,7 @@ func inboundStreamSettingsBlockSchema() schema.SingleNestedBlock {
 		Attributes: map[string]schema.Attribute{
 			"network": schema.StringAttribute{
 				Optional: true, Computed: true,
-				Description: "Transport network (tcp, ws, grpc, httpupgrade, xhttp, kcp).",
+				Description: "Transport network (tcp, ws, grpc, httpupgrade, xhttp, kcp, hysteria).",
 				Validators:  networkValidators(),
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -85,10 +85,12 @@ func (p *ThreeXUIProvider) Schema(_ context.Context, _ provider.SchemaRequest, r
 			"endpoint": schema.StringAttribute{
 				Optional:    true,
 				Description: "Base URL of the 3x-ui panel, e.g. http://localhost:2053. Can also be set via THREEXUI_ENDPOINT environment variable.",
+				Validators:  endpointValidators(),
 			},
 			"base_path": schema.StringAttribute{
 				Optional:    true,
 				Description: "Base path configured in 3x-ui (webBasePath). Default is '/'. Can also be set via THREEXUI_BASE_PATH environment variable.",
+				Validators:  basePathValidators(),
 			},
 			"username": schema.StringAttribute{
 				Optional:    true,
@@ -120,9 +122,11 @@ func (p *ThreeXUIProvider) Schema(_ context.Context, _ provider.SchemaRequest, r
 			"request_timeout": schema.StringAttribute{
 				Optional:    true,
 				Description: "HTTP request timeout (e.g. 30s, 1m). Can also be set via THREEXUI_REQUEST_TIMEOUT environment variable.",
+				Validators:  requestTimeoutValidators(),
 			},
 			"max_retries": schema.Int64Attribute{
-				Optional: true,
+				Optional:   true,
+				Validators: maxRetriesValidators(),
 				Description: fmt.Sprintf(
 					"Maximum number of additional attempts on transient HTTP 5xx responses for idempotent write endpoints "+
 						"(UpdateInbound, UpdateInboundClient, UpdateSettings, UpdateXrayTemplate, SetXrayOutboundTestURL). "+

--- a/provider/resource_inbound.go
+++ b/provider/resource_inbound.go
@@ -143,7 +143,7 @@ func (r *InboundResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				Optional:    true,
 				Computed:    true,
 				Default:     stringdefault.StaticString("never"),
-				Description: "Traffic reset interval (e.g. 'never', 'day', 'week', 'month', 'year').",
+				Description: "Traffic reset interval (e.g. 'never', 'hourly', 'daily', 'weekly', 'monthly').",
 				Validators:  trafficResetValidators(),
 			},
 			"last_traffic_reset_time": schema.Int64Attribute{

--- a/provider/resource_inbound.go
+++ b/provider/resource_inbound.go
@@ -144,6 +144,7 @@ func (r *InboundResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				Computed:    true,
 				Default:     stringdefault.StaticString("never"),
 				Description: "Traffic reset interval (e.g. 'never', 'day', 'week', 'month', 'year').",
+				Validators:  trafficResetValidators(),
 			},
 			"last_traffic_reset_time": schema.Int64Attribute{
 				Computed:    true,
@@ -159,10 +160,12 @@ func (r *InboundResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 			"port": schema.Int64Attribute{
 				Required:    true,
 				Description: "Listen port.",
+				Validators:  portValidators(),
 			},
 			"protocol": schema.StringAttribute{
 				Required:    true,
 				Description: "Protocol (vless, vmess, trojan, shadowsocks, http, mixed, wireguard, tunnel, tun, hysteria). socks and dokodemo-door are deprecated since 3x-ui v3.2.0 — use mixed and tunnel instead. tun is an alias for tunnel available since 3x-ui v3.2.7.",
+				Validators:  protocolValidators(),
 			},
 			"tag": schema.StringAttribute{
 				Computed:    true,

--- a/provider/validators.go
+++ b/provider/validators.go
@@ -1,0 +1,160 @@
+package provider
+
+import (
+	"context"
+	"regexp"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+// ---------------------------------------------------------------------------
+// Provider config validators
+// ---------------------------------------------------------------------------
+
+// endpointValidators validates the provider endpoint URL format.
+func endpointValidators() []validator.String {
+	return []validator.String{
+		stringvalidator.RegexMatches(
+			regexp.MustCompile(`^https?://.+`),
+			"must be a valid HTTP or HTTPS URL (e.g. http://localhost:2053)",
+		),
+	}
+}
+
+// basePathValidators validates the provider base_path.
+func basePathValidators() []validator.String {
+	return []validator.String{
+		stringvalidator.RegexMatches(
+			regexp.MustCompile(`^/.*`),
+			"must start with '/'",
+		),
+	}
+}
+
+// requestTimeoutValidators validates the provider request_timeout duration string.
+func requestTimeoutValidators() []validator.String {
+	return []validator.String{
+		durationValidator{},
+	}
+}
+
+// maxRetriesValidators validates the provider max_retries integer range.
+func maxRetriesValidators() []validator.Int64 {
+	return []validator.Int64{
+		int64validator.Between(0, int64(maxAllowedRetries)),
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Inbound resource validators
+// ---------------------------------------------------------------------------
+
+// portValidators validates inbound port range (1-65535).
+func portValidators() []validator.Int64 {
+	return []validator.Int64{
+		int64validator.Between(1, 65535),
+	}
+}
+
+// protocolValidators validates inbound protocol enum values.
+func protocolValidators() []validator.String {
+	return []validator.String{
+		stringvalidator.OneOf(
+			"vless", "vmess", "trojan", "shadowsocks",
+			"http", "socks", "mixed", "wireguard",
+			"dokodemo-door", "tunnel", "tun",
+			"hysteria", "hysteria2",
+		),
+	}
+}
+
+// trafficResetValidators validates inbound traffic_reset enum values.
+func trafficResetValidators() []validator.String {
+	return []validator.String{
+		stringvalidator.OneOf("never", "day", "week", "month", "year"),
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Stream settings validators
+// ---------------------------------------------------------------------------
+
+// networkValidators validates stream network enum values.
+func networkValidators() []validator.String {
+	return []validator.String{
+		stringvalidator.OneOf("tcp", "ws", "grpc", "httpupgrade", "xhttp", "kcp", "hysteria"),
+	}
+}
+
+// securityValidators validates stream security enum values.
+func securityValidators() []validator.String {
+	return []validator.String{
+		stringvalidator.OneOf("none", "tls", "reality"),
+	}
+}
+
+// tcpHeaderTypeValidators validates TCP header_type enum values.
+func tcpHeaderTypeValidators() []validator.String {
+	return []validator.String{
+		stringvalidator.OneOf("none", "http"),
+	}
+}
+
+// kcpHeaderTypeValidators validates KCP header_type enum values.
+func kcpHeaderTypeValidators() []validator.String {
+	return []validator.String{
+		stringvalidator.OneOf("none", "srtp", "utp", "wechat-video", "dtls", "wireguard"),
+	}
+}
+
+// xhttpModeValidators validates XHTTP mode enum values.
+func xhttpModeValidators() []validator.String {
+	return []validator.String{
+		stringvalidator.OneOf("auto", "packet-up", "stream-up", "stream-one"),
+	}
+}
+
+// tproxyValidators validates sockopt tproxy enum values.
+func tproxyValidators() []validator.String {
+	return []validator.String{
+		stringvalidator.OneOf("off", "redirect", "tproxy"),
+	}
+}
+
+// domainStrategyValidators validates sockopt domain_strategy enum values.
+func domainStrategyValidators() []validator.String {
+	return []validator.String{
+		stringvalidator.OneOf("AsIs", "IPIfNonMatch", "IPOnDemand"),
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Custom duration validator
+// ---------------------------------------------------------------------------
+
+// durationValidator validates that a string can be parsed as a Go duration.
+type durationValidator struct{}
+
+func (durationValidator) Description(_ context.Context) string {
+	return "must be a valid Go duration string (e.g. 30s, 1m, 2m30s)"
+}
+
+func (durationValidator) MarkdownDescription(_ context.Context) string {
+	return "must be a valid Go duration string (e.g. `30s`, `1m`, `2m30s`)"
+}
+
+func (durationValidator) ValidateString(_ context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+	if _, err := time.ParseDuration(req.ConfigValue.ValueString()); err != nil {
+		resp.Diagnostics.AddAttributeError(
+			req.Path,
+			"Invalid duration",
+			err.Error(),
+		)
+	}
+}

--- a/provider/validators.go
+++ b/provider/validators.go
@@ -127,7 +127,10 @@ func tproxyValidators() []validator.String {
 // domainStrategyValidators validates sockopt domain_strategy enum values.
 func domainStrategyValidators() []validator.String {
 	return []validator.String{
-		stringvalidator.OneOf("AsIs", "IPIfNonMatch", "IPOnDemand"),
+		stringvalidator.OneOf(
+			"AsIs", "UseIP", "UseIPv6v4", "UseIPv6", "UseIPv4v6", "UseIPv4",
+			"ForceIP", "ForceIPv6v4", "ForceIPv6", "ForceIPv4v6", "ForceIPv4",
+		),
 	}
 }
 

--- a/provider/validators.go
+++ b/provider/validators.go
@@ -74,7 +74,7 @@ func protocolValidators() []validator.String {
 // trafficResetValidators validates inbound traffic_reset enum values.
 func trafficResetValidators() []validator.String {
 	return []validator.String{
-		stringvalidator.OneOf("never", "day", "week", "month", "year"),
+		stringvalidator.OneOf("never", "hourly", "daily", "weekly", "monthly"),
 	}
 }
 

--- a/provider/validators_test.go
+++ b/provider/validators_test.go
@@ -180,7 +180,7 @@ func TestProtocolValidators(t *testing.T) {
 
 func TestTrafficResetValidators(t *testing.T) {
 	v := trafficResetValidators()
-	valid := []string{"never", "day", "week", "month", "year"}
+	valid := []string{"never", "hourly", "daily", "weekly", "monthly"}
 	for _, val := range valid {
 		for _, vv := range v {
 			if testStringValidator(t, vv, val) {
@@ -189,7 +189,7 @@ func TestTrafficResetValidators(t *testing.T) {
 		}
 	}
 
-	invalid := []string{"daily", "hourly", "NEVER", ""}
+	invalid := []string{"day", "week", "month", "year", "NEVER", ""}
 	for _, val := range invalid {
 		for _, vv := range v {
 			if !testStringValidator(t, vv, val) {

--- a/provider/validators_test.go
+++ b/provider/validators_test.go
@@ -331,7 +331,8 @@ func TestTproxyValidators(t *testing.T) {
 
 func TestDomainStrategyValidators(t *testing.T) {
 	v := domainStrategyValidators()
-	valid := []string{"AsIs", "IPIfNonMatch", "IPOnDemand"}
+	valid := []string{"AsIs", "UseIP", "UseIPv6v4", "UseIPv6", "UseIPv4v6", "UseIPv4",
+		"ForceIP", "ForceIPv6v4", "ForceIPv6", "ForceIPv4v6", "ForceIPv4"}
 	for _, val := range valid {
 		for _, vv := range v {
 			if testStringValidator(t, vv, val) {
@@ -340,7 +341,7 @@ func TestDomainStrategyValidators(t *testing.T) {
 		}
 	}
 
-	invalid := []string{"asis", "ipifnonmatch", ""}
+	invalid := []string{"asis", "IPIfNonMatch", "IPOnDemand", ""}
 	for _, val := range invalid {
 		for _, vv := range v {
 			if !testStringValidator(t, vv, val) {

--- a/provider/validators_test.go
+++ b/provider/validators_test.go
@@ -1,0 +1,369 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// testStringValidator is a helper that runs a StringValidator against a given
+// string value and returns whether validation produced errors.
+func testStringValidator(t *testing.T, v validator.String, value string) bool {
+	t.Helper()
+	req := validator.StringRequest{
+		ConfigValue: types.StringValue(value),
+	}
+	resp := &validator.StringResponse{}
+	v.ValidateString(context.Background(), req, resp)
+	return resp.Diagnostics.HasError()
+}
+
+func testInt64Validator(t *testing.T, v validator.Int64, value int64) bool {
+	t.Helper()
+	req := validator.Int64Request{
+		ConfigValue: types.Int64Value(value),
+	}
+	resp := &validator.Int64Response{}
+	v.ValidateInt64(context.Background(), req, resp)
+	return resp.Diagnostics.HasError()
+}
+
+// ---------------------------------------------------------------------------
+// Provider config validators
+// ---------------------------------------------------------------------------
+
+func TestEndpointValidators(t *testing.T) {
+	v := endpointValidators()
+	valid := []string{
+		"http://localhost:2053",
+		"https://panel.example.com",
+		"http://192.168.1.1:8080",
+	}
+	for _, val := range valid {
+		for _, vv := range v {
+			if testStringValidator(t, vv, val) {
+				t.Errorf("endpointValidators should accept %q", val)
+			}
+		}
+	}
+
+	invalid := []string{
+		"ftp://bad",
+		"just-a-string",
+		"localhost:2053",
+		"",
+	}
+	for _, val := range invalid {
+		for _, vv := range v {
+			if !testStringValidator(t, vv, val) {
+				t.Errorf("endpointValidators should reject %q", val)
+			}
+		}
+	}
+}
+
+func TestBasePathValidators(t *testing.T) {
+	v := basePathValidators()
+	valid := []string{"/", "/panel/", "/some/path"}
+	for _, val := range valid {
+		for _, vv := range v {
+			if testStringValidator(t, vv, val) {
+				t.Errorf("basePathValidators should accept %q", val)
+			}
+		}
+	}
+
+	invalid := []string{"panel/", "no-slash", ""}
+	for _, val := range invalid {
+		for _, vv := range v {
+			if !testStringValidator(t, vv, val) {
+				t.Errorf("basePathValidators should reject %q", val)
+			}
+		}
+	}
+}
+
+func TestRequestTimeoutValidators(t *testing.T) {
+	v := requestTimeoutValidators()
+	valid := []string{"30s", "1m", "2m30s", "1h", "500ms"}
+	for _, val := range valid {
+		for _, vv := range v {
+			if testStringValidator(t, vv, val) {
+				t.Errorf("requestTimeoutValidators should accept %q", val)
+			}
+		}
+	}
+
+	invalid := []string{"abc", "1x", "now"}
+	for _, val := range invalid {
+		for _, vv := range v {
+			if !testStringValidator(t, vv, val) {
+				t.Errorf("requestTimeoutValidators should reject %q", val)
+			}
+		}
+	}
+}
+
+func TestMaxRetriesValidators(t *testing.T) {
+	v := maxRetriesValidators()
+	valid := []int64{0, 1, 5, 10}
+	for _, val := range valid {
+		for _, vv := range v {
+			if testInt64Validator(t, vv, val) {
+				t.Errorf("maxRetriesValidators should accept %d", val)
+			}
+		}
+	}
+
+	invalid := []int64{-1, 11, 100}
+	for _, val := range invalid {
+		for _, vv := range v {
+			if !testInt64Validator(t, vv, val) {
+				t.Errorf("maxRetriesValidators should reject %d", val)
+			}
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Inbound resource validators
+// ---------------------------------------------------------------------------
+
+func TestPortValidators(t *testing.T) {
+	v := portValidators()
+	valid := []int64{1, 80, 443, 8080, 65535}
+	for _, val := range valid {
+		for _, vv := range v {
+			if testInt64Validator(t, vv, val) {
+				t.Errorf("portValidators should accept %d", val)
+			}
+		}
+	}
+
+	invalid := []int64{0, -1, 65536, 100000}
+	for _, val := range invalid {
+		for _, vv := range v {
+			if !testInt64Validator(t, vv, val) {
+				t.Errorf("portValidators should reject %d", val)
+			}
+		}
+	}
+}
+
+func TestProtocolValidators(t *testing.T) {
+	v := protocolValidators()
+	valid := []string{
+		"vless", "vmess", "trojan", "shadowsocks",
+		"http", "socks", "mixed", "wireguard",
+		"dokodemo-door", "tunnel", "tun",
+		"hysteria", "hysteria2",
+	}
+	for _, val := range valid {
+		for _, vv := range v {
+			if testStringValidator(t, vv, val) {
+				t.Errorf("protocolValidators should accept %q", val)
+			}
+		}
+	}
+
+	invalid := []string{"invalid", "VLESS", "tcp", "udp", ""}
+	for _, val := range invalid {
+		for _, vv := range v {
+			if !testStringValidator(t, vv, val) {
+				t.Errorf("protocolValidators should reject %q", val)
+			}
+		}
+	}
+}
+
+func TestTrafficResetValidators(t *testing.T) {
+	v := trafficResetValidators()
+	valid := []string{"never", "day", "week", "month", "year"}
+	for _, val := range valid {
+		for _, vv := range v {
+			if testStringValidator(t, vv, val) {
+				t.Errorf("trafficResetValidators should accept %q", val)
+			}
+		}
+	}
+
+	invalid := []string{"daily", "hourly", "NEVER", ""}
+	for _, val := range invalid {
+		for _, vv := range v {
+			if !testStringValidator(t, vv, val) {
+				t.Errorf("trafficResetValidators should reject %q", val)
+			}
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Stream settings validators
+// ---------------------------------------------------------------------------
+
+func TestNetworkValidators(t *testing.T) {
+	v := networkValidators()
+	valid := []string{"tcp", "ws", "grpc", "httpupgrade", "xhttp", "kcp", "hysteria"}
+	for _, val := range valid {
+		for _, vv := range v {
+			if testStringValidator(t, vv, val) {
+				t.Errorf("networkValidators should accept %q", val)
+			}
+		}
+	}
+
+	invalid := []string{"quic", "TCP", "udp", ""}
+	for _, val := range invalid {
+		for _, vv := range v {
+			if !testStringValidator(t, vv, val) {
+				t.Errorf("networkValidators should reject %q", val)
+			}
+		}
+	}
+}
+
+func TestSecurityValidators(t *testing.T) {
+	v := securityValidators()
+	valid := []string{"none", "tls", "reality"}
+	for _, val := range valid {
+		for _, vv := range v {
+			if testStringValidator(t, vv, val) {
+				t.Errorf("securityValidators should accept %q", val)
+			}
+		}
+	}
+
+	invalid := []string{"ssl", "TLS", " Reality ", ""}
+	for _, val := range invalid {
+		for _, vv := range v {
+			if !testStringValidator(t, vv, val) {
+				t.Errorf("securityValidators should reject %q", val)
+			}
+		}
+	}
+}
+
+func TestTCPHeaderTypeValidators(t *testing.T) {
+	v := tcpHeaderTypeValidators()
+	valid := []string{"none", "http"}
+	for _, val := range valid {
+		for _, vv := range v {
+			if testStringValidator(t, vv, val) {
+				t.Errorf("tcpHeaderTypeValidators should accept %q", val)
+			}
+		}
+	}
+
+	invalid := []string{"srtp", "HTTP", ""}
+	for _, val := range invalid {
+		for _, vv := range v {
+			if !testStringValidator(t, vv, val) {
+				t.Errorf("tcpHeaderTypeValidators should reject %q", val)
+			}
+		}
+	}
+}
+
+func TestKCPHeaderTypeValidators(t *testing.T) {
+	v := kcpHeaderTypeValidators()
+	valid := []string{"none", "srtp", "utp", "wechat-video", "dtls", "wireguard"}
+	for _, val := range valid {
+		for _, vv := range v {
+			if testStringValidator(t, vv, val) {
+				t.Errorf("kcpHeaderTypeValidators should accept %q", val)
+			}
+		}
+	}
+
+	invalid := []string{"http", "SRTP", ""}
+	for _, val := range invalid {
+		for _, vv := range v {
+			if !testStringValidator(t, vv, val) {
+				t.Errorf("kcpHeaderTypeValidators should reject %q", val)
+			}
+		}
+	}
+}
+
+func TestXHTTPModeValidators(t *testing.T) {
+	v := xhttpModeValidators()
+	valid := []string{"auto", "packet-up", "stream-up", "stream-one"}
+	for _, val := range valid {
+		for _, vv := range v {
+			if testStringValidator(t, vv, val) {
+				t.Errorf("xhttpModeValidators should accept %q", val)
+			}
+		}
+	}
+
+	invalid := []string{"packet", "stream", ""}
+	for _, val := range invalid {
+		for _, vv := range v {
+			if !testStringValidator(t, vv, val) {
+				t.Errorf("xhttpModeValidators should reject %q", val)
+			}
+		}
+	}
+}
+
+func TestTproxyValidators(t *testing.T) {
+	v := tproxyValidators()
+	valid := []string{"off", "redirect", "tproxy"}
+	for _, val := range valid {
+		for _, vv := range v {
+			if testStringValidator(t, vv, val) {
+				t.Errorf("tproxyValidators should accept %q", val)
+			}
+		}
+	}
+
+	invalid := []string{"on", "OFF", ""}
+	for _, val := range invalid {
+		for _, vv := range v {
+			if !testStringValidator(t, vv, val) {
+				t.Errorf("tproxyValidators should reject %q", val)
+			}
+		}
+	}
+}
+
+func TestDomainStrategyValidators(t *testing.T) {
+	v := domainStrategyValidators()
+	valid := []string{"AsIs", "IPIfNonMatch", "IPOnDemand"}
+	for _, val := range valid {
+		for _, vv := range v {
+			if testStringValidator(t, vv, val) {
+				t.Errorf("domainStrategyValidators should accept %q", val)
+			}
+		}
+	}
+
+	invalid := []string{"asis", "ipifnonmatch", ""}
+	for _, val := range invalid {
+		for _, vv := range v {
+			if !testStringValidator(t, vv, val) {
+				t.Errorf("domainStrategyValidators should reject %q", val)
+			}
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Duration validator (null/unknown skip)
+// ---------------------------------------------------------------------------
+
+func TestDurationValidator_SkipsNullAndUnknown(t *testing.T) {
+	v := durationValidator{}
+
+	// Null value should not produce errors
+	req := validator.StringRequest{
+		ConfigValue: types.StringNull(),
+	}
+	resp := &validator.StringResponse{}
+	v.ValidateString(context.Background(), req, resp)
+	if resp.Diagnostics.HasError() {
+		t.Error("durationValidator should skip null values")
+	}
+}


### PR DESCRIPTION
## Summary

- Add `terraform-plugin-framework-validators` dependency and apply schema validators to provider config and inbound resource fields so invalid values are caught during plan instead of apply
- Provider config: endpoint (URL regex), base_path (leading `/`), request_timeout (Go duration), max_retries (0-10 range)
- Inbound resource: port (1-65535), protocol (enum), traffic_reset (enum)
- Stream settings: network, security, tcp/kcp header_type, xhttp mode, sockopt tproxy, sockopt domain_strategy (all enum validators)
- 17 unit tests covering valid and invalid values for each validator group

Closes #248

## Test plan

- [x] `task fmt` passes
- [x] `task vet` passes
- [x] `task lint` passes
- [x] `task build` passes
- [x] `task test:unit` passes (all existing + 17 new validator tests)
- [ ] `task test:acc` passes (requires Docker)