### PR TITLE
test: inject retry budgets for faster unit tests

### DIFF
--- a/provider/client.go
+++ b/provider/client.go
@@ -53,27 +53,46 @@ type ClientConfig struct {
 	// 5xx for idempotent write endpoints. 0 disables retry entirely; 1 (the
 	// default applied by the provider) means up to one retry after a backoff.
 	MaxRetries int
+	// The fields below override production retry/backoff timings for tests.
+	// Zero means use the production default.
+	RetryBackoff           time.Duration // default: 500ms
+	ReadAfterWriteAttempts int           // default: 20
+	ReadAfterWriteBackoff  time.Duration // default: 500ms
+	VersionRetryAttempts   int           // default: 4
+	VersionRetryBackoff    time.Duration // default: 2s
 }
 
 type Client struct {
-	baseURL          *url.URL
-	basePath         string
-	username         string
-	password         string
-	twoFactor        string
-	httpClient       *http.Client
-	maxRetries       int
-	authMu           sync.Mutex
-	csrfToken        string
-	settingsSecretMu sync.Mutex
-	settingsSecrets  map[string]string
-	newClientMu      sync.Mutex
-	newClientAPI     *bool // nil=undetected, true=v3.1.0+ /panel/api/clients/*, false=old
+	baseURL                 *url.URL
+	basePath                string
+	username                string
+	password                string
+	twoFactor               string
+	httpClient              *http.Client
+	maxRetries              int
+	retryBackoff            time.Duration
+	rawAttempts             int
+	rawBackoff              time.Duration
+	versionRetryAttempts    int
+	versionRetryBaseBackoff time.Duration
+	authMu                  sync.Mutex
+	csrfToken               string
+	settingsSecretMu        sync.Mutex
+	settingsSecrets         map[string]string
+	newClientMu             sync.Mutex
+	newClientAPI            *bool // nil=undetected, true=v3.1.0+ /panel/api/clients/*, false=old
 }
 
 // SetBasePath updates the client's base path to match a new webBasePath.
 func (c *Client) SetBasePath(p string) {
 	c.basePath = normalizeBasePath(p)
+}
+
+// ReadAfterWriteConfig returns the read-after-write retry budget (attempts and
+// backoff) so callers like waitForInboundDeletion can align their own polling
+// loops with the same budget without hard-coding the constants.
+func (c *Client) ReadAfterWriteConfig() (attempts int, backoff time.Duration) {
+	return c.rawAttempts, c.rawBackoff
 }
 
 type apiResponse struct {
@@ -126,14 +145,40 @@ func NewClient(cfg ClientConfig) (*Client, error) {
 		maxRetries = 0
 	}
 
+	rb := cfg.RetryBackoff
+	if rb == 0 {
+		rb = defaultRetryBackoff
+	}
+	ra := cfg.ReadAfterWriteAttempts
+	if ra == 0 {
+		ra = readAfterWriteAttempts
+	}
+	raBackoff := cfg.ReadAfterWriteBackoff
+	if raBackoff == 0 {
+		raBackoff = readAfterWriteBackoff
+	}
+	vAttempts := cfg.VersionRetryAttempts
+	if vAttempts == 0 {
+		vAttempts = versionRetryAttempts
+	}
+	vBackoff := cfg.VersionRetryBackoff
+	if vBackoff == 0 {
+		vBackoff = versionRetryBaseBackoff
+	}
+
 	return &Client{
-		baseURL:    baseURL,
-		basePath:   basePath,
-		username:   cfg.Username,
-		password:   cfg.Password,
-		twoFactor:  cfg.TwoFactorCode,
-		httpClient: client,
-		maxRetries: maxRetries,
+		baseURL:                 baseURL,
+		basePath:                basePath,
+		username:                cfg.Username,
+		password:                cfg.Password,
+		twoFactor:               cfg.TwoFactorCode,
+		httpClient:              client,
+		maxRetries:              maxRetries,
+		retryBackoff:            rb,
+		rawAttempts:             ra,
+		rawBackoff:              raBackoff,
+		versionRetryAttempts:    vAttempts,
+		versionRetryBaseBackoff: vBackoff,
 	}, nil
 }
 
