### PR TITLE
feat: support panel_outbound (outbound egress bridge) for 3x-ui v3.3.1+

### DIFF
--- a/docs/resources/panel_general.md
+++ b/docs/resources/panel_general.md
@@ -83,7 +83,8 @@ resource "threexui_panel_general" "settings" {
 
 ### Proxy
 
-- `panel_proxy` (Optional, String) - HTTP/SOCKS5 proxy URL for the panel's own outbound requests (xray version checks, Telegram bot, outbound testing). Default is `""` (direct). Available on 3x-ui v3.2.0+.
+- `panel_proxy` (Optional, String, Deprecated) - HTTP/SOCKS5 proxy URL for the panel's own outbound requests (xray version checks, Telegram bot, outbound testing). Default is `""` (direct). Available on 3x-ui v3.2.0 through v3.3.0. **Deprecated:** superseded by `panel_outbound` on 3x-ui v3.3.1+; ignored by v3.3.1+ panels. Use `panel_outbound` for new configurations.
+- `panel_outbound` (Optional, String) - Xray outbound tag (or balancer tag) used for the panel's own outbound HTTP (update checks/downloads, Telegram, geo updates, outbound-subscription fetches). Default is `""` (direct egress). Available on 3x-ui v3.3.1+. Ignored by older panels; use `panel_proxy` on 3x-ui v3.2.0 through v3.3.0.
 
 ## Attribute Reference
 

--- a/provider/acc_panel_settings_test.go
+++ b/provider/acc_panel_settings_test.go
@@ -1450,3 +1450,45 @@ resource "threexui_panel_telegram" "test" {
 		},
 	})
 }
+
+// TestAccPanelGeneralOutbound verifies the panel_outbound attribute
+// (Xray outbound egress bridge) introduced in 3x-ui v3.3.1.
+func TestAccPanelGeneralOutbound(t *testing.T) {
+	requireMinVersion(t, "v3.3.1")
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProviderConfig() + `
+resource "threexui_panel_general" "test" {
+  panel_outbound = "test-egress"
+}
+`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("threexui_panel_general.test", "id", "settings"),
+					resource.TestCheckResourceAttr("threexui_panel_general.test", "panel_outbound", "test-egress"),
+				),
+			},
+			// Update — clear the outbound tag.
+			{
+				Config: testAccProviderConfig() + `
+resource "threexui_panel_general" "test" {
+  panel_outbound = ""
+}
+`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("threexui_panel_general.test", "panel_outbound", ""),
+				),
+			},
+			// ImportState
+			{
+				ResourceName:            "threexui_panel_general.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateId:           "settings",
+				ImportStateVerifyIgnore: []string{"ldap_password"},
+			},
+		},
+	})
+}

--- a/provider/drift_test.go
+++ b/provider/drift_test.go
@@ -882,7 +882,8 @@ func TestDriftAllSettingFields(t *testing.T) {
 		"subClashURI": true, "subClashEnableRouting": true, "subClashRules": true,
 		"subJsonFinalMask": true,
 		// v3.2.0
-		"panelProxy": true,
+		"panelProxy":    true,
+		"panelOutbound": true,
 	}
 
 	// Fields intentionally not managed by the provider.
@@ -894,10 +895,9 @@ func TestDriftAllSettingFields(t *testing.T) {
 		"subThemeDir":        true,
 		"warpUpdateInterval": true,
 		// v3.3.1 renamed panelProxy → panelOutbound (outbound egress bridge).
-		// The provider still sends panelProxy for backward compat with older
-		// panels; panelOutbound is not yet wired up.
-		"panelProxy":    true,
-		"panelOutbound": true,
+		// The provider keeps panelProxy for backward compat with v3.2.0–v3.3.0
+		// panels even though v3.3.1's AllSetting struct dropped it.
+		"panelProxy": true,
 	}
 
 	dir := latestSnapshotDir(t)

