### PR TITLE
fix(settings): restart panel when subscription server settings change

### DIFF
--- a/provider/resource_settings_tabs.go
+++ b/provider/resource_settings_tabs.go
@@ -2144,6 +2144,16 @@ func panelSettingsNeedRestart(existing, desired map[string]any) bool {
 		"webCertFile",
 		"webKeyFile",
 		"sessionMaxAge",
+		// Subscription server binding — parallels the web* keys above. The sub server is
+		// (re)initialised at panel startup, so changing whether/where it listens needs a
+		// panel restart; without it the subscription URL 404s until the panel is restarted.
+		"subEnable",
+		"subListen",
+		"subDomain",
+		"subPort",
+		"subPath",
+		"subCertFile",
+		"subKeyFile",
 	}
 	for _, key := range restartKeys {
 		newVal, ok := desired[key]

--- a/provider/settings_tabs_test.go
+++ b/provider/settings_tabs_test.go
@@ -83,6 +83,27 @@ func TestPanelSettingsNeedRestart_NoRestartKeys(t *testing.T) {
 	}
 }
 
+func TestPanelSettingsNeedRestart_SubscriptionServerKey(t *testing.T) {
+	// Toggling/changing the subscription server must trigger a panel restart — the sub
+	// server is initialised at panel startup, so otherwise the subscription URL 404s.
+	if !panelSettingsNeedRestart(map[string]any{"subEnable": false}, map[string]any{"subEnable": true}) {
+		t.Fatalf("expected restart when the subscription server is enabled")
+	}
+	if !panelSettingsNeedRestart(map[string]any{"subPath": "/old/"}, map[string]any{"subPath": "/new/"}) {
+		t.Fatalf("expected restart when the subscription path changes")
+	}
+	if !panelSettingsNeedRestart(map[string]any{"subPort": float64(2096)}, map[string]any{"subPort": float64(2097)}) {
+		t.Fatalf("expected restart when the subscription port changes")
+	}
+}
+
+func TestPanelSettingsNeedRestart_SubscriptionLinkKeyNoRestart(t *testing.T) {
+	// Link-generation settings (read at request time) must NOT force a restart.
+	if panelSettingsNeedRestart(map[string]any{"subURI": "https://a/"}, map[string]any{"subURI": "https://b/"}) {
+		t.Fatalf("expected no restart for subURI (link-generation only)")
+	}
+}
+
 func TestSettingsValueEqual_Strings(t *testing.T) {
 	if !settingsValueEqual("abc", "abc") {
 		t.Fatalf("expected equal")


### PR DESCRIPTION
Fixes #291.

### Problem

`panelSettingsNeedRestart` only triggers a panel restart for the `web*` server keys, so
changing the **subscription server** (via `threexui_panel_subscription`: `sub_enable`,
`sub_port`, `sub_path`, …) updates the settings without restarting the panel. The 3x-ui
sub server is initialised at panel startup, so the subscription URL returns **404** until
the panel is restarted manually.

### Change

Add the subscription server-binding keys to `restartKeys`, mirroring the existing `web*`
set:

```
subEnable, subListen, subDomain, subPort, subPath, subCertFile, subKeyFile
```

Link-generation settings (`subURI`, `subTitle`, `subJsonEnable`, …) are read per request
and intentionally **not** added (no restart needed).

### Tests

`provider/settings_tabs_test.go`:
- `TestPanelSettingsNeedRestart_SubscriptionServerKey` — `subEnable`/`subPath`/`subPort` changes require a restart.
- `TestPanelSettingsNeedRestart_SubscriptionLinkKeyNoRestart` — `subURI` change does not.

`gofmt` clean, `go build ./...` and `go test ./provider/ -run NeedRestart` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)