### PR TITLE
fix: make sub_id Optional+Computed for disaster recovery

### DIFF
--- a/docs/resources/inbound_client.md
+++ b/docs/resources/inbound_client.md
@@ -88,15 +88,14 @@ resource "threexui_inbound_client" "hysteria_user" {
 - `reset` (Optional, Number) - Traffic reset period in days. `0` means never (default).
 - `group` (Optional, String) - Client group name. Available on 3x-ui v3.2.0+.
 - `restart_xray` (Optional, Boolean) - Restart Xray core after create, update, or delete operations. Default is `false`.
+- `sub_id` (Optional, String) - Subscription ID used for subscription URLs. Auto-generated if not provided. Set this to preserve existing subscription links when restoring from backup.
 
 ## Read-Only Attributes
-
-- `sub_id` (String) - Auto-generated subscription ID used for subscription URLs.
 
 ## Usage: Subscription URLs
 
 When the panel subscription service is enabled (`threexui_panel_subscription`),
-each client receives an auto-generated `sub_id`. Use it to build subscription
+each client receives a `sub_id`. Use it to build subscription
 URLs that clients can import into v2rayN, Hiddify, Streisand, or any compatible app:
 
 ```hcl

--- a/provider/acc_inbound_client_test.go
+++ b/provider/acc_inbound_client_test.go
@@ -467,6 +467,87 @@ func TestAccInboundClientExplicitSubID(t *testing.T) {
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
 			},
+			// Import preserves sub_id
+			{
+				ResourceName:            "threexui_inbound_client.subid",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"password"},
+			},
+		},
+	})
+}
+
+// --- Update sub_id: auto-generated → explicit (disaster recovery) ---
+
+func TestAccInboundClientSubIDUpdate(t *testing.T) {
+	hostConfig := `
+	resource "threexui_inbound" "subid_upd_host" {
+	  port     = 25110
+	  protocol = "vless"
+	  remark   = "acc-subid-upd-host"
+	  enable   = true
+	  vless_settings {
+	    decryption = "none"
+	  }
+	  stream_settings {
+	    network  = "tcp"
+	    security = "reality"
+	    reality_settings {
+	      target       = "google.com:443"
+	      server_names = ["google.com"]
+	    }
+	  }
+	}
+	`
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		CheckDestroy:             testAccCheckInboundClientDestroyed,
+		Steps: []resource.TestStep{
+			// Step 1: create without sub_id — auto-generated
+			{
+				Config: testAccProviderConfig() + hostConfig + `
+				resource "threexui_inbound_client" "subid_upd" {
+				  inbound_id = threexui_inbound.subid_upd_host.id
+				  email      = "subid-upd@test.com"
+				  enable     = true
+				  flow       = "xtls-rprx-vision"
+				}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("threexui_inbound_client.subid_upd", "sub_id"),
+				),
+			},
+			// Step 2: update to explicit sub_id
+			{
+				Config: testAccProviderConfig() + hostConfig + `
+				resource "threexui_inbound_client" "subid_upd" {
+				  inbound_id = threexui_inbound.subid_upd_host.id
+				  email      = "subid-upd@test.com"
+				  sub_id     = "updated123subid456"
+				  enable     = true
+				  flow       = "xtls-rprx-vision"
+				}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("threexui_inbound_client.subid_upd", "sub_id", "updated123subid456"),
+				),
+			},
+			// Step 3: idempotency after update
+			{
+				Config: testAccProviderConfig() + hostConfig + `
+				resource "threexui_inbound_client" "subid_upd" {
+				  inbound_id = threexui_inbound.subid_upd_host.id
+				  email      = "subid-upd@test.com"
+				  sub_id     = "updated123subid456"
+				  enable     = true
+				  flow       = "xtls-rprx-vision"
+				}
+				`,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
 		},
 	})
 }

--- a/provider/acc_inbound_client_test.go
+++ b/provider/acc_inbound_client_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-// --- All fields: email, flow, limit_ip, total_gb, expiry_time, enable, tg_id, comment, reset (sub_id is Computed) ---
+// --- All fields: email, flow, limit_ip, total_gb, expiry_time, enable, tg_id, comment, reset (sub_id is Optional+Computed) ---
 
 func TestAccInboundClientAllFields(t *testing.T) {
 	config := testAccProviderConfig() + `
@@ -406,6 +406,59 @@ resource "threexui_inbound_client" "explicitid" {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("threexui_inbound_client.explicitid", "client_id", "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"),
 					resource.TestCheckResourceAttr("threexui_inbound_client.explicitid", "email", "explicitid@test.com"),
+				),
+			},
+			// Idempotency
+			{
+				Config:             config,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+// --- Client with explicit sub_id (disaster recovery) ---
+
+func TestAccInboundClientExplicitSubID(t *testing.T) {
+	config := testAccProviderConfig() + `
+	resource "threexui_inbound" "subid_host" {
+	  port     = 25109
+	  protocol = "vless"
+	  remark   = "acc-subid-host"
+	  enable   = true
+	  vless_settings {
+	    decryption = "none"
+	  }
+	  stream_settings {
+	    network  = "tcp"
+	    security = "reality"
+	    reality_settings {
+	      target       = "google.com:443"
+	      server_names = ["google.com"]
+	    }
+	  }
+	}
+
+	resource "threexui_inbound_client" "subid" {
+	  inbound_id = threexui_inbound.subid_host.id
+	  email      = "subid@test.com"
+	  sub_id     = "eh12gmmy6dj87kkw"
+	  enable     = true
+	  flow       = "xtls-rprx-vision"
+	}
+	`
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		CheckDestroy:             testAccCheckInboundClientDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("threexui_inbound_client.subid", "id"),
+					resource.TestCheckResourceAttr("threexui_inbound_client.subid", "email", "subid@test.com"),
+					resource.TestCheckResourceAttr("threexui_inbound_client.subid", "sub_id", "eh12gmmy6dj87kkw"),
 				),
 			},
 			// Idempotency

--- a/provider/resource_inbound_client.go
+++ b/provider/resource_inbound_client.go
@@ -171,6 +171,7 @@ func (r *InboundClientResource) Schema(_ context.Context, _ resource.SchemaReque
 				},
 			},
 			"sub_id": schema.StringAttribute{
+				Optional: true,
 				Computed: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),


### PR DESCRIPTION
## Summary
- Changes `sub_id` in `threexui_inbound_client` from read-only to `Optional + Computed`
- Users can now set a specific `sub_id` to preserve subscription links when restoring from backup
- If `sub_id` is not provided, it is auto-generated as before

## Test plan
- [x] Unit tests pass (`task test:unit`)
- [x] Pre-commit hooks pass (fmt, vet, lint, build, markdownlint)
- [ ] Acceptance test `TestAccInboundClientExplicitSubID` with explicit `sub_id`
- [ ] Existing `TestAccInboundClientAllFields` still passes (auto-generated `sub_id`)

Closes #271
