### PR TITLE
feat: add write-only secret arguments for Terraform 1.11+

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,13 @@ Env vars: `THREEXUI_ENDPOINT`, `THREEXUI_USERNAME`, `THREEXUI_PASSWORD`,
 | `task test:acc` | Acceptance tests (Docker lifecycle included) |
 | `task pre-commit` | fmt + vet + lint + build |
 
+**Watch CI status for a PR:**
+
+```bash
+gh pr checks <PR>          # one-shot
+gh pr checks <PR> --watch  # live
+```
+
 **Version-specific acc tests:**
 
 ```bash
@@ -43,6 +50,7 @@ THREEXUI_VERSION=v3.1.0 task test:acc:compat
 ```bash
 TF_ACC=1 THREEXUI_ENDPOINT=http://localhost:2053 \
   THREEXUI_USERNAME=admin THREEXUI_PASSWORD=admin \
+  THREEXUI_VERSION=v3.3.0 \
   go test ./provider -run TestAccInboundVLESS -count=1 -timeout 600s -v
 ```
 
@@ -124,17 +132,13 @@ Separate resource — singleton with ID `"xray_version"`. Calls `InstallXray` + 
 `waitForXrayVersion` until the version matches. Delete is a no-op with a warning
 (removing from state does NOT revert the installed version).
 
-### Panel user (write-only password)
+### Panel user (`resource_panel_user.go`)
 
 `threexui_panel_user` — no read API exists. Read is a no-op, state is preserved
 from plan. Create uses provider credentials as old credentials; Update uses
-previous state credentials, falling back to provider credentials when state
-password is empty (e.g. after using `password_wo`).
-
-`password` is Optional with `AtLeastOneOf("password", "password_wo")` validation.
-When `password_wo` is used, `password` is set to null in state so the secret
-is not persisted. Update falls back to provider credentials as old credentials
-in this case.
+prior state credentials (falls back to provider credentials when state
+password is empty, e.g. after using `password_wo`). See Write-only section
+above for the `password` / `password_wo` lifecycle.
 
 ### HTTP client (`client.go`)
 
@@ -179,8 +183,7 @@ These are non-obvious constraints that have caused real bugs.
 | DNS servers: string vs object | Address-only → string; with extra fields → object |
 | `xray_version` delete is a no-op | Removing from state does NOT revert the installed xray version |
 | `web_base_path` change triggers panel restart | Must also update provider `base_path`; code auto-updates client |
-| Write-only attrs: read from `req.Config`, not plan | Framework nulls `_wo` values in plan/state; must use config to get the actual value |
-| `password_wo` nulls state password | Update falls back to provider credentials as old password when state is empty |
+| Write-only attrs quirks | See "Write-only secret attributes" section above — read `_wo` from `req.Config`; ModifyPlan marks plain `Unknown` on version change; `panel_user` nulls state password instead |
 
 **Always check 3x-ui source snapshots** (`3x-ui-<version>/`) before assuming API behavior.
 Key paths: `database/model/`, `web/service/`, `web/controller/`, `web/entity/`, `frontend/src/schemas/`, `xray/`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,11 +91,19 @@ Each secret gets three attributes: old `Sensitive` attr + `WriteOnly` attr + `_w
 | `panel_general` | `ldap_password` | `ldap_password_wo` | `ldap_password_wo_version` |
 
 - `PreferWriteOnlyAttribute` validator warns on TF >= 1.11 when using old attr.
+- `int64validator.AlsoRequires` enforces that `*_wo_version` can only be set with `*_wo`.
 - Write-only values read from `req.Config` (not plan/state — framework nulls them).
-- For settings resources, `resolveXxxWO` copies `_wo` value into the old model field
-  before `expand*()` so the existing expand/flatten pipeline is unchanged.
-- Version trigger: `resolveXxxWOUpdate` only sends the `_wo` value when version
-  changes (or on first use when state has no version yet).
+- Two resolution strategies:
+  - **panel_user**: `password` is nulled in state when `password_wo` is used. Update
+    falls back to provider credentials when state password is empty. No ModifyPlan
+    needed because state has no prior password to conflict with.
+  - **settings (security/telegram/general)**: `resolveXxxWO` copies `_wo` value into
+    the old model field before `expand*()`. ModifyPlan marks the plain attr as Unknown
+    on `woVersionTriggered` so Terraform accepts a new sensitive value from Apply.
+    Needed because flatten reads the masked value back, which would otherwise be
+    rejected as "inconsistent values for sensitive".
+- Version trigger: `resolveXxxWOUpdate` only sends the `_wo` value when
+  `woVersionTriggered(plan, state)` (version changes, or first use when state has none).
 
 ### Xray settings (two modes)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,25 @@ Four resources — `panel_general`, `panel_security`, `panel_telegram`,
 - Changing `web_base_path` in `panel_general` triggers a panel restart and updates
   the provider client's base path via `SetBasePath` + `WaitForReady`.
 
+### Write-only secret attributes (Terraform 1.11+)
+
+Four singleton secrets have write-only (`_wo`) alternatives following the AWS/Azure pattern.
+Each secret gets three attributes: old `Sensitive` attr + `WriteOnly` attr + `_wo_version` trigger.
+
+| Resource | Old attr | Write-only | Version trigger |
+| --- | --- | --- | --- |
+| `panel_user` | `password` | `password_wo` | `password_wo_version` |
+| `panel_security` | `two_factor_token` | `two_factor_token_wo` | `two_factor_token_wo_version` |
+| `panel_telegram` | `tg_bot_token` | `tg_bot_token_wo` | `tg_bot_token_wo_version` |
+| `panel_general` | `ldap_password` | `ldap_password_wo` | `ldap_password_wo_version` |
+
+- `PreferWriteOnlyAttribute` validator warns on TF >= 1.11 when using old attr.
+- Write-only values read from `req.Config` (not plan/state — framework nulls them).
+- For settings resources, `resolveXxxWO` copies `_wo` value into the old model field
+  before `expand*()` so the existing expand/flatten pipeline is unchanged.
+- Version trigger: `resolveXxxWOUpdate` only sends the `_wo` value when version
+  changes (or on first use when state has no version yet).
+
 ### Xray settings (two modes)
 
 Six xray resources share `resource_xray_settings.go`: `xray_basics`, `xray_dns`,
@@ -97,11 +116,17 @@ Separate resource — singleton with ID `"xray_version"`. Calls `InstallXray` + 
 `waitForXrayVersion` until the version matches. Delete is a no-op with a warning
 (removing from state does NOT revert the installed version).
 
-### Panel user (write-only)
+### Panel user (write-only password)
 
 `threexui_panel_user` — no read API exists. Read is a no-op, state is preserved
 from plan. Create uses provider credentials as old credentials; Update uses
-previous state.
+previous state credentials, falling back to provider credentials when state
+password is empty (e.g. after using `password_wo`).
+
+`password` is Optional with `AtLeastOneOf("password", "password_wo")` validation.
+When `password_wo` is used, `password` is set to null in state so the secret
+is not persisted. Update falls back to provider credentials as old credentials
+in this case.
 
 ### HTTP client (`client.go`)
 
@@ -146,6 +171,8 @@ These are non-obvious constraints that have caused real bugs.
 | DNS servers: string vs object | Address-only → string; with extra fields → object |
 | `xray_version` delete is a no-op | Removing from state does NOT revert the installed xray version |
 | `web_base_path` change triggers panel restart | Must also update provider `base_path`; code auto-updates client |
+| Write-only attrs: read from `req.Config`, not plan | Framework nulls `_wo` values in plan/state; must use config to get the actual value |
+| `password_wo` nulls state password | Update falls back to provider credentials as old password when state is empty |
 
 **Always check 3x-ui source snapshots** (`3x-ui-<version>/`) before assuming API behavior.
 Key paths: `database/model/`, `web/service/`, `web/controller/`, `web/entity/`, `frontend/src/schemas/`, `xray/`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ Four resources — `panel_general`, `panel_security`, `panel_telegram`,
 - Changing `web_base_path` in `panel_general` triggers a panel restart and updates
   the provider client's base path via `SetBasePath` + `WaitForReady`.
 
-### Write-only secret attributes (Terraform 1.11+)
+### Write-only secret attributes (Terraform 1.11+ / OpenTofu 1.11+)
 
 Four singleton secrets have write-only (`_wo`) alternatives following the AWS/Azure pattern.
 Each secret gets three attributes: old `Sensitive` attr + `WriteOnly` attr + `_wo_version` trigger.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -52,12 +52,12 @@ Terraform state stores **all** sensitive values in plaintext, regardless of the 
 - **Avoid committing `terraform.tfstate`** or `*.tfstate.backup` to git — they are in the default `.gitignore`, but worth verifying.
 - **Rotate the panel password** if a state file is exposed; the provider stores the credentials it was given.
 
-## Write-Only Arguments (Terraform 1.11+)
+## Write-Only Arguments (Terraform 1.11+ / OpenTofu 1.11+)
 
-Starting with provider v3.13.0, resources that manage secrets offer write-only (`_wo`) attribute alternatives. Write-only values are sent to the 3x-ui panel but **never stored** in Terraform plan or state artifacts.
+Starting with provider v3.13.0, resources that manage secrets offer write-only (`_wo`) attribute alternatives. Write-only values are sent to the 3x-ui panel but **never stored** in Terraform plan or state artifacts. Requires Terraform ≥ 1.11 or OpenTofu ≥ 1.11; on earlier versions, `_wo` attributes fall back to plain `Sensitive` behaviour and the secret is persisted in state.
 
 | Resource | Write-only attribute | Version trigger |
-|---|---|---|
+| --- | --- | --- |
 | `threexui_panel_user` | `password_wo` | `password_wo_version` |
 | `threexui_panel_security` | `two_factor_token_wo` | `two_factor_token_wo_version` |
 | `threexui_panel_telegram` | `tg_bot_token_wo` | `tg_bot_token_wo_version` |