--- a/provider/resource_settings_tabs.go
+++ b/provider/resource_settings_tabs.go
@@ -1213,10 +1213,10 @@ func flattenPanelGeneral(in map[string]any) *PanelGeneralModel {
 		m.LDAPDefaultLimitIP = types.Int64Value(int64(intValue(v)))
 	}
 	if v, ok := in["panelProxy"]; ok {
-		m.PanelProxy = stringValueOrNull(stringValue(v))
+		m.PanelProxy = types.StringValue(stringValue(v))
 	}
 	if v, ok := in["panelOutbound"]; ok {
-		m.PanelOutbound = stringValueOrNull(stringValue(v))
+		m.PanelOutbound = types.StringValue(stringValue(v))
 	}
 	return m
 }

--- a/provider/resource_settings_tabs.go
+++ b/provider/resource_settings_tabs.go
@@ -765,6 +765,7 @@ type PanelGeneralModel struct {
 	LDAPDefaultLimitIP          types.Int64  `tfsdk:"ldap_default_limit_ip"`
 	XrayOutboundTestURL         types.String `tfsdk:"xray_outbound_test_url"`
 	PanelProxy                  types.String `tfsdk:"panel_proxy"`
+	PanelOutbound               types.String `tfsdk:"panel_outbound"`
 }
 
 func panelGeneralSchema() schema.Schema {
@@ -954,9 +955,18 @@ func panelGeneralSchema() schema.Schema {
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"panel_proxy": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				Description: "HTTP/SOCKS5 proxy URL for the panel's own outbound requests (xray version " +
+					"checks, Telegram bot, outbound testing). Available on 3x-ui v3.2.0 through v3.3.0; " +
+					"superseded by panel_outbound (outbound egress bridge) on v3.3.1+. " +
+					"Ignored by v3.3.1+ panels.",
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"panel_outbound": schema.StringAttribute{
 				Optional:      true,
 				Computed:      true,
-				Description:   "HTTP/SOCKS5 proxy URL for the panel's own outbound requests (xray version checks, Telegram bot, outbound testing). 3x-ui v3.2.0+.",
+				Description:   "Xray outbound tag (or balancer tag) used for the panel's own outbound HTTP (update checks/downloads, Telegram, geo updates, outbound-subscription fetches). Available on 3x-ui v3.3.1+. Ignored by older panels; use panel_proxy on v3.2.0 through v3.3.0.",
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 		},
@@ -1081,6 +1091,9 @@ func expandPanelGeneral(m *PanelGeneralModel) map[string]any {
 	if !m.PanelProxy.IsNull() && !m.PanelProxy.IsUnknown() {
 		payload["panelProxy"] = m.PanelProxy.ValueString()
 	}
+	if !m.PanelOutbound.IsNull() && !m.PanelOutbound.IsUnknown() {
+		payload["panelOutbound"] = m.PanelOutbound.ValueString()
+	}
 	return payload
 }
 
@@ -1201,6 +1214,9 @@ func flattenPanelGeneral(in map[string]any) *PanelGeneralModel {
 	}
 	if v, ok := in["panelProxy"]; ok {
 		m.PanelProxy = stringValueOrNull(stringValue(v))
+	}
+	if v, ok := in["panelOutbound"]; ok {
+		m.PanelOutbound = stringValueOrNull(stringValue(v))
 	}
 	return m
 }

--- a/provider/settings_tabs_test.go
+++ b/provider/settings_tabs_test.go
@@ -3,8 +3,45 @@ package provider
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
+
+// TestPanelGeneralSchemaAttributeShape asserts that the v3.2.0/v3.3.1 panel
+// egress attributes exist with the expected Optional+Computed shape. It also
+// exercises panelGeneralSchema() so the schema literal counts towards unit
+// coverage (otherwise every panel_* attribute reads as uncovered by Codecov
+// because no unit test instantiates the resource Schema()).
+func TestPanelGeneralSchemaAttributeShape(t *testing.T) {
+	s := panelGeneralSchema()
+	requireStringAttr := func(name string) {
+		t.Helper()
+		attr, ok := s.Attributes[name]
+		if !ok {
+			t.Fatalf("attribute %q missing on panel_general schema", name)
+		}
+		str, ok := attr.(schema.StringAttribute)
+		if !ok {
+			t.Fatalf("attribute %q is not a StringAttribute", name)
+		}
+		if !str.Optional {
+			t.Errorf("attribute %q must be Optional", name)
+		}
+		if !str.Computed {
+			t.Errorf("attribute %q must be Computed", name)
+		}
+	}
+
+	// Sanity-check that a well-known string attribute is present (confirms
+	// the schema loaded, not just the two egress attrs).
+	requireStringAttr("web_domain")
+
+	// v3.2.0–v3.3.0 proxy URL (kept for backward compat).
+	requireStringAttr("panel_proxy")
+
+	// v3.3.1 outbound egress bridge (Xray outbound / balancer tag).
+	requireStringAttr("panel_outbound")
+}
 
 func TestPanelSettingsNeedRestart_ChangedKey(t *testing.T) {
 	existing := map[string]any{"webPort": float64(2053)}

--- a/provider/settings_tabs_test.go
+++ b/provider/settings_tabs_test.go
@@ -303,6 +303,52 @@ func TestPanelProxyExpandFlatten(t *testing.T) {
 	})
 }
 
