### PR TITLE
fix: emit real deprecation warning for panel_proxy

### DIFF
--- a/provider/resource_settings_tabs.go
+++ b/provider/resource_settings_tabs.go
@@ -961,7 +961,8 @@ func panelGeneralSchema() schema.Schema {
 					"checks, Telegram bot, outbound testing). Available on 3x-ui v3.2.0 through v3.3.0; " +
 					"superseded by panel_outbound (outbound egress bridge) on v3.3.1+. " +
 					"Ignored by v3.3.1+ panels.",
-				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+				PlanModifiers:      []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+				DeprecationMessage: "Superseded by panel_outbound on 3x-ui v3.3.1+. Use panel_outbound for new configurations.",
 			},
 			"panel_outbound": schema.StringAttribute{
 				Optional:      true,


### PR DESCRIPTION
## Summary

Surfaced during the review of #287: `panel_proxy` was documented as **Deprecated** in `docs/resources/panel_general.md` and `CLAUDE.md`, but the schema attribute itself did not set `DeprecationMessage`. As a result, Terraform CLI did **not** emit a real deprecation warning when users referenced `panel_proxy` in a configuration — the deprecation existed only in prose, not in runtime behaviour.

## Change

Add `DeprecationMessage` to the `panel_proxy` `schema.StringAttribute` so the runtime behaviour matches the documentation:

```diff
 "panel_proxy": schema.StringAttribute{
     Optional:  true,
     Computed:  true,
     Description: "...superseded by panel_outbound (outbound egress bridge) on v3.3.1+...",
-    PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+    PlanModifiers:      []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+    DeprecationMessage: "Superseded by panel_outbound on 3x-ui v3.3.1+. Use panel_outbound for new configurations.",
 },
```

After this change, `terraform plan`/`apply` will surface a standard Terraform deprecation warning for any config still using `panel_proxy`, guiding users to migrate to `panel_outbound` on 3x-ui v3.3.1+.

## Context

- 3x-ui v3.3.1 renamed `panelProxy` → `panelOutbound` and changed its semantics (Xray outbound/balancer tag instead of an HTTP/SOCKS5 URL). `panel_proxy` is retained for v3.2.0–v3.3.0 panels. (Introduced in #283.)
- This is the follow-up code change to close the docs-vs-schema mismatch noted as a nit in the #287 review.

## Changed files

- `provider/resource_settings_tabs.go` (+1 line, reformatted alignment)

## Checks

- `go build ./...` → pass
- `go vet ./...` → pass
- `gofmt -l provider/resource_settings_tabs.go` → clean
- `go test ./provider -run 'TestPanelGeneral|TestSettings|TestPanelSchema|TestPanelGeneralSchemaAttributeShape'` → pass
- `go test ./provider -run 'TestDrift'` → pass
- pre-commit hooks → Passed

## Notes

Behavioural change for end users only in that a deprecation warning now appears where it was already documented to exist — no removal, no semantic change. `panel_proxy` continues to work exactly as before.
