### PR TITLE
docs: focus Context7 index & document panel_outbound/panel_proxy split

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,6 +183,7 @@ These are non-obvious constraints that have caused real bugs.
 | DNS servers: string vs object | Address-only → string; with extra fields → object |
 | `xray_version` delete is a no-op | Removing from state does NOT revert the installed xray version |
 | `web_base_path` change triggers panel restart | Must also update provider `base_path`; code auto-updates client |
+| `panel_outbound` vs `panel_proxy` is version-specific | 3x-ui v3.3.1 renamed `panelProxy`→`panelOutbound` and changed semantics: `panel_outbound` takes an Xray outbound/balancer tag; `panel_proxy` (HTTP/SOCKS5 URL) is kept for v3.2.0–v3.3.0 and is `Deprecated`. Both coexist safely — gin ignores the unknown field per version |
 | Write-only attrs quirks | See "Write-only secret attributes" section above — read `_wo` from `req.Config`; ModifyPlan marks plain `Unknown` on version change; `panel_user` nulls state password instead |
 | xray-settings acc-tests restart xray-core | `TestAccXrayBasics`/`DNS`/`Routing`/`Balancers`/`Reverse`/`Outbounds` each apply a new config = xray restart; `version` becomes `"Unknown"` for ~30-90s after. Use `waitForXrayVersion(t, ctx, client)` poll-loop in any acc-test probing version after them (#280) |
 | `GetXrayVersions` hits GitHub anonymously | 3x-ui's `getXrayVersion` handler has no `Authorization`; 60 req/h/IP on shared runners. Use `skipOnUpstreamRateLimit(t, err)` / `testAccSkipOnXrayVersionsRateLimit(t)` to skip, not fail (#279) |
@@ -216,6 +217,11 @@ Imperative mood, concise subjects.
 - **SECURITY.md** tracks sensitive fields — add a row when adding resources that
   handle secrets.
 - **`docs/guides/`** for operational walkthroughs needing more than an `examples/` folder.
+- **`context7.json`** (repo root) controls how [Context7](https://context7.com) indexes
+  this project. It excludes the `3x-ui-<version>/` source snapshots (~1900 upstream
+  files that would otherwise drown the provider's own API in search results), `CHANGELOG.md`,
+  and build/cache artefacts, and exposes `rules` for coding agents. Update `excludeFolders`
+  whenever a new snapshot is added (see "Adding a new 3x-ui version to CI").
 
 ### Testing
 
@@ -270,3 +276,4 @@ When a new 3x-ui version is released:
 6. **`provider/testdata/upstream_contract.json`** — update `all_setting_fields`, `protocols_go_model`, `version` to match the latest 3x-ui release (used by drift tests when no local snapshot is present)
 7. **`docs/`** — if provider schema changed, update the corresponding resource/data-source doc
 8. **`CLAUDE.md`** — update the "up to vX.Y.Z" version reference if the minor line changed
+9. **`context7.json`** — add the new `3x-ui-<version>/` snapshot folder to `excludeFolders` so Context7 does not index the upstream source copy

--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://context7.com/schema/context7.json",
+  "projectTitle": "Terraform Provider for 3x-UI",
+  "description": "Terraform provider for managing 3x-ui panel inbounds, clients, settings, and Xray configuration via its HTTP API.",
+  "excludeFolders": [
+    "3x-ui-3.0.2",
+    "3x-ui-3.1.0",
+    "3x-ui-3.2.0",
+    "3x-ui-3.3.0",
+    "3x-ui-3.3.1",
+    ".cache",
+    ".claude",
+    ".git",
+    "node_modules"
+  ],
+  "excludeFiles": [
+    "CHANGELOG.md",
+    "coverage.out",
+    "go.sum",
+    ".DS_Store"
+  ],
+  "rules": [
+    "This repository is a Terraform Provider (type name `threexui`), NOT the 3x-ui panel. Users manage resources/data sources such as threexui_inbound, threexui_inbound_client, threexui_panel_*, and threexui_xray_*.",
+    "Resources/data sources are built with terraform-plugin-framework (not SDKv2). Schema helpers live in provider/<area>_schema.go.",
+    "JSON string fields (settings, stream_settings, sniffing) convert through three layers: typed model (types.String/Int64/Bool) <-> untyped map <-> JSON string. See provider/settings.go and provider/stream_settings.go.",
+    "The 3x-ui-<version>/ directories are read-only upstream source snapshots used only to verify API/struct truth for drift tests. Never cite their code as the provider's own API.",
+    "Supported 3x-ui versions: v3.1.x, v3.2.x, v3.3.x (up to v3.3.1). Version-specific features are gated with requireMinVersion in acceptance tests."
+  ]
+}


### PR DESCRIPTION
## Summary

Two doc/config improvements surfaced by a documentation audit + Context7 best-practices research (https://context7.com/docs/adding-libraries).

### 1. Add `context7.json` to focus the Context7 index

The repo is already indexed by Context7 (`/batonogov/terraform-provider-threexui`, 311 snippets, reputation 8.7), but it had **no `context7.json`**, so Context7 parsed every file — including the five `3x-ui-<version>/` upstream source snapshots (~1900 Go/TS/Vue files), `CHANGELOG.md`, `go.sum`, and build/cache artefacts. This drowns the provider's own API in search results and pollutes the snippets returned to coding agents.

The new config:
- **`excludeFolders`** — the five `3x-ui-*` snapshots, plus `.cache`, `.claude`, `.git`, `node_modules`
- **`excludeFiles`** — `CHANGELOG.md`, `coverage.out`, `go.sum`, `.DS_Store`
- **`projectTitle`** + **`description`** — accurate metadata instead of LLM guessing
- **`rules`** — orient coding agents: "this is the provider, not the panel"; `terraform-plugin-framework`; three-layer JSON conversion; snapshots are upstream truth only; supported version range
- **`$schema`** — editor validation/autocomplete

### 2. Document `panel_outbound` vs `panel_proxy` in `CLAUDE.md`

Surfaced during the doc audit (#283 shipped `panel_outbound` but the gotcha was missing from `CLAUDE.md`):

- **Critical Gotchas** — `panel_outbound`/`panel_proxy` is version-specific. 3x-ui v3.3.1 renamed `panelProxy`→`panelOutbound` and changed semantics (Xray outbound/balancer tag instead of HTTP/SOCKS5 URL). `panel_proxy` is retained for v3.2.0–v3.3.0 and marked `Deprecated`; both coexist safely (gin ignores unknown JSON fields per version).
- **Conventions** + **"Adding a new 3x-ui version to CI"** — describe `context7.json` maintenance so future snapshots are excluded from the index.

The user-facing docs (`docs/resources/panel_general.md`, `docs/guides/version-compatibility.md`) were already accurate — no changes needed there.

## Changed files

- `context7.json` (new)
- `CLAUDE.md` (+7 lines)

## Checks

- `python3 -c json.load` → JSON valid
- `markdownlint-cli2 CLAUDE.md` → clean
- pre-commit hooks (merge-conflicts, case-conflicts, large-files) → Passed
- No Go source touched → no build/test impact

## Notes

- Re-indexing by Context7 happens automatically after merge to `main`; can be force-refreshed via the admin panel after claiming the library.
- Docs-only PR per Conventional Commits (`docs:`).
