### PR TITLE
fix: emit deprecation warnings for remaining deprecated attributes

### DIFF
--- a/provider/resource_settings_tabs.go
+++ b/provider/resource_settings_tabs.go
@@ -404,7 +404,8 @@ func panelSubscriptionSchema() schema.Schema {
 					"`{\"packets\":\"tlshello\",\"length\":\"100-200\",\"interval\":\"10-20\"}`. " +
 					"**v2.9.1 and earlier:** full outbound object with tag, protocol, settings and streamSettings. " +
 					"Deprecated in 3x-ui v3.2.8 — replaced by sub_clash_enable_routing.",
-				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+				PlanModifiers:      []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+				DeprecationMessage: "Deprecated in 3x-ui v3.2.8. Use sub_clash_enable_routing instead.",
 			},
 			"sub_json_noises": schema.StringAttribute{
 				Optional: true, Computed: true,
@@ -413,7 +414,8 @@ func panelSubscriptionSchema() schema.Schema {
 					"`[{\"type\":\"rand\",\"packet\":\"10-20\",\"delay\":\"10-16\"}]`. " +
 					"**v2.9.1 and earlier:** full outbound object with tag, protocol, settings and streamSettings. " +
 					"Deprecated in 3x-ui v3.2.8 — replaced by sub_clash_rules.",
-				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+				PlanModifiers:      []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+				DeprecationMessage: "Deprecated in 3x-ui v3.2.8. Use sub_clash_rules instead.",
 			},
 			"sub_json_mux": schema.StringAttribute{
 				Optional: true, Computed: true,

--- a/provider/xray_outbound_freedom.go
+++ b/provider/xray_outbound_freedom.go
@@ -39,6 +39,7 @@ func freedomSettingsBlock() schema.ListNestedBlock {
 					PlanModifiers: []planmodifier.List{
 						listplanmodifier.UseStateForUnknown(),
 					},
+					DeprecationMessage: "Deprecated. Use final_rule on 3x-ui v2.9.4+ instead.",
 				},
 			},
 			Blocks: map[string]schema.Block{


### PR DESCRIPTION
## Summary

Completes the deprecation-message consistency follow-up started in #288. Three more attributes were documented as **Deprecated** in their `Description` text but did not set `DeprecationMessage` on the schema, so Terraform CLI did not emit a real deprecation warning when users referenced them.

## Changes

| Attribute | Type | Resource | Deprecation |
|---|---|---|---|
| `sub_json_fragment` | `StringAttribute` | `panel_subscription` | Deprecated in 3x-ui v3.2.8 → `sub_clash_enable_routing` |
| `sub_json_noises` | `StringAttribute` | `panel_subscription` | Deprecated in 3x-ui v3.2.8 → `sub_clash_rules` |
| `ips_blocked` | `ListAttribute` | `xray_outbounds` (freedom block) | Deprecated legacy list → `final_rule` on v2.9.4+ |

Each `DeprecationMessage` mirrors the wording already present in the attribute's `Description`, so runtime behaviour now matches the documentation. After this change, `terraform plan`/`apply` surfaces a standard Terraform deprecation warning for any config still using these attributes.

```diff
 "sub_json_fragment": schema.StringAttribute{
     ...
     Description: "...Deprecated in 3x-ui v3.2.8 — replaced by sub_clash_enable_routing.",
-    PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+    PlanModifiers:      []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+    DeprecationMessage: "Deprecated in 3x-ui v3.2.8. Use sub_clash_enable_routing instead.",
 },
```

## Context

- Follow-up to #288 (`panel_proxy`), which itself closed the nit from the #287 review.
- Verified via Context7 that `DeprecationMessage` is a valid field on all `schema.Attribute` types in `terraform-plugin-framework`, including `ListAttribute`.

## Changed files

- `provider/resource_settings_tabs.go` (+4/−2)
- `provider/xray_outbound_freedom.go` (+1)

## Checks

- `go build ./...` → pass
- `go vet ./...` → pass
- `gofmt -l` → clean
- `go test ./provider -run 'TestPanelSubscription|TestXrayOutbounds|TestOutbound|TestFreedom|TestDrift|TestSettings'` → pass
- pre-commit hooks → Passed

## Notes

Behavioural change for end users is limited to a deprecation warning now appearing where it was already documented to exist — no removal, no semantic change. These attributes continue to work exactly as before.