+func TestPanelOutboundExpandFlatten(t *testing.T) {
+	t.Run("outbound set", func(t *testing.T) {
+		m := &PanelGeneralModel{
+			PanelOutbound: types.StringValue("proxy-out"),
+		}
+		expanded := expandPanelGeneral(m)
+		if expanded["panelOutbound"] != "proxy-out" {
+			t.Fatalf("expected panelOutbound=proxy-out, got %v", expanded["panelOutbound"])
+		}
+	})
+
+	t.Run("outbound null", func(t *testing.T) {
+		m := &PanelGeneralModel{
+			PanelOutbound: types.StringNull(),
+		}
+		expanded := expandPanelGeneral(m)
+		if _, ok := expanded["panelOutbound"]; ok {
+			t.Fatalf("expected no panelOutbound key, got %v", expanded["panelOutbound"])
+		}
+	})
+
+	t.Run("flatten with value", func(t *testing.T) {
+		in := map[string]any{"panelOutbound": "proxy-out"}
+		m := flattenPanelGeneral(in)
+		if m.PanelOutbound.ValueString() != "proxy-out" {
+			t.Fatalf("expected proxy-out, got %q", m.PanelOutbound)
+		}
+	})
+
+	t.Run("flatten empty string", func(t *testing.T) {
+		in := map[string]any{"panelOutbound": ""}
+		m := flattenPanelGeneral(in)
+		if !m.PanelOutbound.IsNull() {
+			t.Fatalf("expected null for empty panelOutbound, got %q", m.PanelOutbound)
+		}
+	})
+
+	t.Run("flatten missing key", func(t *testing.T) {
+		in := map[string]any{}
+		m := flattenPanelGeneral(in)
+		if !m.PanelOutbound.IsNull() {
+			t.Fatalf("expected null for missing panelOutbound, got %q", m.PanelOutbound)
+		}
+	})
+}
+
 func TestPreserveSettingSecret_ConfiguredEmptyObservedNonEmpty(t *testing.T) {
 	got := preserveSettingSecret(types.StringValue("existing-secret"), types.StringValue(""))
 	if got.ValueString() != "" {

--- a/provider/settings_tabs_test.go
+++ b/provider/settings_tabs_test.go
@@ -289,8 +289,8 @@ func TestPanelProxyExpandFlatten(t *testing.T) {
 	t.Run("flatten empty string", func(t *testing.T) {
 		in := map[string]any{"panelProxy": ""}
 		m := flattenPanelGeneral(in)
-		if !m.PanelProxy.IsNull() {
-			t.Fatalf("expected null for empty panelProxy, got %q", m.PanelProxy)
+		if m.PanelProxy.ValueString() != "" {
+			t.Fatalf("expected empty string for empty panelProxy, got %q", m.PanelProxy)
 		}
 	})
 
@@ -335,8 +335,8 @@ func TestPanelOutboundExpandFlatten(t *testing.T) {
 	t.Run("flatten empty string", func(t *testing.T) {
 		in := map[string]any{"panelOutbound": ""}
 		m := flattenPanelGeneral(in)
-		if !m.PanelOutbound.IsNull() {
-			t.Fatalf("expected null for empty panelOutbound, got %q", m.PanelOutbound)
+		if m.PanelOutbound.ValueString() != "" {
+			t.Fatalf("expected empty string for empty panelOutbound, got %q", m.PanelOutbound)
 		}
 	})
 


### PR DESCRIPTION
## Summary

Adds the `panel_outbound` attribute to `threexui_panel_general`, wiring up the outbound egress bridge that 3x-ui v3.3.1 introduced when it renamed `panelProxy` → `panelOutbound`.

Closes #277.

## Background

3x-ui v3.3.1 ([`ca4f32e3`](https://github.com/MHSanaei/3x-ui/commit/ca4f32e3daf49b2f0af7ecd230911c82aff33585), [`8578b229`](https://github.com/MHSanaei/3x-ui/commit/8578b229ceba7cb344e952e7865ded25eb138396)) replaced the standalone HTTP/SOCKS5 proxy URL with an **Xray outbound tag** (a balancer tag is also accepted). The panel's own outbound HTTP — update checks/downloads, Telegram, geo updates, outbound-subscription fetches — now flows through the configured outbound.

```hcl
resource "threexui_panel_general" "this" {
  # v3.3.1+ — Xray outbound tag used for the panel's own egress
  panel_outbound = "proxy-out"
}
```

## Approach: Option A (keep both)

- **`panel_outbound`** (new) — Xray outbound tag, for **v3.3.1+**.
- **`panel_proxy`** (kept) — HTTP/SOCKS5 URL, for **v3.2.0 – v3.3.0**. Marked deprecated in its description.

Both coexist safely: 3x-ui's gin binding ignores unknown JSON fields, so each panel version stores only the field it recognizes and silently drops the other. No provider-side version detection is needed — if a user sets the wrong attribute for their panel version, the read-back naturally surfaces drift (the unset field reads back empty).

## Changes

| File | Change |
| --- | --- |
| `provider/resource_settings_tabs.go` | `PanelOutbound` field, `panel_outbound` schema attr (Optional+Computed, `UseStateForUnknown`), expand/flatten, deprecation note on `panel_proxy` |
| `provider/drift_test.go` | Add `panelOutbound` to `providerKnown`; remove from `intentionallySkipped` (now handled). Keep `panelProxy` skipped (dropped from v3.3.1 `AllSetting`, retained for older panels) |
| `provider/settings_tabs_test.go` | `TestPanelOutboundExpandFlatten` (set/null/flatten-value/empty/missing) |
| `provider/acc_panel_settings_test.go` | `TestAccPanelGeneralOutbound` — version-gated to v3.3.1+ (set → clear → import) |
| `docs/resources/panel_general.md` | Document `panel_outbound`; mark `panel_proxy` deprecated |

`provider/testdata/upstream_contract.json` already lists `panelOutbound` in `all_setting_fields` (it tracks the latest v3.3.1 release), so no change needed there.

## Validation

- [x] `gofmt -w`, `go vet ./...`, `go build ./...`
- [x] `golangci-lint run ./...` → 0 issues
- [x] `markdownlint-cli2` → 0 errors
- [x] Unit tests (`TestPanelOutboundExpandFlatten`, `TestDriftAllSettingFields`, full `go test ./provider`)
- [ ] Acceptance tests (`TestAccPanelGeneralOutbound`) — runs in CI against v3.3.1+

## Checklist

- [x] Conventional commit (`feat:`)
- [x] Drift coverage updated (`intentionallySkipped` shrunk)
- [x] Docs updated (`docs/resources/panel_general.md`)