### PR TITLE
chore: CI flakiness hardening (#280, #279)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -101,10 +101,18 @@ tasks:
       # этого момента GetCurrentXrayVersion возвращает "Unknown", что роняет
       # тесты вроде XrayVersionDrift ложным ErrXrayVersionUnknown (issue #161).
       #
-      # Пробуем /panel/api/server/status и проверяем xray.state == "running"
-      # (или version != "Unknown"). Этот эндпоинт не ходит во внешние сервисы,
-      # в отличие от getXrayVersion (тот дёргает GitHub API за списком релизов
-      # и упирается в анонимный rate limit на шаренном runner IP — issue #161).
+      # В v3.3.1 process.Start() выставляет state="running" сразу после
+      # cmd.Start(), а версию проставляет refreshVersion() отдельным вызовом
+      # `xray -version` чуть позже — между ними возникает гонка, и проверка
+      # только state="running" пропускает тесты в момент, когда version ещё
+      # "Unknown" (issue #280).
+      #
+      # Пробуем /panel/api/server/status и ждём одновременно:
+      #   - xray.state == "running" И
+      #   - xray.version задана и не "Unknown"
+      # Этот эндпоинт не ходит во внешние сервисы, в отличие от getXrayVersion
+      # (тот дёргает GitHub API за списком релизов и упирается в анонимный
+      # rate limit на шаренном runner IP — issue #161).
       - |
         cookie=$(mktemp)
         trap 'rm -f "$cookie"' EXIT
@@ -122,12 +130,16 @@ tasks:
           fi
           body=$(curl -fsS -b "$cookie" \
             "http://localhost:2053/panel/api/server/status" 2>/dev/null || true)
-          # Успех: success:true и `"xray":{...,"state":"running",...}`.
-          # Якорим state по xray-блоку, а не голым `"state":"running"` —
-          # иначе будущие поля state в других секциях ответа дадут ложно
-          # успешное срабатывание.
+          # Успех: success:true, xray.state == "running" И version задана
+          # и не равна "Unknown". Все три поля якорим по xray-блоку
+          # (`"xray":\{[^}]*...`), а не голыми `"state":"running"`/
+          # `"version":"..."` — иначе поля в других секциях ответа дадут
+          # ложное срабатывание. POSIX-only (без grep -P / PCRE), чтобы
+          # работало и на ubuntu CI, и на macOS локально (issue #280).
           if printf '%s' "$body" | grep -q '"success":true' \
-             && printf '%s' "$body" | grep -Eq '"xray":\{[^}]*"state":"running"'; then
+             && printf '%s' "$body" | grep -Eq '"xray":\{[^}]*"state":"running"' \
+             && printf '%s' "$body" | grep -Eq '"xray":\{[^}]*"version":"[^"]+"' \
+             && ! printf '%s' "$body" | grep -Eq '"xray":\{[^}]*"version":"Unknown"'; then
             echo "xray subsystem ready after ${i}s"
             exit 0
           fi

--- a/provider/acc_data_source_test.go
+++ b/provider/acc_data_source_test.go
@@ -58,6 +58,10 @@ func TestAccDataSourceServerStatus(t *testing.T) {
 }
 
 func TestAccDataSourceXrayVersions(t *testing.T) {
+	testAccPreCheck(t)
+	// Pre-flight: this data source calls the panel's getXrayVersion handler,
+	// which hits api.github.com anonymously. Skip on rate limit (issue #279).
+	testAccSkipOnXrayVersionsRateLimit(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),

--- a/provider/acc_test.go
+++ b/provider/acc_test.go
@@ -36,6 +36,35 @@ func testAccPreCheck(t *testing.T) {
 	}
 }
 
+// skipOnUpstreamRateLimit converts an upstream GitHub API rate-limit error
+// from the 3x-ui panel into a test skip rather than a failure. The panel's
+// getXrayVersion handler hits api.github.com anonymously (no Authorization),
+// so on shared CI runner IPs the 60 req/h budget is quickly exhausted. Rate
+// limiting is an environment issue, not a provider regression (issue #279).
+func skipOnUpstreamRateLimit(t *testing.T, err error) {
+	t.Helper()
+	if err != nil && isUpstreamRateLimitError(err) {
+		t.Skipf("skipping: upstream GitHub API rate limit: %s", err)
+	}
+}
+
+// testAccSkipOnXrayVersionsRateLimit pre-flights the panel's internal GitHub
+// API call before a Terraform-driven test that exercises the
+// threexui_xray_versions data source (or the xray_version resource). Without
+// this, a rate-limited apply would surface as a Terraform plan/apply error
+// and fail the CI run; pre-flighting turns it into a clean skip (issue #279).
+func testAccSkipOnXrayVersionsRateLimit(t *testing.T) {
+	t.Helper()
+	client, err := testAccClientFromEnv()
+	if err != nil {
+		// Let the test itself surface the init error.
+		return
+	}
+	if _, err := client.GetXrayVersions(context.Background()); err != nil {
+		skipOnUpstreamRateLimit(t, err)
+	}
+}
+
 func testAccProviderConfig() string {
 	endpoint := os.Getenv(envEndpoint)
 	basePath := os.Getenv(envBasePath)
@@ -343,6 +372,11 @@ func TestAccInboundClientBasic(t *testing.T) {
 }
 
 func TestAccDataSources(t *testing.T) {
+	testAccPreCheck(t)
+	// Pre-flight: the composite includes threexui_xray_versions, which calls
+	// the panel's getXrayVersion handler (anonymous GitHub API). Skip on rate
+	// limit so a shared runner IP doesn't fail the whole composite (issue #279).
+	testAccSkipOnXrayVersionsRateLimit(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),

--- a/provider/acc_xray_version_test.go
+++ b/provider/acc_xray_version_test.go
@@ -22,6 +22,7 @@ func TestAccXrayVersion(t *testing.T) {
 	// Verify GetCurrentXrayVersion returns a v-prefixed string.
 	currentVersion, err := client.GetCurrentXrayVersion(ctx)
 	if err != nil {
+		skipOnUpstreamRateLimit(t, err)
 		t.Fatalf("GetCurrentXrayVersion: %s", err)
 	}
 	if currentVersion == "" {
@@ -35,6 +36,7 @@ func TestAccXrayVersion(t *testing.T) {
 	// Verify GetXrayVersions returns a non-empty list with v-prefixed versions.
 	versions, err := client.GetXrayVersions(ctx)
 	if err != nil {
+		skipOnUpstreamRateLimit(t, err)
 		t.Fatalf("GetXrayVersions: %s", err)
 	}
 	if len(versions) == 0 {
@@ -59,6 +61,7 @@ func TestAccXrayVersionResource(t *testing.T) {
 
 	currentVersion, err := client.GetCurrentXrayVersion(ctx)
 	if err != nil {
+		skipOnUpstreamRateLimit(t, err)
 		t.Fatalf("GetCurrentXrayVersion: %s", err)
 	}
 
@@ -126,6 +129,7 @@ func TestAccXrayVersionDrift(t *testing.T) {
 	// Get available versions; we need at least two distinct ones.
 	versions, err := client.GetXrayVersions(ctx)
 	if err != nil {
+		skipOnUpstreamRateLimit(t, err)
 		t.Fatalf("GetXrayVersions: %s", err)
 	}
 

--- a/provider/acc_xray_version_test.go
+++ b/provider/acc_xray_version_test.go
@@ -11,6 +11,47 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
+// waitForXrayVersion polls GetCurrentXrayVersion until it returns a real
+// version (not "Unknown"), retrying on ErrXrayVersionUnknown. Covers two
+// races that surface as "xray version is unknown":
+//
+//   - cold start: the _wait-for-xray Taskfile gate (issue #280) now waits
+//     for xray.version != "Unknown" before tests run, so this rarely fires
+//     on start.
+//   - mid-test restart: on slow CI runners (PostgreSQL + v3.3.1) xray can
+//     crash/restart between the start gate and the test's first version
+//     probe — e.g. ~2.5 min after "ready" in the failing PostgreSQL run on
+//     PR #281 — briefly reporting version="Unknown" again. A single
+//     GetCurrentXrayVersion call hits this window and fails the whole test.
+//
+// Budget mirrors the previous inline loop in TestAccXrayVersionDrift
+// (90 attempts × 1s). Non-Unknown errors are fatal after a rate-limit skip.
+func waitForXrayVersion(t *testing.T, ctx context.Context, client *Client) string {
+	t.Helper()
+	const maxAttempts = 90
+	var (
+		version string
+		err     error
+	)
+	for i := 0; i < maxAttempts; i++ {
+		version, err = client.GetCurrentXrayVersion(ctx)
+		if err == nil {
+			return version
+		}
+		if !errors.Is(err, ErrXrayVersionUnknown) {
+			skipOnUpstreamRateLimit(t, err)
+			t.Fatalf("GetCurrentXrayVersion: %s", err)
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatalf("GetCurrentXrayVersion: context cancelled: %s", ctx.Err())
+		case <-time.After(time.Second):
+		}
+	}
+	t.Fatalf("GetCurrentXrayVersion: xray not running after %ds: %s", maxAttempts, err)
+	return ""
+}
+
 func TestAccXrayVersion(t *testing.T) {
 	testAccPreCheck(t)
 	client, err := testAccClientFromEnv()
@@ -20,11 +61,7 @@ func TestAccXrayVersion(t *testing.T) {
 	ctx := context.Background()
 
 	// Verify GetCurrentXrayVersion returns a v-prefixed string.
-	currentVersion, err := client.GetCurrentXrayVersion(ctx)
-	if err != nil {
-		skipOnUpstreamRateLimit(t, err)
-		t.Fatalf("GetCurrentXrayVersion: %s", err)
-	}
+	currentVersion := waitForXrayVersion(t, ctx, client)
 	if currentVersion == "" {
 		t.Fatal("GetCurrentXrayVersion returned empty string")
 	}
@@ -59,11 +96,7 @@ func TestAccXrayVersionResource(t *testing.T) {
 	}
 	ctx := context.Background()
 
-	currentVersion, err := client.GetCurrentXrayVersion(ctx)
-	if err != nil {
-		skipOnUpstreamRateLimit(t, err)
-		t.Fatalf("GetCurrentXrayVersion: %s", err)
-	}
+	currentVersion := waitForXrayVersion(t, ctx, client)
 
 	// Pre-flight: try installing the current version. If it fails
 	// (e.g. Docker can't reach GitHub), skip the test.
@@ -134,26 +167,10 @@ func TestAccXrayVersionDrift(t *testing.T) {
 	}
 
 	// GetCurrentXrayVersion may return ErrXrayVersionUnknown if xray is
-	// restarting after a previous test's InstallXray. Retry with the same
-	// budget as waitForXrayVersion (90s) to accommodate slow CI runners.
-	var currentVersion string
-	for i := 0; i < 90; i++ {
-		currentVersion, err = client.GetCurrentXrayVersion(ctx)
-		if err == nil {
-			break
-		}
-		if !errors.Is(err, ErrXrayVersionUnknown) {
-			t.Fatalf("GetCurrentXrayVersion: %s", err)
-		}
-		select {
-		case <-ctx.Done():
-			t.Fatalf("GetCurrentXrayVersion: context cancelled: %s", ctx.Err())
-		case <-time.After(time.Second):
-		}
-	}
-	if err != nil {
-		t.Fatalf("GetCurrentXrayVersion: xray not running after 90s: %s", err)
-	}
+	// restarting after a previous test's InstallXray or due to a mid-test
+	// restart on slow CI runners. waitForXrayVersion retries with a 90s
+	// budget (issue #280).
+	currentVersion := waitForXrayVersion(t, ctx, client)
 
 	// Find an alternative version different from the current one.
 	var altVersion string


### PR DESCRIPTION
## Summary

Closes the **CI flakiness hardening** milestone — two independent fixes for acc-test flakiness surfaced by PR #278 (`feat: add 3x-ui v3.3.1`).

- Closes #280
- Closes #279

---

### #280 — `fix(ci): wait for xray.version != "Unknown" in _wait-for-xray`

**Root cause:** in 3x-ui v3.3.1, `process.Start()` sets `state="running"` immediately after `cmd.Start()`, but the version is populated separately by `refreshVersion()` (an `xray -version` exec) a moment later. `Taskfile.yml → _wait-for-xray` only checked `xray.state == "running"`, so the gate opened while `version` was still `"Unknown"` → acc-tests hit `ErrXrayVersionUnknown` and CI went red on `Compat (v3.3.1)`.

**Fix:** the gate now requires **all three** to be true simultaneously:
- `"success":true`
- `xray.state == "running"`
- `xray.version` is set and `!= "Unknown"`

POSIX-only grep (no `-P` / PCRE negative lookahead) so it works on both ubuntu CI runners and macOS local dev. Anchored to the `"xray":{...}` block to avoid stray `"state":"running"` fields in other sections giving a false positive.

**Backward compat:** verified `Xray{State, Version}` exists in `web/service/server.go` across v3.1.0, v3.2.0, v3.3.0, v3.3.1 — older versions never report `"Unknown"` for a running xray-core, so the stricter gate is safe.

The grep logic was validated against 9 cases (race, ready, stopped, stray-state, empty-version, success:false, realistic payload, field-order variation).

### #279 — `test: skip acc-tests on upstream GitHub API rate limit`

**Root cause:** upstream 3x-ui `GetXrayVersions` (`internal/web/service/server.go`) calls `https://api.github.com/repos/XTLS/Xray-core/releases` **anonymously** (no `Authorization`). `GITHUB_TOKEN` never reaches the container because 3x-ui doesn't read it. Anonymous budget = 60 req/h per IP; shared GitHub-hosted runners burn through it fast. The provider client retries 4x (`versionRetryAttempts`) then surfaces the error; acc-tests did `t.Fatalf` → red CI on an infra limit, not a regression.

**Fix:** convert rate-limit failures into `t.Skipf` (clean skip, not a false fail). Two helpers in `provider/acc_test.go`:

| Helper | Use case |
| --- | --- |
| `skipOnUpstreamRateLimit(t, err)` | Direct client API calls — drop-in before `t.Fatalf` |
| `testAccSkipOnXrayVersionsRateLimit(t)` | Pre-flight for Terraform-driven tests (data sources/resources) before `resource.Test` runs, so a rate-limited apply surfaces as a skip rather than a plan/apply error |

Applied in 5 acc-tests: `TestAccXrayVersion`, `TestAccXrayVersionResource`, `TestAccXrayVersionDrift`, `TestAccDataSourceXrayVersions`, `TestAccDataSources`.

Real regressions in `GetXrayVersions` are still caught — on a fresh IP / re-trigger the test runs normally.

---

## Files changed

| File | Change |
| --- | --- |
| `Taskfile.yml` | +21/-9 — `_wait-for-xray` gate + comments |
| `provider/acc_test.go` | +34 — 2 helpers + pre-flight in `TestAccDataSources` |
| `provider/acc_xray_version_test.go` | +4 — skip on rate limit (4 sites) |
| `provider/acc_data_source_test.go` | +4 — pre-flight in `TestAccDataSourceXrayVersions` |

## Checklist

- [x] `gofmt` — clean
- [x] `go vet ./...` — clean
- [x] `golangci-lint run` — 0 issues
- [x] `go build` — OK
- [x] `task test:unit` — PASS
- [x] pre-commit hooks pass (fmt/vet/lint/build/markdownlint)
- [x] `_wait-for-xray` grep logic validated on 9 cases

## Not tested locally

- `task test:acc` — requires Docker with a 3x-ui container. The real validation will come from this PR's CI matrix (v3.1.x / v3.2.x / v3.3.x).

## Risks

- The stricter `_wait-for-xray` gate could hit the 30s timeout if a version is slow to populate, but per the #280 analysis `version` is never `"Unknown"` on a healthy running xray across all supported versions.
- The pre-flight in `testAccSkipOnXrayVersionsRateLimit` makes one extra panel call in 2 tests; it hits the warmed cache (`_warm-xray-version-cache` runs first), not GitHub directly.