@@ -67,7 +67,7 @@ Starting with provider v3.13.0, resources that manage secrets offer write-only (
 
 - Set `<field>_wo` to the secret value and `<field>_wo_version` to an integer.
 - To update the secret, increment `<field>_wo_version` — Terraform detects the change and re-sends the `_wo` value.
-- The plain `<field>` attribute remains for backward compatibility. Using it on Terraform 1.11+ produces a warning suggesting migration to `_wo`.
+- The plain `<field>` attribute remains for backward compatibility. Using it on Terraform 1.11+ / OpenTofu 1.11+ produces a warning suggesting migration to `_wo`.
 
 ### Trade-offs
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -52,6 +52,28 @@ Terraform state stores **all** sensitive values in plaintext, regardless of the 
 - **Avoid committing `terraform.tfstate`** or `*.tfstate.backup` to git — they are in the default `.gitignore`, but worth verifying.
 - **Rotate the panel password** if a state file is exposed; the provider stores the credentials it was given.
 
+## Write-Only Arguments (Terraform 1.11+)
+
+Starting with provider v3.13.0, resources that manage secrets offer write-only (`_wo`) attribute alternatives. Write-only values are sent to the 3x-ui panel but **never stored** in Terraform plan or state artifacts.
+
+| Resource | Write-only attribute | Version trigger |
+|---|---|---|
+| `threexui_panel_user` | `password_wo` | `password_wo_version` |
+| `threexui_panel_security` | `two_factor_token_wo` | `two_factor_token_wo_version` |
+| `threexui_panel_telegram` | `tg_bot_token_wo` | `tg_bot_token_wo_version` |
+| `threexui_panel_general` | `ldap_password_wo` | `ldap_password_wo_version` |
+
+### How it works
+
+- Set `<field>_wo` to the secret value and `<field>_wo_version` to an integer.
+- To update the secret, increment `<field>_wo_version` — Terraform detects the change and re-sends the `_wo` value.
+- The plain `<field>` attribute remains for backward compatibility. Using it on Terraform 1.11+ produces a warning suggesting migration to `_wo`.
+
+### Trade-offs
+
+- Write-only values are not available in data sources or during `import`. After import, provide the secret again via `_wo` or the plain attribute.
+- Both attributes can coexist in a configuration. The `_wo` value takes priority.
+
 ## Network and Authentication Notes
 
 - The provider authenticates to 3x-ui over HTTP/HTTPS with form-based session cookies.

--- a/docs/resources/panel_general.md
+++ b/docs/resources/panel_general.md
@@ -60,6 +60,8 @@ resource "threexui_panel_general" "settings" {
 - `ldap_use_tls` (Optional, Boolean) - Use TLS for LDAP. Default is `false`.
 - `ldap_bind_dn` (Optional, String) - Bind DN. Default is `""`.
 - `ldap_password` (Optional, String, Sensitive) - Bind password. Default is `""`.
+- `ldap_password_wo` (Optional, String, WriteOnly) - Write-only version of `ldap_password`. Not persisted in state. Terraform 1.11+.
+- `ldap_password_wo_version` (Optional, Number) - Increment to trigger re-send of `ldap_password_wo`.
 - `ldap_base_dn` (Optional, String) - Base DN. Default is `""`.
 - `ldap_user_filter` (Optional, String) - User filter. Default is `(objectClass=person)`.
 - `ldap_user_attr` (Optional, String) - User attribute. Default is `mail`.

--- a/docs/resources/panel_general.md
+++ b/docs/resources/panel_general.md
@@ -60,7 +60,7 @@ resource "threexui_panel_general" "settings" {
 - `ldap_use_tls` (Optional, Boolean) - Use TLS for LDAP. Default is `false`.
 - `ldap_bind_dn` (Optional, String) - Bind DN. Default is `""`.
 - `ldap_password` (Optional, String, Sensitive) - Bind password. Default is `""`.
-- `ldap_password_wo` (Optional, String, WriteOnly) - Write-only version of `ldap_password`. Not persisted in state. Terraform 1.11+.
+- `ldap_password_wo` (Optional, String, WriteOnly) - Write-only version of `ldap_password`. Not persisted in state. Terraform 1.11+ / OpenTofu 1.11+.
 - `ldap_password_wo_version` (Optional, Number) - Increment to trigger re-send of `ldap_password_wo`. Must be set together with `ldap_password_wo`.
 - `ldap_base_dn` (Optional, String) - Base DN. Default is `""`.
 - `ldap_user_filter` (Optional, String) - User filter. Default is `(objectClass=person)`.

--- a/docs/resources/panel_general.md
+++ b/docs/resources/panel_general.md
@@ -61,7 +61,7 @@ resource "threexui_panel_general" "settings" {
 - `ldap_bind_dn` (Optional, String) - Bind DN. Default is `""`.
 - `ldap_password` (Optional, String, Sensitive) - Bind password. Default is `""`.
 - `ldap_password_wo` (Optional, String, WriteOnly) - Write-only version of `ldap_password`. Not persisted in state. Terraform 1.11+.
-- `ldap_password_wo_version` (Optional, Number) - Increment to trigger re-send of `ldap_password_wo`.
+- `ldap_password_wo_version` (Optional, Number) - Increment to trigger re-send of `ldap_password_wo`. Must be set together with `ldap_password_wo`.
 - `ldap_base_dn` (Optional, String) - Base DN. Default is `""`.
 - `ldap_user_filter` (Optional, String) - User filter. Default is `(objectClass=person)`.
 - `ldap_user_attr` (Optional, String) - User attribute. Default is `mail`.

--- a/docs/resources/panel_security.md
+++ b/docs/resources/panel_security.md
@@ -25,6 +25,8 @@ resource "threexui_panel_security" "settings" {
 
 - `two_factor_enable` (Optional, Boolean) - Enable two-factor authentication.
 - `two_factor_token` (Optional, String, Sensitive) - Two-factor authentication token/secret.
+- `two_factor_token_wo` (Optional, String, WriteOnly) - Write-only version of `two_factor_token`. Not persisted in state. Terraform 1.11+.
+- `two_factor_token_wo_version` (Optional, Number) - Increment to trigger re-send of `two_factor_token_wo`.
 
 ## Attribute Reference
 

--- a/docs/resources/panel_security.md
+++ b/docs/resources/panel_security.md
@@ -26,7 +26,7 @@ resource "threexui_panel_security" "settings" {
 - `two_factor_enable` (Optional, Boolean) - Enable two-factor authentication.
 - `two_factor_token` (Optional, String, Sensitive) - Two-factor authentication token/secret.
 - `two_factor_token_wo` (Optional, String, WriteOnly) - Write-only version of `two_factor_token`. Not persisted in state. Terraform 1.11+.
-- `two_factor_token_wo_version` (Optional, Number) - Increment to trigger re-send of `two_factor_token_wo`.
+- `two_factor_token_wo_version` (Optional, Number) - Increment to trigger re-send of `two_factor_token_wo`. Must be set together with `two_factor_token_wo`.
 
 ## Attribute Reference
 

--- a/docs/resources/panel_security.md
+++ b/docs/resources/panel_security.md
@@ -25,7 +25,7 @@ resource "threexui_panel_security" "settings" {
 
 - `two_factor_enable` (Optional, Boolean) - Enable two-factor authentication.
 - `two_factor_token` (Optional, String, Sensitive) - Two-factor authentication token/secret.
-- `two_factor_token_wo` (Optional, String, WriteOnly) - Write-only version of `two_factor_token`. Not persisted in state. Terraform 1.11+.
+- `two_factor_token_wo` (Optional, String, WriteOnly) - Write-only version of `two_factor_token`. Not persisted in state. Terraform 1.11+ / OpenTofu 1.11+.
 - `two_factor_token_wo_version` (Optional, Number) - Increment to trigger re-send of `two_factor_token_wo`. Must be set together with `two_factor_token_wo`.
 
 ## Attribute Reference

--- a/docs/resources/panel_telegram.md
+++ b/docs/resources/panel_telegram.md
@@ -30,7 +30,7 @@ resource "threexui_panel_telegram" "settings" {
 - `tg_bot_enable` (Optional, Boolean) - Enable Telegram bot.
 - `tg_bot_token` (Optional, String, Sensitive) - Telegram bot token.
 - `tg_bot_token_wo` (Optional, String, WriteOnly) - Write-only version of `tg_bot_token`. Not persisted in state. Terraform 1.11+.
-- `tg_bot_token_wo_version` (Optional, Number) - Increment to trigger re-send of `tg_bot_token_wo`.
+- `tg_bot_token_wo_version` (Optional, Number) - Increment to trigger re-send of `tg_bot_token_wo`. Must be set together with `tg_bot_token_wo`.
 - `tg_bot_proxy` (Optional, String) - Proxy for Telegram bot.
 - `tg_bot_api_server` (Optional, String) - Custom Telegram API server URL.
 - `tg_bot_chat_id` (Optional, String) - Telegram chat ID for notifications.

--- a/docs/resources/panel_telegram.md
+++ b/docs/resources/panel_telegram.md
@@ -29,7 +29,7 @@ resource "threexui_panel_telegram" "settings" {
 
 - `tg_bot_enable` (Optional, Boolean) - Enable Telegram bot.
 - `tg_bot_token` (Optional, String, Sensitive) - Telegram bot token.
-- `tg_bot_token_wo` (Optional, String, WriteOnly) - Write-only version of `tg_bot_token`. Not persisted in state. Terraform 1.11+.
+- `tg_bot_token_wo` (Optional, String, WriteOnly) - Write-only version of `tg_bot_token`. Not persisted in state. Terraform 1.11+ / OpenTofu 1.11+.
 - `tg_bot_token_wo_version` (Optional, Number) - Increment to trigger re-send of `tg_bot_token_wo`. Must be set together with `tg_bot_token_wo`.
 - `tg_bot_proxy` (Optional, String) - Proxy for Telegram bot.
 - `tg_bot_api_server` (Optional, String) - Custom Telegram API server URL.

--- a/docs/resources/panel_telegram.md
+++ b/docs/resources/panel_telegram.md
@@ -29,6 +29,8 @@ resource "threexui_panel_telegram" "settings" {
 
 - `tg_bot_enable` (Optional, Boolean) - Enable Telegram bot.
 - `tg_bot_token` (Optional, String, Sensitive) - Telegram bot token.
+- `tg_bot_token_wo` (Optional, String, WriteOnly) - Write-only version of `tg_bot_token`. Not persisted in state. Terraform 1.11+.
+- `tg_bot_token_wo_version` (Optional, Number) - Increment to trigger re-send of `tg_bot_token_wo`.
 - `tg_bot_proxy` (Optional, String) - Proxy for Telegram bot.
 - `tg_bot_api_server` (Optional, String) - Custom Telegram API server URL.
 - `tg_bot_chat_id` (Optional, String) - Telegram chat ID for notifications.

--- a/docs/resources/panel_user.md
+++ b/docs/resources/panel_user.md
@@ -37,7 +37,7 @@ resource "threexui_panel_user" "admin" {
 - `username` (Required, String) - The desired admin username.
 - `password` (Optional, String, Sensitive) - The desired admin password. Prefer `password_wo` on Terraform 1.11+.
 - `password_wo` (Optional, String, WriteOnly) - Write-only version of `password`. Not persisted in state. Terraform 1.11+.
-- `password_wo_version` (Optional, Number) - Increment to trigger re-send of `password_wo`.
+- `password_wo_version` (Optional, Number) - Increment to trigger re-send of `password_wo`. Must be set together with `password_wo`.
 
 ## Attribute Reference
 

--- a/docs/resources/panel_user.md
+++ b/docs/resources/panel_user.md
@@ -22,10 +22,22 @@ resource "threexui_panel_user" "admin" {
 }
 ```
 
+### Write-Only Password (Terraform 1.11+)
+
+```hcl
+resource "threexui_panel_user" "admin" {
+  username            = "myadmin"
+  password_wo         = "s3cureP@ss"
+  password_wo_version = 1
+}
+```
+
 ## Argument Reference
 
 - `username` (Required, String) - The desired admin username.
-- `password` (Required, String, Sensitive) - The desired admin password.
+- `password` (Optional, String, Sensitive) - The desired admin password. Prefer `password_wo` on Terraform 1.11+.
+- `password_wo` (Optional, String, WriteOnly) - Write-only version of `password`. Not persisted in state. Terraform 1.11+.
+- `password_wo_version` (Optional, Number) - Increment to trigger re-send of `password_wo`.
 
 ## Attribute Reference
 

--- a/docs/resources/panel_user.md
+++ b/docs/resources/panel_user.md
@@ -22,7 +22,7 @@ resource "threexui_panel_user" "admin" {
 }
 ```
 
-### Write-Only Password (Terraform 1.11+)
+### Write-Only Password (Terraform 1.11+ / OpenTofu 1.11+)
 
 ```hcl
 resource "threexui_panel_user" "admin" {
@@ -35,8 +35,8 @@ resource "threexui_panel_user" "admin" {
 ## Argument Reference
 
 - `username` (Required, String) - The desired admin username.
-- `password` (Optional, String, Sensitive) - The desired admin password. Prefer `password_wo` on Terraform 1.11+.
-- `password_wo` (Optional, String, WriteOnly) - Write-only version of `password`. Not persisted in state. Terraform 1.11+.
+- `password` (Optional, String, Sensitive) - The desired admin password. Prefer `password_wo` on Terraform 1.11+ / OpenTofu 1.11+.
+- `password_wo` (Optional, String, WriteOnly) - Write-only version of `password`. Not persisted in state. Terraform 1.11+ / OpenTofu 1.11+.
 - `password_wo_version` (Optional, Number) - Increment to trigger re-send of `password_wo`. Must be set together with `password_wo`.
 
 ## Attribute Reference

--- a/provider/acc_panel_settings_test.go
+++ b/provider/acc_panel_settings_test.go
@@ -7,7 +7,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 )
 
 // --- Panel General: page_size, remark_model, time_location, update, idempotency ---
@@ -1102,6 +1104,88 @@ resource "threexui_panel_subscription" "test" {
 				ResourceName:      "threexui_panel_subscription.test",
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccPanelSecurityWriteOnly(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.11.0"))),
+		},
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProviderConfig() + `
+resource "threexui_panel_security" "test" {
+  two_factor_enable           = false
+  two_factor_token_wo         = "test-token-value"
+  two_factor_token_wo_version = 1
+}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("threexui_panel_security.test", "id", "settings"),
+					resource.TestCheckResourceAttr("threexui_panel_security.test", "two_factor_enable", "false"),
+				),
+			},
+			// Restore defaults
+			{
+				Config: testAccProviderConfig() + `
+resource "threexui_panel_security" "test" {
+  two_factor_enable = false
+  two_factor_token  = ""
+}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("threexui_panel_security.test", "id", "settings"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccPanelTelegramWriteOnly(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.11.0"))),
+		},
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProviderConfig() + `
+resource "threexui_panel_telegram" "test" {
+  tg_bot_enable           = false
+  tg_bot_token_wo         = "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11"
+  tg_bot_token_wo_version = 1
+  tg_bot_chat_id          = ""
+  tg_lang                 = "en"
+  tg_run_time             = "@daily"
+  tg_bot_backup           = false
+  tg_bot_login_notify     = true
+  tg_cpu                  = 80
+}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("threexui_panel_telegram.test", "id", "settings"),
+					resource.TestCheckResourceAttr("threexui_panel_telegram.test", "tg_bot_enable", "false"),
+				),
+			},
+			// Restore defaults
+			{
+				Config: testAccProviderConfig() + `
+resource "threexui_panel_telegram" "test" {
+  tg_bot_enable       = false
+  tg_bot_token        = ""
+  tg_bot_chat_id      = ""
+  tg_lang             = "en"
+  tg_run_time         = "@daily"
+  tg_bot_backup       = false
+  tg_bot_login_notify = true
+  tg_cpu              = 80
+}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("threexui_panel_telegram.test", "id", "settings"),
+				),
 			},
 		},
 	})

--- a/provider/acc_panel_settings_test.go
+++ b/provider/acc_panel_settings_test.go
@@ -1127,7 +1127,20 @@ resource "threexui_panel_security" "test" {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("threexui_panel_security.test", "id", "settings"),
 					resource.TestCheckResourceAttr("threexui_panel_security.test", "two_factor_enable", "false"),
+					resource.TestCheckResourceAttr("threexui_panel_security.test", "two_factor_token_wo_version", "1"),
 				),
+			},
+			// Idempotency: re-applying the same _wo config must produce an empty plan.
+			// Verifies that mergeSettingsForUpdate replays the cached secret via
+			// preserveCachedSettingSecrets when expand omits the field.
+			{
+				Config: testAccProviderConfig() + `
+resource "threexui_panel_security" "test" {
+  two_factor_enable           = false
+  two_factor_token_wo         = "test-token-value"
+  two_factor_token_wo_version = 1
+}`,
+				PlanOnly: true,
 			},
 			// Restore defaults
 			{
@@ -1138,6 +1151,75 @@ resource "threexui_panel_security" "test" {
 }`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("threexui_panel_security.test", "id", "settings"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccPanelSecurityWriteOnlyUpdate(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.11.0"))),
+		},
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProviderConfig() + `
+resource "threexui_panel_security" "test" {
+  two_factor_enable           = false
+  two_factor_token_wo         = "token-v1"
+  two_factor_token_wo_version = 1
+}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("threexui_panel_security.test", "two_factor_token_wo_version", "1"),
+				),
+			},
+			{
+				Config: testAccProviderConfig() + `
+resource "threexui_panel_security" "test" {
+  two_factor_enable           = false
+  two_factor_token_wo         = "token-v2"
+  two_factor_token_wo_version = 2
+}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("threexui_panel_security.test", "two_factor_token_wo_version", "2"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccPanelSecurityWriteOnlyMigration verifies switching from the plain
+// attribute to _wo: existing configs that migrate must continue to work.
+func TestAccPanelSecurityWriteOnlyMigration(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.11.0"))),
+		},
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProviderConfig() + `
+resource "threexui_panel_security" "test" {
+  two_factor_enable = false
+  two_factor_token  = "plain-token"
+}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("threexui_panel_security.test", "two_factor_token", "plain-token"),
+				),
+			},
+			{
+				Config: testAccProviderConfig() + `
+resource "threexui_panel_security" "test" {
+  two_factor_enable           = false
+  two_factor_token_wo         = "wo-token"
+  two_factor_token_wo_version = 1
+}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("threexui_panel_security.test", "two_factor_token_wo_version", "1"),
 				),
 			},
 		},
@@ -1168,7 +1250,24 @@ resource "threexui_panel_telegram" "test" {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("threexui_panel_telegram.test", "id", "settings"),
 					resource.TestCheckResourceAttr("threexui_panel_telegram.test", "tg_bot_enable", "false"),
+					resource.TestCheckResourceAttr("threexui_panel_telegram.test", "tg_bot_token_wo_version", "1"),
 				),
+			},
+			// Idempotency: re-applying the same _wo config must produce an empty plan.
+			{
+				Config: testAccProviderConfig() + `
+resource "threexui_panel_telegram" "test" {
+  tg_bot_enable           = false
+  tg_bot_token_wo         = "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11"
+  tg_bot_token_wo_version = 1
+  tg_bot_chat_id          = ""
+  tg_lang                 = "en"
+  tg_run_time             = "@daily"
+  tg_bot_backup           = false
+  tg_bot_login_notify     = true
+  tg_cpu                  = 80
+}`,
+				PlanOnly: true,
 			},
 			// Restore defaults
 			{

--- a/provider/acc_panel_settings_test.go
+++ b/provider/acc_panel_settings_test.go
@@ -1290,6 +1290,49 @@ resource "threexui_panel_telegram" "test" {
 	})
 }
 
+func testAccPanelGeneralConfigWO(password string, version int) string {
+	return fmt.Sprintf(`
+resource "threexui_panel_general" "test" {
+  date_picker                    = "gregorian"
+  expire_diff                    = 0
+  external_traffic_inform_enable = false
+  external_traffic_inform_uri    = ""
+  ldap_auto_create               = false
+  ldap_auto_delete               = false
+  ldap_base_dn                   = "dc=example,dc=com"
+  ldap_bind_dn                   = "cn=admin,dc=example,dc=com"
+  ldap_default_expiry_days       = 0
+  ldap_default_limit_ip          = 0
+  ldap_default_total_gb          = 0
+  ldap_enable                    = true
+  ldap_flag_field                = ""
+  ldap_host                      = "ldap.example.com"
+  ldap_inbound_tags              = ""
+  ldap_invert_flag               = false
+  ldap_password_wo               = %q
+  ldap_password_wo_version       = %d
+  ldap_port                      = 636
+  ldap_sync_cron                 = "@every 1m"
+  ldap_truthy_values             = "true,1,yes,on"
+  ldap_use_tls                   = true
+  ldap_user_attr                 = "mail"
+  ldap_user_filter               = "(objectClass=person)"
+  ldap_vless_field               = "vless_enabled"
+  page_size                      = 25
+  remark_model                   = "-ieo"
+  session_max_age                = 360
+  time_location                  = "Local"
+  traffic_diff                   = 0
+  web_base_path                  = "/"
+  web_cert_file                  = ""
+  web_domain                     = ""
+  web_key_file                   = ""
+  web_listen                     = ""
+  web_port                       = 2053
+  xray_outbound_test_url         = "https://www.google.com/generate_204"
+}`, password, version)
+}
+
 func TestAccPanelGeneralWriteOnly(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -1299,46 +1342,7 @@ func TestAccPanelGeneralWriteOnly(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProviderConfig() + `
-resource "threexui_panel_general" "test" {
-  date_picker                    = "gregorian"
-  expire_diff                    = 0
-  external_traffic_inform_enable = false
-  external_traffic_inform_uri    = ""
-  ldap_auto_create               = false
-  ldap_auto_delete               = false
-  ldap_base_dn                   = "dc=example,dc=com"
-  ldap_bind_dn                   = "cn=admin,dc=example,dc=com"
-  ldap_default_expiry_days       = 0
-  ldap_default_limit_ip          = 0
-  ldap_default_total_gb          = 0
-  ldap_enable                    = true
-  ldap_flag_field                = ""
-  ldap_host                      = "ldap.example.com"
-  ldap_inbound_tags              = ""
-  ldap_invert_flag               = false
-  ldap_password_wo               = "ldappass-wo"
-  ldap_password_wo_version       = 1
-  ldap_port                      = 636
-  ldap_sync_cron                 = "@every 1m"
-  ldap_truthy_values             = "true,1,yes,on"
-  ldap_use_tls                   = true
-  ldap_user_attr                 = "mail"
-  ldap_user_filter               = "(objectClass=person)"
-  ldap_vless_field               = "vless_enabled"
-  page_size                      = 25
-  remark_model                   = "-ieo"
-  session_max_age                = 360
-  time_location                  = "Local"
-  traffic_diff                   = 0
-  web_base_path                  = "/"
-  web_cert_file                  = ""
-  web_domain                     = ""
-  web_key_file                   = ""
-  web_listen                     = ""
-  web_port                       = 2053
-  xray_outbound_test_url         = "https://www.google.com/generate_204"
-}`,
+				Config: testAccProviderConfig() + testAccPanelGeneralConfigWO("ldappass-wo", 1),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("threexui_panel_general.test", "id", "settings"),
 					resource.TestCheckResourceAttr("threexui_panel_general.test", "ldap_enable", "true"),
@@ -1347,46 +1351,7 @@ resource "threexui_panel_general" "test" {
 			},
 			// Idempotency: re-applying the same _wo config must produce an empty plan.
 			{
-				Config: testAccProviderConfig() + `
-resource "threexui_panel_general" "test" {
-  date_picker                    = "gregorian"
-  expire_diff                    = 0
-  external_traffic_inform_enable = false
-  external_traffic_inform_uri    = ""
-  ldap_auto_create               = false
-  ldap_auto_delete               = false
-  ldap_base_dn                   = "dc=example,dc=com"
-  ldap_bind_dn                   = "cn=admin,dc=example,dc=com"
-  ldap_default_expiry_days       = 0
-  ldap_default_limit_ip          = 0
-  ldap_default_total_gb          = 0
-  ldap_enable                    = true
-  ldap_flag_field                = ""
-  ldap_host                      = "ldap.example.com"
-  ldap_inbound_tags              = ""
-  ldap_invert_flag               = false
-  ldap_password_wo               = "ldappass-wo"
-  ldap_password_wo_version       = 1
-  ldap_port                      = 636
-  ldap_sync_cron                 = "@every 1m"
-  ldap_truthy_values             = "true,1,yes,on"
-  ldap_use_tls                   = true
-  ldap_user_attr                 = "mail"
-  ldap_user_filter               = "(objectClass=person)"
-  ldap_vless_field               = "vless_enabled"
-  page_size                      = 25
-  remark_model                   = "-ieo"
-  session_max_age                = 360
-  time_location                  = "Local"
-  traffic_diff                   = 0
-  web_base_path                  = "/"
-  web_cert_file                  = ""
-  web_domain                     = ""
-  web_key_file                   = ""
-  web_listen                     = ""
-  web_port                       = 2053
-  xray_outbound_test_url         = "https://www.google.com/generate_204"
-}`,
+				Config:   testAccProviderConfig() + testAccPanelGeneralConfigWO("ldappass-wo", 1),
 				PlanOnly: true,
 			},
 		},

--- a/provider/acc_panel_settings_test.go
+++ b/provider/acc_panel_settings_test.go
@@ -1289,3 +1289,199 @@ resource "threexui_panel_telegram" "test" {
 		},
 	})
 }
+
+func TestAccPanelGeneralWriteOnly(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.11.0"))),
+		},
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProviderConfig() + `
+resource "threexui_panel_general" "test" {
+  date_picker                    = "gregorian"
+  expire_diff                    = 0
+  external_traffic_inform_enable = false
+  external_traffic_inform_uri    = ""
+  ldap_auto_create               = false
+  ldap_auto_delete               = false
+  ldap_base_dn                   = "dc=example,dc=com"
+  ldap_bind_dn                   = "cn=admin,dc=example,dc=com"
+  ldap_default_expiry_days       = 0
+  ldap_default_limit_ip          = 0
+  ldap_default_total_gb          = 0
+  ldap_enable                    = true
+  ldap_flag_field                = ""
+  ldap_host                      = "ldap.example.com"
+  ldap_inbound_tags              = ""
+  ldap_invert_flag               = false
+  ldap_password_wo               = "ldappass-wo"
+  ldap_password_wo_version       = 1
+  ldap_port                      = 636
+  ldap_sync_cron                 = "@every 1m"
+  ldap_truthy_values             = "true,1,yes,on"
+  ldap_use_tls                   = true
+  ldap_user_attr                 = "mail"
+  ldap_user_filter               = "(objectClass=person)"
+  ldap_vless_field               = "vless_enabled"
+  page_size                      = 25
+  remark_model                   = "-ieo"
+  session_max_age                = 360
+  time_location                  = "Local"
+  traffic_diff                   = 0
+  web_base_path                  = "/"
+  web_cert_file                  = ""
+  web_domain                     = ""
+  web_key_file                   = ""
+  web_listen                     = ""
+  web_port                       = 2053
+  xray_outbound_test_url         = "https://www.google.com/generate_204"
+}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("threexui_panel_general.test", "id", "settings"),
+					resource.TestCheckResourceAttr("threexui_panel_general.test", "ldap_enable", "true"),
+					resource.TestCheckResourceAttr("threexui_panel_general.test", "ldap_password_wo_version", "1"),
+				),
+			},
+			// Idempotency: re-applying the same _wo config must produce an empty plan.
+			{
+				Config: testAccProviderConfig() + `
+resource "threexui_panel_general" "test" {
+  date_picker                    = "gregorian"
+  expire_diff                    = 0
+  external_traffic_inform_enable = false
+  external_traffic_inform_uri    = ""
+  ldap_auto_create               = false
+  ldap_auto_delete               = false
+  ldap_base_dn                   = "dc=example,dc=com"
+  ldap_bind_dn                   = "cn=admin,dc=example,dc=com"
+  ldap_default_expiry_days       = 0
+  ldap_default_limit_ip          = 0
+  ldap_default_total_gb          = 0
+  ldap_enable                    = true
+  ldap_flag_field                = ""
+  ldap_host                      = "ldap.example.com"
+  ldap_inbound_tags              = ""
+  ldap_invert_flag               = false
+  ldap_password_wo               = "ldappass-wo"
+  ldap_password_wo_version       = 1
+  ldap_port                      = 636
+  ldap_sync_cron                 = "@every 1m"
+  ldap_truthy_values             = "true,1,yes,on"
+  ldap_use_tls                   = true
+  ldap_user_attr                 = "mail"
+  ldap_user_filter               = "(objectClass=person)"
+  ldap_vless_field               = "vless_enabled"
+  page_size                      = 25
+  remark_model                   = "-ieo"
+  session_max_age                = 360
+  time_location                  = "Local"
+  traffic_diff                   = 0
+  web_base_path                  = "/"
+  web_cert_file                  = ""
+  web_domain                     = ""
+  web_key_file                   = ""
+  web_listen                     = ""
+  web_port                       = 2053
+  xray_outbound_test_url         = "https://www.google.com/generate_204"
+}`,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccPanelTelegramWriteOnlyUpdate(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.11.0"))),
+		},
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProviderConfig() + `
+resource "threexui_panel_telegram" "test" {
+  tg_bot_enable           = false
+  tg_bot_token_wo         = "111:token-v1"
+  tg_bot_token_wo_version = 1
+  tg_bot_chat_id          = ""
+  tg_lang                 = "en"
+  tg_run_time             = "@daily"
+  tg_bot_backup           = false
+  tg_bot_login_notify     = true
+  tg_cpu                  = 80
+}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("threexui_panel_telegram.test", "tg_bot_token_wo_version", "1"),
+				),
+			},
+			{
+				Config: testAccProviderConfig() + `
+resource "threexui_panel_telegram" "test" {
+  tg_bot_enable           = false
+  tg_bot_token_wo         = "222:token-v2"
+  tg_bot_token_wo_version = 2
+  tg_bot_chat_id          = ""
+  tg_lang                 = "en"
+  tg_run_time             = "@daily"
+  tg_bot_backup           = false
+  tg_bot_login_notify     = true
+  tg_cpu                  = 80
+}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("threexui_panel_telegram.test", "tg_bot_token_wo_version", "2"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccPanelTelegramWriteOnlyMigration verifies switching from the plain
+// tg_bot_token to tg_bot_token_wo.
+func TestAccPanelTelegramWriteOnlyMigration(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.11.0"))),
+		},
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProviderConfig() + `
+resource "threexui_panel_telegram" "test" {
+  tg_bot_enable       = false
+  tg_bot_token        = "plain-token"
+  tg_bot_chat_id      = ""
+  tg_lang             = "en"
+  tg_run_time         = "@daily"
+  tg_bot_backup       = false
+  tg_bot_login_notify = true
+  tg_cpu              = 80
+}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("threexui_panel_telegram.test", "tg_bot_token", "plain-token"),
+				),
+			},
+			{
+				Config: testAccProviderConfig() + `
+resource "threexui_panel_telegram" "test" {
+  tg_bot_enable           = false
+  tg_bot_token_wo         = "wo-token"
+  tg_bot_token_wo_version = 1
+  tg_bot_chat_id          = ""
+  tg_lang                 = "en"
+  tg_run_time             = "@daily"
+  tg_bot_backup           = false
+  tg_bot_login_notify     = true
+  tg_cpu                  = 80
+}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("threexui_panel_telegram.test", "tg_bot_token_wo_version", "1"),
+				),
+			},
+		},
+	})
+}

--- a/provider/acc_panel_user_test.go
+++ b/provider/acc_panel_user_test.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 )
 
 // TestAccPanelUser verifies the resource lifecycle (create, update, idempotency)
@@ -204,6 +206,79 @@ func TestAccPanelUserImport(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"username", "password"},
+			},
+		},
+	})
+}
+
+func TestAccPanelUserWriteOnly(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.11.0"))),
+		},
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			// Create with password_wo
+			{
+				Config: testAccProviderConfig() + `
+resource "threexui_panel_user" "test" {
+  username            = "admin"
+  password_wo         = "admin"
+  password_wo_version = 1
+}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("threexui_panel_user.test", "id", "user"),
+					resource.TestCheckResourceAttr("threexui_panel_user.test", "username", "admin"),
+				),
+			},
+			// Idempotency with write-only
+			{
+				Config: testAccProviderConfig() + `
+resource "threexui_panel_user" "test" {
+  username            = "admin"
+  password_wo         = "admin"
+  password_wo_version = 1
+}`,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+func TestAccPanelUserWriteOnlyUpdate(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.11.0"))),
+		},
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			// Create with password_wo
+			{
+				Config: testAccProviderConfig() + `
+resource "threexui_panel_user" "test" {
+  username            = "admin"
+  password_wo         = "admin"
+  password_wo_version = 1
+}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("threexui_panel_user.test", "id", "user"),
+				),
+			},
+			// Update via version trigger
+			{
+				Config: testAccProviderConfig() + `
+resource "threexui_panel_user" "test" {
+  username            = "admin"
+  password_wo         = "admin"
+  password_wo_version = 2
+}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("threexui_panel_user.test", "id", "user"),
+					resource.TestCheckResourceAttr("threexui_panel_user.test", "password_wo_version", "2"),
+				),
 			},
 		},
 	})

