### PR TITLE
feat: add acceptance tests with PostgreSQL backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,9 +216,9 @@ jobs:
           retry_on: error
           command: task test:acc:postgres
 
-      - name: Capture 3x-ui container logs
+      - name: Capture container logs
         if: failure()
-        run: docker compose logs 3xui > 3xui-container.log 2>&1
+        run: docker compose --profile postgres logs > 3xui-container.log 2>&1
 
       - name: Upload container logs
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,58 @@ jobs:
           path: 3xui-container.log
           retention-days: 7
 
+  acceptance-tests-postgres:
+    name: Acceptance Tests (PostgreSQL)
+    runs-on: ubuntu-latest
+    needs: [lint]
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: go.mod
+
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4
+        with:
+          terraform_wrapper: false
+
+      - name: Install Task
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run acceptance tests with PostgreSQL
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          timeout_minutes: 18
+          max_attempts: 2
+          retry_on: error
+          command: task test:acc:postgres
+
+      - name: Capture 3x-ui container logs
+        if: failure()
+        run: docker compose logs 3xui > 3xui-container.log 2>&1
+
+      - name: Upload container logs
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: 3xui-container-logs-postgres
+          path: 3xui-container.log
+          retention-days: 7
+
   acceptance-matrix-prepare:
     name: Prepare compat matrix
     runs-on: ubuntu-latest

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -69,6 +69,29 @@ tasks:
         THREEXUI_VERSION={{.THREEXUI_VERSION}}
         go test ./provider -run TestAcc -count=1 -timeout 600s -v
 
+  test:acc:postgres:
+    desc: Запустить acceptance-тесты с PostgreSQL бэкендом
+    vars:
+      TERRAFORM_PATH:
+        sh: which terraform
+      THREEXUI_VERSION: '{{.THREEXUI_VERSION | default "v3.3.0"}}'
+    cmds:
+      - docker compose down -v 2>/dev/null || true
+      - XUI_DB_TYPE=postgres XUI_DB_DSN=postgres://xui:xui@postgres:5432/xui?sslmode=disable docker compose --profile postgres up --detach --wait --quiet-pull
+      - defer: docker compose --profile postgres down -v
+      - task: _wait-for-xray
+      - task: _warm-xray-version-cache
+      - >-
+        TF_ACC=1
+        TF_ACC_TERRAFORM_PATH={{.TERRAFORM_PATH}}
+        TF_ACC_PROVIDER_NAMESPACE=batonogov
+        TF_ACC_PROVIDER_HOST=registry.terraform.io
+        THREEXUI_ENDPOINT=http://localhost:2053
+        THREEXUI_USERNAME=admin
+        THREEXUI_PASSWORD=admin
+        THREEXUI_VERSION={{.THREEXUI_VERSION}}
+        go test ./provider -run TestAcc -count=1 -timeout 600s -v
+
   _wait-for-xray:
     desc: Дождаться готовности xray-подсистемы внутри 3x-ui (внутренняя задача)
     silent: true

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,6 +7,11 @@ services:
       XRAY_VMESS_AEAD_FORCED: "false"
       XUI_ENABLE_FAIL2BAN: "true"
       GITHUB_TOKEN: "${GITHUB_TOKEN:-}"
+      # Set both to activate PostgreSQL (via --profile postgres):
+      #   XUI_DB_TYPE=postgres
+      #   XUI_DB_DSN=postgres://xui:xui@postgres:5432/xui?sslmode=disable
+      XUI_DB_TYPE: "${XUI_DB_TYPE:-}"
+      XUI_DB_DSN: "${XUI_DB_DSN:-}"
     tty: true
     restart: unless-stopped
     # `/` returns 200 (login page) once the gin router is up — earlier
@@ -20,3 +25,18 @@ services:
       timeout: 3s
       retries: 15
       start_period: 5s
+
+  postgres:
+    image: postgres:16-alpine
+    container_name: 3xui_postgres
+    profiles: ["postgres"]
+    environment:
+      POSTGRES_USER: xui
+      POSTGRES_PASSWORD: xui
+      POSTGRES_DB: xui
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U xui"]
+      interval: 2s
+      timeout: 3s
+      retries: 10
+    restart: unless-stopped

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,6 +12,10 @@ services:
       #   XUI_DB_DSN=postgres://xui:xui@postgres:5432/xui?sslmode=disable
       XUI_DB_TYPE: "${XUI_DB_TYPE:-}"
       XUI_DB_DSN: "${XUI_DB_DSN:-}"
+    depends_on:
+      postgres:
+        condition: service_healthy
+        required: false
     tty: true
     restart: unless-stopped
     # `/` returns 200 (login page) once the gin router is up — earlier


### PR DESCRIPTION
## Summary

- Add `postgres` service (profile-based) to `docker-compose.yaml` with healthcheck
- Add `test:acc:postgres` Taskfile target that runs acc tests against 3x-ui with PostgreSQL
- Add `acceptance-tests-postgres` CI job (latest 3x-ui version only, not full matrix)

## Test plan

- [ ] `task test:acc:postgres` passes locally
- [ ] CI `acceptance-tests-postgres` job is green
- [ ] Existing `test:acc` (SQLite) is unaffected