### PR TITLE
docs: note panel-restart side effect in threexui_panel_subscription

### DIFF
--- a/docs/resources/panel_subscription.md
+++ b/docs/resources/panel_subscription.md
@@ -11,6 +11,8 @@ Manages the subscription service settings of the 3x-ui panel.
 
 This is a singleton resource -- only one instance should exist per provider. Deleting this resource only removes it from Terraform state; it does not reset the settings.
 
+~> **Note:** Changing any subscription **server-binding** field — `sub_enable`, `sub_listen`, `sub_domain`, `sub_port`, `sub_path`, `sub_cert_file`, `sub_key_file` — triggers a panel restart and therefore brief panel downtime. The 3x-ui subscription server is only (re)initialised at panel startup, so changing whether or where it listens needs a restart to take effect; without it the subscription URL keeps returning 404 until the panel is restarted manually. Link-generation and display fields (for example `sub_uri`, `sub_title`, `sub_json_enable`, `sub_encrypt`, `sub_show_info`) are read on every request and do **not** trigger a restart.
+
 ~> **Note:** When `sub_port` (default `2096`) differs from the main panel port and the panel runs behind a reverse proxy, the proxy must be configured to forward subscription path requests to the subscription port. Without this, subscription URLs will return 404.
 
 **Caddy** example:


### PR DESCRIPTION
## What & Why

Follow-up to #292 (fix for #291). PR #292 added the subscription server-binding keys (`subEnable`, `subListen`, `subDomain`, `subPort`, `subPath`, `subCertFile`, `subKeyFile`) to `panelSettingsNeedRestart`, so changing them via `threexui_panel_subscription` now triggers a panel restart (brief downtime). That restart is correct behavior — the 3x-ui subscription server is only (re)initialised at panel startup, so without a restart the subscription URL keeps returning 404 — but the downtime side effect was previously undocumented, which would surprise someone tweaking "just" `sub_path` in CI.

## Change

Add a short admonition note to `docs/resources/panel_subscription.md` that:

- Lists all 7 server-binding attributes that trigger a panel restart: `sub_enable`, `sub_listen`, `sub_domain`, `sub_port`, `sub_path`, `sub_cert_file`, `sub_key_file`.
- Explains the why: the sub server is (re)initialised only at panel startup, so a restart is needed; otherwise the subscription URL 404s until a manual restart.
- Clarifies that link-generation / display fields (`sub_uri`, `sub_title`, `sub_json_enable`, `sub_encrypt`, `sub_show_info`, ...) are read per request and do **not** trigger a restart.

The note uses the existing `~> **Note:**` admonition style already present in that file (the reverse-proxy requirement for `sub_port`), and mirrors the restart-semantics precedent documented in `docs/resources/panel_general.md`. No other files are touched.

Closes #295