--- a/provider/resource_panel_user.go
+++ b/provider/resource_panel_user.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -76,6 +77,9 @@ func (r *PanelUserResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				PlanModifiers: []planmodifier.Int64{
 					int64planmodifier.UseStateForUnknown(),
 				},
+				Validators: []validator.Int64{
+					int64validator.AlsoRequires(path.MatchRoot("password_wo")),
+				},
 			},
 		},
 	}
@@ -115,6 +119,7 @@ func (r *PanelUserResource) Create(ctx context.Context, req resource.CreateReque
 	newUsername := plan.Username.ValueString()
 	newPassword := resolvePanelUserPassword(plan, config)
 
+	// Create: provider credentials are the only "previous" credentials available.
 	oldUsername := r.client.username
 	oldPassword := r.client.password
 
@@ -158,6 +163,8 @@ func (r *PanelUserResource) Update(ctx context.Context, req resource.UpdateReque
 	newUsername := plan.Username.ValueString()
 	newPassword := resolvePanelUserPasswordUpdate(plan, state, config)
 
+	// Update: prior state credentials; fall back to provider credentials when
+	// state password was nulled (resource was created via password_wo).
 	oldUsername := state.Username.ValueString()
 	oldPassword := state.Password.ValueString()
 	if oldPassword == "" {

--- a/provider/resource_panel_user.go
+++ b/provider/resource_panel_user.go
@@ -3,19 +3,24 @@ package provider
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 var (
-	_ resource.Resource                = &PanelUserResource{}
-	_ resource.ResourceWithConfigure   = &PanelUserResource{}
-	_ resource.ResourceWithImportState = &PanelUserResource{}
+	_ resource.Resource                     = &PanelUserResource{}
+	_ resource.ResourceWithConfigure        = &PanelUserResource{}
+	_ resource.ResourceWithImportState      = &PanelUserResource{}
+	_ resource.ResourceWithConfigValidators = &PanelUserResource{}
 )
 
 type PanelUserResource struct {
@@ -23,9 +28,11 @@ type PanelUserResource struct {
 }
 
 type PanelUserModel struct {
-	ID       types.String `tfsdk:"id"`
-	Username types.String `tfsdk:"username"`
-	Password types.String `tfsdk:"password"`
+	ID                types.String `tfsdk:"id"`
+	Username          types.String `tfsdk:"username"`
+	Password          types.String `tfsdk:"password"`
+	PasswordWO        types.String `tfsdk:"password_wo"`
+	PasswordWOVersion types.Int64  `tfsdk:"password_wo_version"`
 }
 
 func NewPanelUserResource() resource.Resource {
@@ -51,11 +58,32 @@ func (r *PanelUserResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				Description: "The desired admin username.",
 			},
 			"password": schema.StringAttribute{
-				Required:    true,
+				Optional:    true,
 				Sensitive:   true,
 				Description: "The desired admin password.",
+				Validators: []validator.String{
+					stringvalidator.PreferWriteOnlyAttribute(path.MatchRelative().AtParent().AtName("password_wo")),
+				},
+			},
+			"password_wo": schema.StringAttribute{
+				Optional:    true,
+				WriteOnly:   true,
+				Description: "Write-only version of password.",
+			},
+			"password_wo_version": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Increment this to trigger a password update when using password_wo.",
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
+				},
 			},
 		},
+	}
+}
+
+func (r *PanelUserResource) ConfigValidators(_ context.Context) []resource.ConfigValidator {
+	return []resource.ConfigValidator{
+		resourcevalidator.AtLeastOneOf(path.MatchRoot("password"), path.MatchRoot("password_wo")),
 	}
 }
 