@@ -659,8 +704,8 @@ func isUpstreamRateLimitError(err error) bool {
 func (c *Client) GetXrayVersions(ctx context.Context) ([]string, error) {
 	var out []string
 	var lastErr error
-	backoff := versionRetryBaseBackoff
-	for attempt := 0; attempt <= versionRetryAttempts; attempt++ {
+	backoff := c.versionRetryBaseBackoff
+	for attempt := 0; attempt <= c.versionRetryAttempts; attempt++ {
 		err := c.doJSON(ctx, http.MethodGet, "panel/api/server/getXrayVersion", nil, &out)
 		if err == nil {
 			return out, nil
@@ -669,7 +714,7 @@ func (c *Client) GetXrayVersions(ctx context.Context) ([]string, error) {
 		if !isUpstreamRateLimitError(err) {
 			return nil, err
 		}
-		if attempt == versionRetryAttempts {
+		if attempt == c.versionRetryAttempts {
 			break
 		}
 		if ctxErr := ctx.Err(); ctxErr != nil {
@@ -677,7 +722,7 @@ func (c *Client) GetXrayVersions(ctx context.Context) ([]string, error) {
 		}
 		tflog.Warn(ctx, "retrying getXrayVersion after upstream rate limit", map[string]any{
 			"attempt":      attempt + 1,
-			"max_attempts": versionRetryAttempts,
+			"max_attempts": c.versionRetryAttempts,
 			"backoff":      backoff.String(),
 		})
 		select {
@@ -687,7 +732,7 @@ func (c *Client) GetXrayVersions(ctx context.Context) ([]string, error) {
 			backoff *= 2
 		}
 	}
-	return nil, fmt.Errorf("getXrayVersion: upstream rate limit persisted after %d retries: %w", versionRetryAttempts, lastErr)
+	return nil, fmt.Errorf("getXrayVersion: upstream rate limit persisted after %d retries: %w", c.versionRetryAttempts, lastErr)
 }
 
 // ErrXrayVersionUnknown is returned when the 3x-ui API reports the Xray
@@ -1109,12 +1154,12 @@ func (c *Client) withRetry(ctx context.Context, op string, fn func() error) erro
 			"attempt":      attempt + 1,
 			"max_attempts": c.maxRetries,
 			"status_code":  statusCode,
-			"backoff":      defaultRetryBackoff.String(),
+			"backoff":      c.retryBackoff.String(),
 		})
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-time.After(defaultRetryBackoff):
+		case <-time.After(c.retryBackoff):
 		}
 	}
 	return err
@@ -1140,10 +1185,10 @@ func (c *Client) doJSONRetryable(ctx context.Context, method, relPath string, bo
 //
 // Non-transient errors (4xx, auth failures, etc.) abort immediately.
 func (c *Client) WithReadAfterWriteRetry(ctx context.Context, opName string, fn func() (bool, error)) error {
-	for attempt := 0; attempt < readAfterWriteAttempts; attempt++ {
+	for attempt := 0; attempt < c.rawAttempts; attempt++ {
 		found, err := fn()
 		if err != nil {
-			if _, retryable := transient5xxStatus(err); !retryable || attempt == readAfterWriteAttempts-1 {
+			if _, retryable := transient5xxStatus(err); !retryable || attempt == c.rawAttempts-1 {
 				return err
 			}
 			if ctxErr := ctx.Err(); ctxErr != nil {
@@ -1152,20 +1197,20 @@ func (c *Client) WithReadAfterWriteRetry(ctx context.Context, opName string, fn 
 			tflog.Warn(ctx, "retrying read-after-write (transient error)", map[string]any{
 				"operation":    opName,
 				"attempt":      attempt + 1,
-				"max_attempts": readAfterWriteAttempts,
-				"backoff":      readAfterWriteBackoff.String(),
+				"max_attempts": c.rawAttempts,
+				"backoff":      c.rawBackoff.String(),
 			})
 			select {
 			case <-ctx.Done():
 				return ctx.Err()
-			case <-time.After(readAfterWriteBackoff):
+			case <-time.After(c.rawBackoff):
 			}
 			continue
 		}
 		if found {
 			return nil
 		}
-		if attempt == readAfterWriteAttempts-1 {
+		if attempt == c.rawAttempts-1 {
 			break
 		}
 		if ctxErr := ctx.Err(); ctxErr != nil {
@@ -1174,16 +1219,16 @@ func (c *Client) WithReadAfterWriteRetry(ctx context.Context, opName string, fn 
 		tflog.Warn(ctx, "retrying read-after-write", map[string]any{
 			"operation":    opName,
 			"attempt":      attempt + 1,
-			"max_attempts": readAfterWriteAttempts,
-			"backoff":      readAfterWriteBackoff.String(),
+			"max_attempts": c.rawAttempts,
+			"backoff":      c.rawBackoff.String(),
 		})
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-time.After(readAfterWriteBackoff):
+		case <-time.After(c.rawBackoff):
 		}
 	}
-	return fmt.Errorf("%s: row not visible after %d attempts (%s total)", opName, readAfterWriteAttempts, readAfterWriteBackoff*time.Duration(readAfterWriteAttempts-1))
+	return fmt.Errorf("%s: row not visible after %d attempts (%s total)", opName, c.rawAttempts, c.rawBackoff*time.Duration(c.rawAttempts-1))
 }
 
 func (c *Client) doRequestOnce(ctx context.Context, method, endpoint, contentType string, body []byte) (*http.Response, error) {

--- a/provider/client_test.go
+++ b/provider/client_test.go
@@ -40,13 +40,18 @@ func newTestClient(t *testing.T, endpoint string) *Client {
 func newTestClientWithRetries(t *testing.T, endpoint string, maxRetries int) *Client {
 	t.Helper()
 	c, err := NewClient(ClientConfig{
-		Endpoint:           endpoint,
-		BasePath:           "/",
-		Username:           "admin",
-		Password:           "admin",
-		InsecureSkipVerify: true,
-		Timeout:            2 * time.Second,
-		MaxRetries:         maxRetries,
+		Endpoint:               endpoint,
+		BasePath:               "/",
+		Username:               "admin",
+		Password:               "admin",
+		InsecureSkipVerify:     true,
+		Timeout:                2 * time.Second,
+		MaxRetries:             maxRetries,
+		RetryBackoff:           1 * time.Millisecond,
+		ReadAfterWriteAttempts: 3,
+		ReadAfterWriteBackoff:  1 * time.Millisecond,
+		VersionRetryAttempts:   2,
+		VersionRetryBackoff:    1 * time.Millisecond,
 	})
 	if err != nil {
 		t.Fatalf("NewClient error: %v", err)
@@ -668,21 +673,22 @@ func TestUpdateUserDoesNotRetryOn5xx(t *testing.T) {
 }
 
 func TestUpdateInboundRetryRespectsCtxCancel(t *testing.T) {
-	// Context cancellation during the 500ms backoff must short-circuit the
-	// retry, not block the caller.
+	// Context cancellation during the backoff must short-circuit the retry,
+	// not block the caller.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "transient", http.StatusInternalServerError)
 	}))
 	defer srv.Close()
 
-	client := newTestClient(t, srv.URL)
-	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	client := newTestClientWithRetries(t, srv.URL, 1)
+	client.retryBackoff = 50 * time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
 	defer cancel()
 	start := time.Now()
 	if _, err := client.UpdateInbound(ctx, &Inbound{ID: 1}); err == nil {
 		t.Fatalf("expected ctx error")
 	}
-	if elapsed := time.Since(start); elapsed > 400*time.Millisecond {
+	if elapsed := time.Since(start); elapsed > 40*time.Millisecond {
 		t.Fatalf("backoff did not respect ctx cancel; elapsed=%v", elapsed)
 	}
 }
@@ -1052,8 +1058,8 @@ func TestGetXrayVersionsRetriesExhausted(t *testing.T) {
 		t.Fatal("expected error after retries exhausted")
 	}
 	// 1 initial + versionRetryAttempts retries
-	if got := atomic.LoadInt32(&calls); got != int32(1+versionRetryAttempts) {
-		t.Fatalf("expected %d calls, got %d", 1+versionRetryAttempts, got)
+	if got := atomic.LoadInt32(&calls); got != int32(1+client.versionRetryAttempts) {
+		t.Fatalf("expected %d calls, got %d", 1+client.versionRetryAttempts, got)
 	}
 }
 
@@ -1090,6 +1096,7 @@ func TestGetXrayVersionsRateLimitRetryRespectsCtxCancel(t *testing.T) {
 	defer srv.Close()
 
 	client := newTestClient(t, srv.URL)
+	client.versionRetryBaseBackoff = 500 * time.Millisecond
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 
@@ -1098,7 +1105,7 @@ func TestGetXrayVersionsRateLimitRetryRespectsCtxCancel(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	// Context should cancel during the first or second backoff (~2-4s without cancel),
+	// Context should cancel during the first or second backoff,
 	// so elapsed must be well under the full retry window.
 	if elapsed := time.Since(start); elapsed > 5*time.Second {
 		t.Fatalf("backoff did not respect ctx cancel; elapsed=%v", elapsed)
@@ -1188,8 +1195,8 @@ func TestWithReadAfterWriteRetry_ExhaustsBudget(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	if calls != readAfterWriteAttempts {
-		t.Fatalf("expected %d calls, got %d", readAfterWriteAttempts, calls)
+	if calls != client.rawAttempts {
+		t.Fatalf("expected %d calls, got %d", client.rawAttempts, calls)
 	}
 }
 
@@ -1204,8 +1211,8 @@ func TestWithReadAfterWriteRetry_Transient5xxExhaustsBudget(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	if calls != readAfterWriteAttempts {
-		t.Fatalf("expected %d calls, got %d", readAfterWriteAttempts, calls)
+	if calls != client.rawAttempts {
+		t.Fatalf("expected %d calls, got %d", client.rawAttempts, calls)
 	}
 }
 
@@ -1229,6 +1236,7 @@ func TestWithReadAfterWriteRetry_Transient5xxRespectsPreCancelledContext(t *test
 
 func TestWithReadAfterWriteRetry_Transient5xxRespectsCtxCancelDuringBackoff(t *testing.T) {
 	client := newTestClient(t, "http://localhost")
+	client.rawBackoff = 500 * time.Millisecond
 	ctx, cancel := context.WithCancel(context.Background())
 
 	var calls int
@@ -1256,6 +1264,7 @@ func TestWithReadAfterWriteRetry_Transient5xxRespectsCtxCancelDuringBackoff(t *t
 
 func TestWithReadAfterWriteRetry_NotFoundRespectsCancelledContext(t *testing.T) {
 	client := newTestClient(t, "http://localhost")
+	client.rawBackoff = 500 * time.Millisecond
 	ctx, cancel := context.WithCancel(context.Background())
 
 	var calls int
@@ -1279,7 +1288,7 @@ func TestWithReadAfterWriteRetry_Transient5xxOnLastAttemptReturnsErr(t *testing.
 
 	err := client.WithReadAfterWriteRetry(context.Background(), "test-op", func() (bool, error) {
 		calls++
-		if calls < readAfterWriteAttempts {
+		if calls < client.rawAttempts {
 			return false, nil
 		}
 		return false, &HTTPStatusError{StatusCode: 500, Body: "late 5xx"}
@@ -1287,7 +1296,7 @@ func TestWithReadAfterWriteRetry_Transient5xxOnLastAttemptReturnsErr(t *testing.
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	if calls != readAfterWriteAttempts {
-		t.Fatalf("expected %d calls, got %d", readAfterWriteAttempts, calls)
+	if calls != client.rawAttempts {
+		t.Fatalf("expected %d calls, got %d", client.rawAttempts, calls)
 	}
 }

--- a/provider/inbound_client_test.go
+++ b/provider/inbound_client_test.go
@@ -212,10 +212,11 @@ func TestInboundResourceWaitForDeletion(t *testing.T) {
 		if err := res.waitForInboundDeletion(context.Background(), 1); err == nil {
 			t.Fatalf("expected error after exhausting attempts")
 		}
-		// destroyVisibilityAttempts changed; resource-side waitForInboundDeletion
-		// is intentionally separate (20×500ms = 10s) — see provider/resource_inbound.go.
-		if got := atomic.LoadInt32(&lists); got != 20 {
-			t.Fatalf("expected 20 list calls, got %d", got)
+		// waitForInboundDeletion uses client.ReadAfterWriteConfig() for its
+		// attempt budget. In tests this is the test-injected value (3).
+		expectedAttempts, _ := res.client.ReadAfterWriteConfig()
+		if got := atomic.LoadInt32(&lists); got != int32(expectedAttempts) {
+			t.Fatalf("expected %d list calls, got %d", expectedAttempts, got)
 		}
 	})
 
@@ -249,7 +250,10 @@ func TestInboundResourceWaitForDeletion(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		res := &InboundResource{client: newTestClient(t, srv.URL)}
+		client := newTestClient(t, srv.URL)
+		client.rawBackoff = 500 * time.Millisecond
+		client.rawAttempts = 20
+		res := &InboundResource{client: client}
 		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 		defer cancel()
 		start := time.Now()
@@ -261,7 +265,7 @@ func TestInboundResourceWaitForDeletion(t *testing.T) {
 		if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
 			t.Fatalf("expected context error, got %v", err)
 		}
-		// Full attempt budget is 6 × 500ms ≈ 3s. Cancellation must
+		// Full attempt budget is 20 x 500ms = 10s. Cancellation must
 		// short-circuit the backoff well before that.
 		if elapsed > 600*time.Millisecond {
 			t.Fatalf("backoff did not respect ctx cancel; elapsed=%v", elapsed)

--- a/provider/resource_inbound.go
+++ b/provider/resource_inbound.go
@@ -480,13 +480,10 @@ func (r *InboundResource) Delete(ctx context.Context, req resource.DeleteRequest
 // row), so we never re-issue DELETE — the original DELETE has already been
 // accepted.
 func (r *InboundResource) waitForInboundDeletion(ctx context.Context, id int) error {
-	// Budget aligned with readAfterWriteAttempts/Backoff so the delete-side
-	// visibility window matches the read-after-write side; both observe the
-	// same SQLite contention pattern (issue #161).
-	const (
-		attempts = 20
-		delay    = 500 * time.Millisecond
-	)
+	// Budget aligned with the client's read-after-write settings so the
+	// delete-side visibility window matches the read-after-write side; both
+	// observe the same SQLite contention pattern (issue #161).
+	attempts, delay := r.client.ReadAfterWriteConfig()
 	var lastErr error
 	for i := 0; i < attempts; i++ {
 		inbounds, err := r.client.GetInbounds(ctx)


### PR DESCRIPTION
## Summary
- Extract retry/backoff settings into injectable `ClientConfig` fields
- Tests inject 1ms backoff and fewer attempts instead of production 500ms
- Production defaults unchanged
- Unit test time reduced from ~87s to ~1s

Closes #252

## Test plan
- [x] `task pre-commit` passes
- [x] `task test:unit` passes in ~1s
- [ ] CI green