@@ -78,10 +106,15 @@ func (r *PanelUserResource) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
-	newUsername := plan.Username.ValueString()
-	newPassword := plan.Password.ValueString()
+	var config PanelUserModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
-	// Use the provider's current credentials as old credentials.
+	newUsername := plan.Username.ValueString()
+	newPassword := resolvePanelUserPassword(plan, config)
+
 	oldUsername := r.client.username
 	oldPassword := r.client.password
 
@@ -93,11 +126,11 @@ func (r *PanelUserResource) Create(ctx context.Context, req resource.CreateReque
 	r.warnCredentialsChanged(&resp.Diagnostics)
 
 	plan.ID = types.StringValue("user")
+	plan.Password = types.StringNull()
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
 func (r *PanelUserResource) Read(_ context.Context, _ resource.ReadRequest, _ *resource.ReadResponse) {
-	// No API to read user credentials; state is preserved as-is.
 }
 
 func (r *PanelUserResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
@@ -113,12 +146,17 @@ func (r *PanelUserResource) Update(ctx context.Context, req resource.UpdateReque
 		return
 	}
 
-	newUsername := plan.Username.ValueString()
-	newPassword := plan.Password.ValueString()
+	var config PanelUserModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
-	// Use the previous state credentials as old credentials.
+	newUsername := plan.Username.ValueString()
+	newPassword := resolvePanelUserPasswordUpdate(plan, state, config)
+
 	oldUsername := state.Username.ValueString()
-	oldPassword := state.Password.ValueString()
+	oldPassword := resolvePanelUserPasswordFromState(state)
 
 	if err := r.client.UpdateUser(ctx, oldUsername, oldPassword, newUsername, newPassword); err != nil {
 		resp.Diagnostics.AddError("Failed to update user", err.Error())
@@ -128,6 +166,7 @@ func (r *PanelUserResource) Update(ctx context.Context, req resource.UpdateReque
 	r.warnCredentialsChanged(&resp.Diagnostics)
 
 	plan.ID = types.StringValue("user")
+	plan.Password = types.StringNull()
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
@@ -147,4 +186,28 @@ func (r *PanelUserResource) warnCredentialsChanged(diags *diag.Diagnostics) {
 
 func (r *PanelUserResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+func resolvePanelUserPassword(plan, config PanelUserModel) string {
+	if !config.PasswordWO.IsNull() {
+		return config.PasswordWO.ValueString()
+	}
+	return plan.Password.ValueString()
+}
+
+func resolvePanelUserPasswordUpdate(plan, state, config PanelUserModel) string {
+	if !config.PasswordWO.IsNull() {
+		return config.PasswordWO.ValueString()
+	}
+	if !plan.Password.IsNull() {
+		return plan.Password.ValueString()
+	}
+	return state.Password.ValueString()
+}
+
+func resolvePanelUserPasswordFromState(state PanelUserModel) string {
+	if !state.Password.IsNull() {
+		return state.Password.ValueString()
+	}
+	return ""
 }

--- a/provider/resource_panel_user.go
+++ b/provider/resource_panel_user.go
@@ -62,7 +62,7 @@ func (r *PanelUserResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				Sensitive:   true,
 				Description: "The desired admin password.",
 				Validators: []validator.String{
-					stringvalidator.PreferWriteOnlyAttribute(path.MatchRelative().AtParent().AtName("password_wo")),
+					stringvalidator.PreferWriteOnlyAttribute(path.MatchRoot("password_wo")),
 				},
 			},
 			"password_wo": schema.StringAttribute{
@@ -126,7 +126,9 @@ func (r *PanelUserResource) Create(ctx context.Context, req resource.CreateReque
 	r.warnCredentialsChanged(&resp.Diagnostics)
 
 	plan.ID = types.StringValue("user")
-	plan.Password = types.StringNull()
+	if !config.PasswordWO.IsNull() {
+		plan.Password = types.StringNull()
+	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
@@ -156,7 +158,7 @@ func (r *PanelUserResource) Update(ctx context.Context, req resource.UpdateReque
 	newPassword := resolvePanelUserPasswordUpdate(plan, state, config)
 
 	oldUsername := state.Username.ValueString()
-	oldPassword := resolvePanelUserPasswordFromState(state)
+	oldPassword := state.Password.ValueString()
 
 	if err := r.client.UpdateUser(ctx, oldUsername, oldPassword, newUsername, newPassword); err != nil {
 		resp.Diagnostics.AddError("Failed to update user", err.Error())
@@ -166,7 +168,9 @@ func (r *PanelUserResource) Update(ctx context.Context, req resource.UpdateReque
 	r.warnCredentialsChanged(&resp.Diagnostics)
 
 	plan.ID = types.StringValue("user")
-	plan.Password = types.StringNull()
+	if !config.PasswordWO.IsNull() {
+		plan.Password = types.StringNull()
+	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
@@ -203,11 +207,4 @@ func resolvePanelUserPasswordUpdate(plan, state, config PanelUserModel) string {
 		return plan.Password.ValueString()
 	}
 	return state.Password.ValueString()
-}
-
-func resolvePanelUserPasswordFromState(state PanelUserModel) string {
-	if !state.Password.IsNull() {
-		return state.Password.ValueString()
-	}
-	return ""
 }

--- a/provider/resource_panel_user.go
+++ b/provider/resource_panel_user.go
@@ -133,6 +133,7 @@ func (r *PanelUserResource) Create(ctx context.Context, req resource.CreateReque
 }
 
 func (r *PanelUserResource) Read(_ context.Context, _ resource.ReadRequest, _ *resource.ReadResponse) {
+	// No API to read user credentials; state is preserved as-is.
 }
 
 func (r *PanelUserResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {

--- a/provider/resource_panel_user.go
+++ b/provider/resource_panel_user.go
@@ -159,6 +159,10 @@ func (r *PanelUserResource) Update(ctx context.Context, req resource.UpdateReque
 
 	oldUsername := state.Username.ValueString()
 	oldPassword := state.Password.ValueString()
+	if oldPassword == "" {
+		oldUsername = r.client.username
+		oldPassword = r.client.password
+	}
 
 	if err := r.client.UpdateUser(ctx, oldUsername, oldPassword, newUsername, newPassword); err != nil {
 		resp.Diagnostics.AddError("Failed to update user", err.Error())

--- a/provider/resource_settings_tabs.go
+++ b/provider/resource_settings_tabs.go
@@ -1311,11 +1311,19 @@ func preserveSettingSecret(observed, configured types.String) types.String {
 	return observed
 }
 
+func preserveWOVersion(observed, configured types.Int64) types.Int64 {
+	if observed.IsNull() || observed.IsUnknown() {
+		return configured
+	}
+	return observed
+}
+
 func preservePanelGeneralSecrets(state, configured *PanelGeneralModel) {
 	if state == nil || configured == nil {
 		return
 	}
 	state.LDAPPassword = preserveSettingSecret(state.LDAPPassword, configured.LDAPPassword)
+	state.LDAPPasswordWOVersion = preserveWOVersion(state.LDAPPasswordWOVersion, configured.LDAPPasswordWOVersion)
 }
 
 func preservePanelSecuritySecrets(state, configured *PanelSecurityModel) {
@@ -1323,6 +1331,7 @@ func preservePanelSecuritySecrets(state, configured *PanelSecurityModel) {
 		return
 	}
 	state.TwoFactorToken = preserveSettingSecret(state.TwoFactorToken, configured.TwoFactorToken)
+	state.TwoFactorTokenWOVersion = preserveWOVersion(state.TwoFactorTokenWOVersion, configured.TwoFactorTokenWOVersion)
 }
 
 func preservePanelTelegramSecrets(state, configured *PanelTelegramModel) {
@@ -1330,6 +1339,7 @@ func preservePanelTelegramSecrets(state, configured *PanelTelegramModel) {
 		return
 	}
 	state.TgBotToken = preserveSettingSecret(state.TgBotToken, configured.TgBotToken)
+	state.TgBotTokenWOVersion = preserveWOVersion(state.TgBotTokenWOVersion, configured.TgBotTokenWOVersion)
 }
 
 // ---------------------------------------------------------------------------

--- a/provider/resource_settings_tabs.go
+++ b/provider/resource_settings_tabs.go
@@ -685,6 +685,8 @@ type PanelGeneralModel struct {
 	LDAPUseTLS                  types.Bool   `tfsdk:"ldap_use_tls"`
 	LDAPBindDN                  types.String `tfsdk:"ldap_bind_dn"`
 	LDAPPassword                types.String `tfsdk:"ldap_password"`
+	LDAPPasswordWO              types.String `tfsdk:"ldap_password_wo"`
+	LDAPPasswordWOVersion       types.Int64  `tfsdk:"ldap_password_wo_version"`
 	LDAPBaseDN                  types.String `tfsdk:"ldap_base_dn"`
 	LDAPUserFilter              types.String `tfsdk:"ldap_user_filter"`
 	LDAPUserAttr                types.String `tfsdk:"ldap_user_attr"`
@@ -810,6 +812,16 @@ func panelGeneralSchema() schema.Schema {
 			"ldap_password": schema.StringAttribute{
 				Optional: true, Computed: true, Sensitive: true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+				Validators: []validator.String{
+					stringvalidator.PreferWriteOnlyAttribute(path.MatchRoot("ldap_password_wo")),
+				},
+			},
+			"ldap_password_wo": schema.StringAttribute{
+				Optional:  true,
+				WriteOnly: true,
+			},
+			"ldap_password_wo_version": schema.Int64Attribute{
+				Optional: true,
 			},
 			"ldap_base_dn": schema.StringAttribute{
 				Optional: true, Computed: true,
@@ -951,7 +963,9 @@ func expandPanelGeneral(m *PanelGeneralModel) map[string]any {
 	if !m.LDAPBindDN.IsNull() && !m.LDAPBindDN.IsUnknown() {
 		payload["ldapBindDN"] = m.LDAPBindDN.ValueString()
 	}
-	if !m.LDAPPassword.IsNull() && !m.LDAPPassword.IsUnknown() {
+	if !m.LDAPPasswordWO.IsNull() && !m.LDAPPasswordWO.IsUnknown() {
+		payload["ldapPassword"] = m.LDAPPasswordWO.ValueString()
+	} else if !m.LDAPPassword.IsNull() && !m.LDAPPassword.IsUnknown() {
 		payload["ldapPassword"] = m.LDAPPassword.ValueString()
 	}
 	if !m.LDAPBaseDN.IsNull() && !m.LDAPBaseDN.IsUnknown() {
@@ -1373,6 +1387,13 @@ func (r *PanelGeneralResource) Create(ctx context.Context, req resource.CreateRe
 		return
 	}
 
+	var config PanelGeneralModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resolveGeneralLDAPPasswordWO(&plan, config)
+
 	r.applyPanelGeneral(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
@@ -1410,6 +1431,19 @@ func (r *PanelGeneralResource) Update(ctx context.Context, req resource.UpdateRe
 		return
 	}
 
+	var priorState PanelGeneralModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &priorState)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var config PanelGeneralModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resolveGeneralLDAPPasswordWOUpdate(&plan, config)
+
 	r.applyPanelGeneral(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
@@ -1435,6 +1469,18 @@ func (r *PanelGeneralResource) ImportState(ctx context.Context, _ resource.Impor
 	}
 	r.client.rememberConfiguredSettingSecrets(expandPanelGeneral(state))
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+}
+
+func resolveGeneralLDAPPasswordWO(plan *PanelGeneralModel, config PanelGeneralModel) {
+	if !config.LDAPPasswordWO.IsNull() {
+		plan.LDAPPassword = config.LDAPPasswordWO
+	}
+}
+
+func resolveGeneralLDAPPasswordWOUpdate(plan *PanelGeneralModel, config PanelGeneralModel) {
+	if !config.LDAPPasswordWO.IsNull() {
+		plan.LDAPPassword = config.LDAPPasswordWO
+	}
 }
 
 func (r *PanelGeneralResource) applyPanelGeneral(ctx context.Context, plan *PanelGeneralModel, diags *diag.Diagnostics) {

--- a/provider/resource_settings_tabs.go
+++ b/provider/resource_settings_tabs.go
@@ -23,11 +23,11 @@ import (
 // ---------------------------------------------------------------------------
 
 type PanelSecurityModel struct {
-	ID                  types.String `tfsdk:"id"`
-	TwoFactorEnable     types.Bool   `tfsdk:"two_factor_enable"`
-	TwoFactorToken      types.String `tfsdk:"two_factor_token"`
-	TwoFactorTokenWO    types.String `tfsdk:"two_factor_token_wo"`
-	TwoFactorTokenWOVer types.Int64  `tfsdk:"two_factor_token_wo_version"`
+	ID                      types.String `tfsdk:"id"`
+	TwoFactorEnable         types.Bool   `tfsdk:"two_factor_enable"`
+	TwoFactorToken          types.String `tfsdk:"two_factor_token"`
+	TwoFactorTokenWO        types.String `tfsdk:"two_factor_token_wo"`
+	TwoFactorTokenWOVersion types.Int64  `tfsdk:"two_factor_token_wo_version"`
 }
 
 func panelSecuritySchema() schema.Schema {
@@ -1442,7 +1442,7 @@ func (r *PanelGeneralResource) Update(ctx context.Context, req resource.UpdateRe
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	resolveGeneralLDAPPasswordWOUpdate(&plan, config)
+	resolveGeneralLDAPPasswordWOUpdate(&plan, priorState, config)
 
 	r.applyPanelGeneral(ctx, &plan, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
@@ -1477,8 +1477,14 @@ func resolveGeneralLDAPPasswordWO(plan *PanelGeneralModel, config PanelGeneralMo
 	}
 }
 
-func resolveGeneralLDAPPasswordWOUpdate(plan *PanelGeneralModel, config PanelGeneralModel) {
-	if !config.LDAPPasswordWO.IsNull() {
+func resolveGeneralLDAPPasswordWOUpdate(plan *PanelGeneralModel, state PanelGeneralModel, config PanelGeneralModel) {
+	if config.LDAPPasswordWO.IsNull() {
+		return
+	}
+	if !plan.LDAPPasswordWOVersion.IsNull() && !state.LDAPPasswordWOVersion.IsNull() &&
+		plan.LDAPPasswordWOVersion.ValueInt64() != state.LDAPPasswordWOVersion.ValueInt64() {
+		plan.LDAPPassword = config.LDAPPasswordWO
+	} else if state.LDAPPasswordWOVersion.IsNull() && !plan.LDAPPasswordWOVersion.IsNull() {
 		plan.LDAPPassword = config.LDAPPasswordWO
 	}
 }
@@ -1653,7 +1659,7 @@ func (r *PanelSecurityResource) Update(ctx context.Context, req resource.UpdateR
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	resolveSecurityTokenWOUpdate(&plan, config)
+	resolveSecurityTokenWOUpdate(&plan, priorState, config)
 
 	r.warnIfTwoFactor(&plan, &resp.Diagnostics)
 
@@ -1693,8 +1699,14 @@ func resolveSecurityTokenWO(plan *PanelSecurityModel, config PanelSecurityModel)
 	}
 }
 
-func resolveSecurityTokenWOUpdate(plan *PanelSecurityModel, config PanelSecurityModel) {
-	if !config.TwoFactorTokenWO.IsNull() {
+func resolveSecurityTokenWOUpdate(plan *PanelSecurityModel, state PanelSecurityModel, config PanelSecurityModel) {
+	if config.TwoFactorTokenWO.IsNull() {
+		return
+	}
+	if !plan.TwoFactorTokenWOVersion.IsNull() && !state.TwoFactorTokenWOVersion.IsNull() &&
+		plan.TwoFactorTokenWOVersion.ValueInt64() != state.TwoFactorTokenWOVersion.ValueInt64() {
+		plan.TwoFactorToken = config.TwoFactorTokenWO
+	} else if state.TwoFactorTokenWOVersion.IsNull() && !plan.TwoFactorTokenWOVersion.IsNull() {
 		plan.TwoFactorToken = config.TwoFactorTokenWO
 	}
 }
@@ -1811,7 +1823,7 @@ func (r *PanelTelegramResource) Update(ctx context.Context, req resource.UpdateR
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	resolveTelegramTokenWOUpdate(&plan, config)
+	resolveTelegramTokenWOUpdate(&plan, priorState, config)
 
 	desired := expandPanelTelegram(&plan)
 	settingsApplyTyped(ctx, desired, &resp.Diagnostics, r.client)
@@ -1835,8 +1847,14 @@ func resolveTelegramTokenWO(plan *PanelTelegramModel, config PanelTelegramModel)
 	}
 }
 
-func resolveTelegramTokenWOUpdate(plan *PanelTelegramModel, config PanelTelegramModel) {
-	if !config.TgBotTokenWO.IsNull() {
+func resolveTelegramTokenWOUpdate(plan *PanelTelegramModel, state PanelTelegramModel, config PanelTelegramModel) {
+	if config.TgBotTokenWO.IsNull() {
+		return
+	}
+	if !plan.TgBotTokenWOVersion.IsNull() && !state.TgBotTokenWOVersion.IsNull() &&
+		plan.TgBotTokenWOVersion.ValueInt64() != state.TgBotTokenWOVersion.ValueInt64() {
+		plan.TgBotToken = config.TgBotTokenWO
+	} else if state.TgBotTokenWOVersion.IsNull() && !plan.TgBotTokenWOVersion.IsNull() {
 		plan.TgBotToken = config.TgBotTokenWO
 	}
 }

--- a/provider/resource_settings_tabs.go
+++ b/provider/resource_settings_tabs.go
@@ -1311,6 +1311,10 @@ func preserveSettingSecret(observed, configured types.String) types.String {
 	return observed
 }
 
+// preserveWOVersion carries the *_wo_version trigger into state during Apply.
+// UseStateForUnknown on the schema handles the Plan phase; this handles Apply,
+// where flatten* (which has no _wo_version field) would otherwise overwrite
+// the planned value with null.
 func preserveWOVersion(observed, configured types.Int64) types.Int64 {
 	if observed.IsNull() || observed.IsUnknown() {
 		return configured

--- a/provider/resource_settings_tabs.go
+++ b/provider/resource_settings_tabs.go
@@ -662,6 +662,59 @@ func flattenPanelSubscription(in map[string]any) *PanelSubscriptionModel {
 	return m
 }
 
+// modifyPlanWOVersion marks the plain secret attribute as Unknown during plan
+// when the *_wo_version trigger changes (or is set for the first time). This
+// tells Terraform to accept a new sensitive value from Apply instead of
+// rejecting it as "inconsistent values for sensitive" — the prior-state value
+// is otherwise carried forward by UseStateForUnknown and blocks the update.
+//
+// On no-op plans (version unchanged, no _wo in config) it does nothing.
+func modifyPlanWOVersion[T any](
+	ctx context.Context,
+	req resource.ModifyPlanRequest,
+	resp *resource.ModifyPlanResponse,
+	woVersion func(T) types.Int64,
+	setPlain func(*T, types.String),
+	plain func(T) types.String,
+) {
+	if req.Plan.Raw.IsNull() {
+		return
+	}
+	if req.State.Raw.IsNull() {
+		return
+	}
+
+	var plan, state T
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !woVersionTriggered(woVersion(plan), woVersion(state)) {
+		return
+	}
+
+	current := plain(plan)
+	if current.IsNull() || current.IsUnknown() {
+		setPlain(&plan, types.StringUnknown())
+	}
+	resp.Diagnostics.Append(resp.Plan.Set(ctx, &plan)...)
+}
+
+// woVersionTriggered reports whether the *_wo_version value represents a
+// change relative to the prior state: the values differ, or the prior state
+// has none while the plan introduces one.
+func woVersionTriggered(plan, state types.Int64) bool {
+	if plan.IsNull() || plan.IsUnknown() {
+		return false
+	}
+	if state.IsNull() || state.IsUnknown() {
+		return true
+	}
+	return plan.ValueInt64() != state.ValueInt64()
+}
+
 // ---------------------------------------------------------------------------
 // Panel General model, schema, expand/flatten
 // ---------------------------------------------------------------------------
@@ -1354,6 +1407,7 @@ var (
 	_ resource.Resource                = &PanelGeneralResource{}
 	_ resource.ResourceWithConfigure   = &PanelGeneralResource{}
 	_ resource.ResourceWithImportState = &PanelGeneralResource{}
+	_ resource.ResourceWithModifyPlan  = &PanelGeneralResource{}
 )
 
 type PanelGeneralResource struct {
@@ -1485,6 +1539,15 @@ func (r *PanelGeneralResource) Delete(ctx context.Context, _ resource.DeleteRequ
 	resp.State.RemoveResource(ctx)
 }
 
+func (r *PanelGeneralResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	modifyPlanWOVersion(
+		ctx, req, resp,
+		func(m PanelGeneralModel) types.Int64 { return m.LDAPPasswordWOVersion },
+		func(m *PanelGeneralModel, v types.String) { m.LDAPPassword = v },
+		func(m PanelGeneralModel) types.String { return m.LDAPPassword },
+	)
+}
+
 func (r *PanelGeneralResource) ImportState(ctx context.Context, _ resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	state := r.readPanelGeneralState(ctx, &resp.Diagnostics)
 	if state == nil {
@@ -1585,6 +1648,7 @@ var (
 	_ resource.Resource                = &PanelSecurityResource{}
 	_ resource.ResourceWithConfigure   = &PanelSecurityResource{}
 	_ resource.ResourceWithImportState = &PanelSecurityResource{}
+	_ resource.ResourceWithModifyPlan  = &PanelSecurityResource{}
 )
 
 type PanelSecurityResource struct {
@@ -1706,6 +1770,15 @@ func (r *PanelSecurityResource) Delete(ctx context.Context, _ resource.DeleteReq
 	resp.State.RemoveResource(ctx)
 }
 
+func (r *PanelSecurityResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	modifyPlanWOVersion(
+		ctx, req, resp,
+		func(m PanelSecurityModel) types.Int64 { return m.TwoFactorTokenWOVersion },
+		func(m *PanelSecurityModel, v types.String) { m.TwoFactorToken = v },
+		func(m PanelSecurityModel) types.String { return m.TwoFactorToken },
+	)
+}
+
 func (r *PanelSecurityResource) ImportState(ctx context.Context, _ resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	settings := settingsReadTyped(ctx, &resp.Diagnostics, r.client)
 	if settings == nil {
@@ -1751,6 +1824,7 @@ var (
 	_ resource.Resource                = &PanelTelegramResource{}
 	_ resource.ResourceWithConfigure   = &PanelTelegramResource{}
 	_ resource.ResourceWithImportState = &PanelTelegramResource{}
+	_ resource.ResourceWithModifyPlan  = &PanelTelegramResource{}
 )
 
 type PanelTelegramResource struct {
@@ -1884,6 +1958,15 @@ func resolveTelegramTokenWOUpdate(plan *PanelTelegramModel, state PanelTelegramM
 
 func (r *PanelTelegramResource) Delete(ctx context.Context, _ resource.DeleteRequest, resp *resource.DeleteResponse) {
 	resp.State.RemoveResource(ctx)
+}
+
+func (r *PanelTelegramResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	modifyPlanWOVersion(
+		ctx, req, resp,
+		func(m PanelTelegramModel) types.Int64 { return m.TgBotTokenWOVersion },
+		func(m *PanelTelegramModel, v types.String) { m.TgBotToken = v },
+		func(m PanelTelegramModel) types.String { return m.TgBotToken },
+	)
 }
 
 func (r *PanelTelegramResource) ImportState(ctx context.Context, _ resource.ImportStateRequest, resp *resource.ImportStateResponse) {

--- a/provider/resource_settings_tabs.go
+++ b/provider/resource_settings_tabs.go
@@ -92,17 +92,19 @@ func flattenPanelSecurity(in map[string]any) *PanelSecurityModel {
 // ---------------------------------------------------------------------------
 
 type PanelTelegramModel struct {
-	ID               types.String `tfsdk:"id"`
-	TgBotEnable      types.Bool   `tfsdk:"tg_bot_enable"`
-	TgBotToken       types.String `tfsdk:"tg_bot_token"`
-	TgBotProxy       types.String `tfsdk:"tg_bot_proxy"`
-	TgBotAPIServer   types.String `tfsdk:"tg_bot_api_server"`
-	TgBotChatID      types.String `tfsdk:"tg_bot_chat_id"`
-	TgLang           types.String `tfsdk:"tg_lang"`
-	TgRunTime        types.String `tfsdk:"tg_run_time"`
-	TgBotBackup      types.Bool   `tfsdk:"tg_bot_backup"`
-	TgBotLoginNotify types.Bool   `tfsdk:"tg_bot_login_notify"`
-	TgCPU            types.Int64  `tfsdk:"tg_cpu"`
+	ID                  types.String `tfsdk:"id"`
+	TgBotEnable         types.Bool   `tfsdk:"tg_bot_enable"`
+	TgBotToken          types.String `tfsdk:"tg_bot_token"`
+	TgBotTokenWO        types.String `tfsdk:"tg_bot_token_wo"`
+	TgBotTokenWOVersion types.Int64  `tfsdk:"tg_bot_token_wo_version"`
+	TgBotProxy          types.String `tfsdk:"tg_bot_proxy"`
+	TgBotAPIServer      types.String `tfsdk:"tg_bot_api_server"`
+	TgBotChatID         types.String `tfsdk:"tg_bot_chat_id"`
+	TgLang              types.String `tfsdk:"tg_lang"`
+	TgRunTime           types.String `tfsdk:"tg_run_time"`
+	TgBotBackup         types.Bool   `tfsdk:"tg_bot_backup"`
+	TgBotLoginNotify    types.Bool   `tfsdk:"tg_bot_login_notify"`
+	TgCPU               types.Int64  `tfsdk:"tg_cpu"`
 }
 
 func panelTelegramSchema() schema.Schema {
@@ -121,6 +123,16 @@ func panelTelegramSchema() schema.Schema {
 			"tg_bot_token": schema.StringAttribute{
 				Optional: true, Computed: true, Sensitive: true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+				Validators: []validator.String{
+					stringvalidator.PreferWriteOnlyAttribute(path.MatchRoot("tg_bot_token_wo")),
+				},
+			},
+			"tg_bot_token_wo": schema.StringAttribute{
+				Optional:  true,
+				WriteOnly: true,
+			},
+			"tg_bot_token_wo_version": schema.Int64Attribute{
+				Optional: true,
 			},
 			"tg_bot_proxy": schema.StringAttribute{
 				Optional: true, Computed: true,
@@ -163,7 +175,9 @@ func expandPanelTelegram(m *PanelTelegramModel) map[string]any {
 	if !m.TgBotEnable.IsNull() && !m.TgBotEnable.IsUnknown() {
 		payload["tgBotEnable"] = m.TgBotEnable.ValueBool()
 	}
-	if !m.TgBotToken.IsNull() && !m.TgBotToken.IsUnknown() {
+	if !m.TgBotTokenWO.IsNull() && !m.TgBotTokenWO.IsUnknown() {
+		payload["tgBotToken"] = m.TgBotTokenWO.ValueString()
+	} else if !m.TgBotToken.IsNull() && !m.TgBotToken.IsUnknown() {
 		payload["tgBotToken"] = m.TgBotToken.ValueString()
 	}
 	if !m.TgBotProxy.IsNull() && !m.TgBotProxy.IsUnknown() {
@@ -1693,6 +1707,13 @@ func (r *PanelTelegramResource) Create(ctx context.Context, req resource.CreateR
 		return
 	}
 
+	var config PanelTelegramModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resolveTelegramTokenWO(&plan, config)
+
 	desired := expandPanelTelegram(&plan)
 	settingsApplyTyped(ctx, desired, &resp.Diagnostics, r.client)
 	if resp.Diagnostics.HasError() {
@@ -1733,6 +1754,19 @@ func (r *PanelTelegramResource) Update(ctx context.Context, req resource.UpdateR
 		return
 	}
 
+	var priorState PanelTelegramModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &priorState)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var config PanelTelegramModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resolveTelegramTokenWOUpdate(&plan, config)
+
 	desired := expandPanelTelegram(&plan)
 	settingsApplyTyped(ctx, desired, &resp.Diagnostics, r.client)
 	if resp.Diagnostics.HasError() {
@@ -1747,6 +1781,18 @@ func (r *PanelTelegramResource) Update(ctx context.Context, req resource.UpdateR
 	preservePanelTelegramSecrets(state, &plan)
 	r.client.rememberConfiguredSettingSecrets(expandPanelTelegram(state))
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+}
+
+func resolveTelegramTokenWO(plan *PanelTelegramModel, config PanelTelegramModel) {
+	if !config.TgBotTokenWO.IsNull() {
+		plan.TgBotToken = config.TgBotTokenWO
+	}
+}
+
+func resolveTelegramTokenWOUpdate(plan *PanelTelegramModel, config PanelTelegramModel) {
+	if !config.TgBotTokenWO.IsNull() {
+		plan.TgBotToken = config.TgBotTokenWO
+	}
 }
 
 func (r *PanelTelegramResource) Delete(ctx context.Context, _ resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/provider/resource_settings_tabs.go
+++ b/provider/resource_settings_tabs.go
@@ -5,13 +5,16 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -20,9 +23,11 @@ import (
 // ---------------------------------------------------------------------------
 
 type PanelSecurityModel struct {
-	ID              types.String `tfsdk:"id"`
-	TwoFactorEnable types.Bool   `tfsdk:"two_factor_enable"`
-	TwoFactorToken  types.String `tfsdk:"two_factor_token"`
+	ID                  types.String `tfsdk:"id"`
+	TwoFactorEnable     types.Bool   `tfsdk:"two_factor_enable"`
+	TwoFactorToken      types.String `tfsdk:"two_factor_token"`
+	TwoFactorTokenWO    types.String `tfsdk:"two_factor_token_wo"`
+	TwoFactorTokenWOVer types.Int64  `tfsdk:"two_factor_token_wo_version"`
 }
 
 func panelSecuritySchema() schema.Schema {
@@ -41,6 +46,16 @@ func panelSecuritySchema() schema.Schema {
 			"two_factor_token": schema.StringAttribute{
 				Optional: true, Computed: true, Sensitive: true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+				Validators: []validator.String{
+					stringvalidator.PreferWriteOnlyAttribute(path.MatchRoot("two_factor_token_wo")),
+				},
+			},
+			"two_factor_token_wo": schema.StringAttribute{
+				Optional:  true,
+				WriteOnly: true,
+			},
+			"two_factor_token_wo_version": schema.Int64Attribute{
+				Optional: true,
 			},
 		},
 	}
@@ -51,7 +66,9 @@ func expandPanelSecurity(m *PanelSecurityModel) map[string]any {
 	if !m.TwoFactorEnable.IsNull() && !m.TwoFactorEnable.IsUnknown() {
 		payload["twoFactorEnable"] = m.TwoFactorEnable.ValueBool()
 	}
-	if !m.TwoFactorToken.IsNull() && !m.TwoFactorToken.IsUnknown() {
+	if !m.TwoFactorTokenWO.IsNull() && !m.TwoFactorTokenWO.IsUnknown() {
+		payload["twoFactorToken"] = m.TwoFactorTokenWO.ValueString()
+	} else if !m.TwoFactorToken.IsNull() && !m.TwoFactorToken.IsUnknown() {
 		payload["twoFactorToken"] = m.TwoFactorToken.ValueString()
 	}
 	return payload
@@ -1516,6 +1533,13 @@ func (r *PanelSecurityResource) Create(ctx context.Context, req resource.CreateR
 		return
 	}
 
+	var config PanelSecurityModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resolveSecurityTokenWO(&plan, config)
+
 	r.warnIfTwoFactor(&plan, &resp.Diagnostics)
 
 	desired := expandPanelSecurity(&plan)
@@ -1558,6 +1582,19 @@ func (r *PanelSecurityResource) Update(ctx context.Context, req resource.UpdateR
 		return
 	}
 
+	var priorState PanelSecurityModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &priorState)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var config PanelSecurityModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resolveSecurityTokenWOUpdate(&plan, config)
+
 	r.warnIfTwoFactor(&plan, &resp.Diagnostics)
 
 	desired := expandPanelSecurity(&plan)
@@ -1588,6 +1625,18 @@ func (r *PanelSecurityResource) ImportState(ctx context.Context, _ resource.Impo
 	state := flattenPanelSecurity(settings)
 	r.client.rememberConfiguredSettingSecrets(expandPanelSecurity(state))
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+}
+
+func resolveSecurityTokenWO(plan *PanelSecurityModel, config PanelSecurityModel) {
+	if !config.TwoFactorTokenWO.IsNull() {
+		plan.TwoFactorToken = config.TwoFactorTokenWO
+	}
+}
+
+func resolveSecurityTokenWOUpdate(plan *PanelSecurityModel, config PanelSecurityModel) {
+	if !config.TwoFactorTokenWO.IsNull() {
+		plan.TwoFactorToken = config.TwoFactorTokenWO
+	}
 }
 
 func (r *PanelSecurityResource) warnIfTwoFactor(plan *PanelSecurityModel, diags *diag.Diagnostics) {

--- a/provider/resource_settings_tabs.go
+++ b/provider/resource_settings_tabs.go
@@ -56,6 +56,9 @@ func panelSecuritySchema() schema.Schema {
 			},
 			"two_factor_token_wo_version": schema.Int64Attribute{
 				Optional: true,
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
+				},
 			},
 		},
 	}
@@ -133,6 +136,9 @@ func panelTelegramSchema() schema.Schema {
 			},
 			"tg_bot_token_wo_version": schema.Int64Attribute{
 				Optional: true,
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
+				},
 			},
 			"tg_bot_proxy": schema.StringAttribute{
 				Optional: true, Computed: true,
@@ -822,6 +828,9 @@ func panelGeneralSchema() schema.Schema {
 			},
 			"ldap_password_wo_version": schema.Int64Attribute{
 				Optional: true,
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
+				},
 			},
 			"ldap_base_dn": schema.StringAttribute{
 				Optional: true, Computed: true,

--- a/provider/resource_settings_tabs.go
+++ b/provider/resource_settings_tabs.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -58,6 +59,9 @@ func panelSecuritySchema() schema.Schema {
 				Optional: true,
 				PlanModifiers: []planmodifier.Int64{
 					int64planmodifier.UseStateForUnknown(),
+				},
+				Validators: []validator.Int64{
+					int64validator.AlsoRequires(path.MatchRoot("two_factor_token_wo")),
 				},
 			},
 		},
@@ -138,6 +142,9 @@ func panelTelegramSchema() schema.Schema {
 				Optional: true,
 				PlanModifiers: []planmodifier.Int64{
 					int64planmodifier.UseStateForUnknown(),
+				},
+				Validators: []validator.Int64{
+					int64validator.AlsoRequires(path.MatchRoot("tg_bot_token_wo")),
 				},
 			},
 			"tg_bot_proxy": schema.StringAttribute{
@@ -880,6 +887,9 @@ func panelGeneralSchema() schema.Schema {
 				PlanModifiers: []planmodifier.Int64{
 					int64planmodifier.UseStateForUnknown(),
 				},
+				Validators: []validator.Int64{
+					int64validator.AlsoRequires(path.MatchRoot("ldap_password_wo")),
+				},
 			},
 			"ldap_base_dn": schema.StringAttribute{
 				Optional: true, Computed: true,
@@ -1562,10 +1572,7 @@ func resolveGeneralLDAPPasswordWOUpdate(plan *PanelGeneralModel, state PanelGene
 	if config.LDAPPasswordWO.IsNull() {
 		return
 	}
-	if !plan.LDAPPasswordWOVersion.IsNull() && !state.LDAPPasswordWOVersion.IsNull() &&
-		plan.LDAPPasswordWOVersion.ValueInt64() != state.LDAPPasswordWOVersion.ValueInt64() {
-		plan.LDAPPassword = config.LDAPPasswordWO
-	} else if state.LDAPPasswordWOVersion.IsNull() && !plan.LDAPPasswordWOVersion.IsNull() {
+	if woVersionTriggered(plan.LDAPPasswordWOVersion, state.LDAPPasswordWOVersion) {
 		plan.LDAPPassword = config.LDAPPasswordWO
 	}
 }
@@ -1793,10 +1800,7 @@ func resolveSecurityTokenWOUpdate(plan *PanelSecurityModel, state PanelSecurityM
 	if config.TwoFactorTokenWO.IsNull() {
 		return
 	}
-	if !plan.TwoFactorTokenWOVersion.IsNull() && !state.TwoFactorTokenWOVersion.IsNull() &&
-		plan.TwoFactorTokenWOVersion.ValueInt64() != state.TwoFactorTokenWOVersion.ValueInt64() {
-		plan.TwoFactorToken = config.TwoFactorTokenWO
-	} else if state.TwoFactorTokenWOVersion.IsNull() && !plan.TwoFactorTokenWOVersion.IsNull() {
+	if woVersionTriggered(plan.TwoFactorTokenWOVersion, state.TwoFactorTokenWOVersion) {
 		plan.TwoFactorToken = config.TwoFactorTokenWO
 	}
 }
@@ -1942,10 +1946,7 @@ func resolveTelegramTokenWOUpdate(plan *PanelTelegramModel, state PanelTelegramM
 	if config.TgBotTokenWO.IsNull() {
 		return
 	}
-	if !plan.TgBotTokenWOVersion.IsNull() && !state.TgBotTokenWOVersion.IsNull() &&
-		plan.TgBotTokenWOVersion.ValueInt64() != state.TgBotTokenWOVersion.ValueInt64() {
-		plan.TgBotToken = config.TgBotTokenWO
-	} else if state.TgBotTokenWOVersion.IsNull() && !plan.TgBotTokenWOVersion.IsNull() {
+	if woVersionTriggered(plan.TgBotTokenWOVersion, state.TgBotTokenWOVersion) {
 		plan.TgBotToken = config.TgBotTokenWO
 	}
 }

--- a/provider/resource_settings_tabs.go
+++ b/provider/resource_settings_tabs.go
@@ -675,7 +675,6 @@ func modifyPlanWOVersion[T any](
 	resp *resource.ModifyPlanResponse,
 	woVersion func(T) types.Int64,
 	setPlain func(*T, types.String),
-	plain func(T) types.String,
 ) {
 	if req.Plan.Raw.IsNull() {
 		return
@@ -695,10 +694,7 @@ func modifyPlanWOVersion[T any](
 		return
 	}
 
-	current := plain(plan)
-	if current.IsNull() || current.IsUnknown() {
-		setPlain(&plan, types.StringUnknown())
-	}
+	setPlain(&plan, types.StringUnknown())
 	resp.Diagnostics.Append(resp.Plan.Set(ctx, &plan)...)
 }
 
@@ -1544,7 +1540,6 @@ func (r *PanelGeneralResource) ModifyPlan(ctx context.Context, req resource.Modi
 		ctx, req, resp,
 		func(m PanelGeneralModel) types.Int64 { return m.LDAPPasswordWOVersion },
 		func(m *PanelGeneralModel, v types.String) { m.LDAPPassword = v },
-		func(m PanelGeneralModel) types.String { return m.LDAPPassword },
 	)
 }
 
@@ -1775,7 +1770,6 @@ func (r *PanelSecurityResource) ModifyPlan(ctx context.Context, req resource.Mod
 		ctx, req, resp,
 		func(m PanelSecurityModel) types.Int64 { return m.TwoFactorTokenWOVersion },
 		func(m *PanelSecurityModel, v types.String) { m.TwoFactorToken = v },
-		func(m PanelSecurityModel) types.String { return m.TwoFactorToken },
 	)
 }
 
@@ -1965,7 +1959,6 @@ func (r *PanelTelegramResource) ModifyPlan(ctx context.Context, req resource.Mod
 		ctx, req, resp,
 		func(m PanelTelegramModel) types.Int64 { return m.TgBotTokenWOVersion },
 		func(m *PanelTelegramModel, v types.String) { m.TgBotToken = v },
-		func(m PanelTelegramModel) types.String { return m.TgBotToken },
 	)
 }
 


### PR DESCRIPTION
## Summary

- Add write-only (`_wo`) attribute alternatives for 4 singleton secrets across panel resources, following the AWS/Azure provider pattern
- Each secret gets a trio: existing `Sensitive` attribute + `WriteOnly` attribute + `_wo_version` trigger
- `PreferWriteOnlyAttribute` validator warns users to migrate on Terraform 1.11+
- Backward compatible — existing configs with `Sensitive` attributes continue to work

Closes #250

## Write-only attributes added

| Resource | Write-only attribute | Version trigger |
|---|---|---|
| `threexui_panel_user` | `password_wo` | `password_wo_version` |
| `threexui_panel_security` | `two_factor_token_wo` | `two_factor_token_wo_version` |
| `threexui_panel_telegram` | `tg_bot_token_wo` | `tg_bot_token_wo_version` |
| `threexui_panel_general` | `ldap_password_wo` | `ldap_password_wo_version` |

## Test plan

- [x] `task pre-commit` — fmt, vet, lint, build all pass
- [x] `task test:unit` — all unit tests pass
- [ ] `task test:acc` — acceptance tests (requires Docker + Terraform 1.11+ for write-only tests)
- [ ] Verify `TestAccPanelUserWriteOnly` creates with `password_wo` and value not in state
- [ ] Verify `TestAccPanelUserWriteOnlyUpdate` updates via version trigger
- [ ] Verify `TestAccPanelSecurityWriteOnly` and `TestAccPanelTelegramWriteOnly`
- [ ] Verify existing tests still pass (no regressions)