### PR TITLE
fix(settings): restart panel when subscription server settings change

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,13 +92,18 @@ Four resources — `panel_general`, `panel_security`, `panel_telegram`,
   returns an empty/redacted sentinel. Note: 3x-ui v3.0.2–v3.3.1 actually returns
   these secrets **raw** on `/setting/all`, so the replay path is defensive and
   mainly fires when the panel genuinely has no secret stored.
-- Changing a restart-triggering key in `panel_general` — `webListen`, `webDomain`,
-  `webPort`, `webBasePath`, `webCertFile`, `webKeyFile`, `sessionMaxAge`, and the
-  subscription-server binding keys (`subEnable`, `subListen`, `subDomain`, `subPort`,
-  `subPath`, `subCertFile`, `subKeyFile`) — triggers a provider-initiated restart
-  (`POST /setting/restartPanel`, SIGHUP; 3x-ui does **not** auto-restart). For
-  `webBasePath` the provider additionally calls `SetBasePath` + `WaitForReady` so
-  subsequent requests target the new path.
+- Changing a restart-triggering key triggers a provider-initiated restart
+  (`POST /setting/restartPanel`, SIGHUP; 3x-ui does **not** auto-restart) in two
+  resources, each gated by the shared `panelSettingsNeedRestart` check followed by
+  `SendRestart` + `WaitForReady`: `panel_general` (`webListen`, `webDomain`,
+  `webPort`, `webBasePath`, `webCertFile`, `webKeyFile`, `sessionMaxAge`) and
+  `panel_subscription` (the subscription-server binding keys `subEnable`, `subListen`,
+  `subDomain`, `subPort`, `subPath`, `subCertFile`, `subKeyFile`). The 3x-ui sub
+  server only (re)binds at startup, so without this restart a changed `sub_path`/
+  `sub_port`/… does not take effect and the subscription URL 404s (#291). Link-
+  generation fields (`subURI`, `subTitle`, …) are read per request and do **not**
+  restart. For `webBasePath` the provider additionally calls `SetBasePath` +
+  `WaitForReady` so subsequent requests target the new path.
 
 ### Write-only secret attributes (Terraform 1.11+ / OpenTofu 1.11+)
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,6 +3,11 @@ services:
     image: ghcr.io/mhsanaei/3x-ui:${THREEXUI_VERSION:-v3.3.1}
     ports:
       - "2053:2053" # HTTP panel
+      # Subscription server port, published so acceptance tests can probe the
+      # subscription endpoint after a provider-triggered panel restart
+      # (see TestAccPanelSubscription_RestartsPanel / #291). Only bound when
+      # the subscription server is enabled, so it is inert for other acc tests.
+      - "2096:2096"
     environment:
       XRAY_VMESS_AEAD_FORCED: "false"
       XUI_ENABLE_FAIL2BAN: "true"

--- a/provider/acc_panel_subscription_test.go
+++ b/provider/acc_panel_subscription_test.go
@@ -1,0 +1,151 @@
+package provider
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// TestAccPanelSubscription_RestartsPanel is the end-to-end regression guard for #291.
+//
+// #292 claimed to fix #291 by adding the subscription server-binding keys to
+// panelSettingsNeedRestart, but it never wired the restart into applySubscription,
+// so a change to a server-binding field (sub_port/sub_path/sub_listen/…) was
+// written to the database without the 3x-ui subscription server actually
+// rebinding — the sub server kept serving the OLD path/port until a manual panel
+// restart.
+//
+// Why sub_path (not sub_enable/sub_port): 3x-ui v3.x ships with subEnable=true,
+// subPort=2096 and subPath="/sub/" by DEFAULT (see 3x-ui/internal/web/service/
+// setting.go defaults), so the sub server is already listening on :2096 from a
+// fresh start and merely re-asserting those defaults would not exercise the
+// restart path. Changing sub_path to a NON-default value ("/sub2/") forces a
+// router re-registration that only happens at sub-server startup (3x-ui/internal/
+// sub/sub.go initRouter(), called from Start()), i.e. only after a panel restart.
+//
+// The test applies a non-default sub_path together with a real inbound client so
+// we have a valid subscription id, then GETs the subscription endpoint under the
+// NEW path. After the provider-triggered panel restart the sub server serves the
+// client's page there (200); without the restart the router still has the old
+// path and the request 404s. A bounded poll covers the panel-restart window.
+//
+// Why 200 rather than "not 404": the 3x-ui subscription handler returns 404 for
+// an UNKNOWN subId (see 3x-ui/internal/sub/controller.go), so "non-404" would be
+// an unreliable success signal. With a real client's subId and the correct path
+// the handler serves the subscription page (200) — the actual user-visible
+// contract (the subscription URL works).
+//
+// Requires the subscription port to be published from the acc-test container —
+// see the "2096:2096" port mapping in docker-compose.yaml.
+func TestAccPanelSubscription_RestartsPanel(t *testing.T) {
+	// The subscription server + its link-generation page exist in all supported
+	// 3x-ui lines (v3.1.x–v3.3.x); no version guard needed.
+
+	const subPort = 2096
+	const subPath = "/sub2/"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProviderConfig() + fmt.Sprintf(`
+resource "threexui_panel_subscription" "sub" {
+  sub_enable      = true
+  sub_listen      = ""
+  sub_domain      = ""
+  sub_port        = %d
+  sub_path        = %q
+  sub_cert_file   = ""
+  sub_key_file    = ""
+  sub_json_enable = true
+}
+
+resource "threexui_inbound" "host" {
+  port     = 25210
+  protocol = "vless"
+  remark   = "acc-sub-restart-host"
+  enable   = true
+  vless_settings {
+    decryption = "none"
+  }
+  stream_settings {
+    network  = "tcp"
+    security = "reality"
+    reality_settings {
+      target       = "google.com:443"
+      server_names = ["google.com"]
+    }
+  }
+}
+
+resource "threexui_inbound_client" "cli" {
+  inbound_id = threexui_inbound.host.id
+  email      = "sub-restart@test.com"
+  enable     = true
+}
+`, subPort, subPath),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("threexui_panel_subscription.sub", "sub_path", subPath),
+					resource.TestCheckResourceAttrWith("threexui_inbound_client.cli", "sub_id", func(subID string) error {
+						if subID == "" {
+							return fmt.Errorf("client sub_id is empty; cannot probe subscription endpoint")
+						}
+						subURL := subscriptionTestURL(t, subPort, subPath, subID)
+						return waitForSubscriptionReady(t, subURL)
+					}),
+				),
+			},
+		},
+	})
+}
+
+// subscriptionTestURL builds the subscription endpoint URL for the acc-test.
+// Host is taken from THREEXUI_ENDPOINT (defaults to localhost when unset/unparseable);
+// the subscription server is published on its own port. subPath is "/"-surrounded
+// (e.g. "/sub2/"); the route is registered as <subPath>:subid (see sub.go initRouter),
+// so the final URL is host:port/<subPath without trailing slash>/<subId>.
+func subscriptionTestURL(t *testing.T, subPort int, subPath, subID string) string {
+	t.Helper()
+	host := "localhost"
+	if ep := os.Getenv("THREEXUI_ENDPOINT"); ep != "" {
+		if u, err := url.Parse(ep); err == nil && u.Hostname() != "" {
+			host = u.Hostname()
+		}
+	}
+	return fmt.Sprintf("http://%s:%d%s/%s", host, subPort, strings.TrimRight(subPath, "/"), subID)
+}
+
+// waitForSubscriptionReady polls the subscription endpoint until it answers
+// with HTTP 200 (the sub server rebound and serves the client's subscription
+// page under the new path), covering the panel-restart window. Bounded to ~60s.
+func waitForSubscriptionReady(t *testing.T, subURL string) error {
+	t.Helper()
+	client := &http.Client{Timeout: 3 * time.Second}
+	const (
+		attempts = 60
+		wait     = 1 * time.Second
+	)
+	var lastErr error
+	for i := 0; i < attempts; i++ {
+		resp, err := client.Get(subURL)
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				t.Logf("subscription endpoint ready at %s after %d attempt(s)", subURL, i+1)
+				return nil
+			}
+			lastErr = fmt.Errorf("subscription endpoint returned HTTP %d (want 200)", resp.StatusCode)
+		} else {
+			lastErr = fmt.Errorf("subscription endpoint not reachable: %w", err)
+		}
+		time.Sleep(wait)
+	}
+	return fmt.Errorf("subscription endpoint not ready after %d attempts: %w", attempts, lastErr)
+}

--- a/provider/apply_subscription_test.go
+++ b/provider/apply_subscription_test.go
@@ -1,0 +1,189 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// TestApplySubscription_RestartsOnServerKeyChange is the regression guard for #291.
+//
+// It runs applySubscription against a stub 3x-ui (httptest) that records
+// /setting/restartPanel calls, and asserts that:
+//
+//   - changing a subscription SERVER-BINDING key (subEnable/subListen/subDomain/
+//     subPort/subPath/subCertFile/subKeyFile) triggers exactly one panel restart;
+//   - changing a LINK-GENERATION key only (subURI) triggers NO restart.
+//
+// Before the fix, applySubscription never called SendRestart on the subscription
+// path, so the subscription server did not rebind and the subscription URL kept
+// 404-ing until a manual panel restart (#291). The unit tests on
+// panelSettingsNeedRestart protect the key LIST; this test protects the
+// end-to-end "restart is actually invoked" contract.
+func TestApplySubscription_RestartsOnServerKeyChange(t *testing.T) {
+	t.Parallel()
+
+	type tc struct {
+		name        string
+		existing    map[string]any
+		plan        PanelSubscriptionModel
+		wantRestart int32
+	}
+
+	// Build a plan model from a partial settings payload. Only the keys present
+	// in the map are set on the model; everything else stays null/unknown so
+	// expandPanelSubscription emits exactly those keys.
+	mkPlan := func(payload map[string]any) PanelSubscriptionModel {
+		m := PanelSubscriptionModel{}
+		if v, ok := payload["subEnable"]; ok {
+			m.SubEnable = types.BoolValue(v.(bool))
+		}
+		if v, ok := payload["subEnableRouting"]; ok {
+			m.SubEnableRouting = types.BoolValue(v.(bool))
+		}
+		if v, ok := payload["subListen"]; ok {
+			m.SubListen = types.StringValue(v.(string))
+		}
+		if v, ok := payload["subPort"]; ok {
+			m.SubPort = types.Int64Value(int64(v.(int)))
+		}
+		if v, ok := payload["subPath"]; ok {
+			m.SubPath = types.StringValue(v.(string))
+		}
+		if v, ok := payload["subDomain"]; ok {
+			m.SubDomain = types.StringValue(v.(string))
+		}
+		if v, ok := payload["subCertFile"]; ok {
+			m.SubCertFile = types.StringValue(v.(string))
+		}
+		if v, ok := payload["subKeyFile"]; ok {
+			m.SubKeyFile = types.StringValue(v.(string))
+		}
+		if v, ok := payload["subURI"]; ok {
+			m.SubURI = types.StringValue(v.(string))
+		}
+		return m
+	}
+
+	cases := []tc{
+		{
+			name:        "enable subscription server (first apply)",
+			existing:    map[string]any{},
+			plan:        mkPlan(map[string]any{"subEnable": true, "subPort": 2096, "subPath": "/sub/"}),
+			wantRestart: 1,
+		},
+		{
+			name:        "change subscription port",
+			existing:    map[string]any{"subEnable": true, "subPort": float64(2096)},
+			plan:        mkPlan(map[string]any{"subPort": 2097}),
+			wantRestart: 1,
+		},
+		{
+			name:        "change subscription path",
+			existing:    map[string]any{"subPath": "/sub/"},
+			plan:        mkPlan(map[string]any{"subPath": "/sub2/"}),
+			wantRestart: 1,
+		},
+		{
+			name:        "change subscription listen address",
+			existing:    map[string]any{"subEnable": true, "subListen": "0.0.0.0"},
+			plan:        mkPlan(map[string]any{"subListen": "127.0.0.1"}),
+			wantRestart: 1,
+		},
+		{
+			name:        "disable subscription server",
+			existing:    map[string]any{"subEnable": true},
+			plan:        mkPlan(map[string]any{"subEnable": false}),
+			wantRestart: 1,
+		},
+		{
+			name:        "link-generation key only (subURI) does NOT restart",
+			existing:    map[string]any{"subURI": "https://old.example/sub/"},
+			plan:        mkPlan(map[string]any{"subURI": "https://new.example/sub/"}),
+			wantRestart: 0,
+		},
+		{
+			name:        "no-op plan (identical) does NOT restart",
+			existing:    map[string]any{"subEnable": true, "subPort": float64(2096)},
+			plan:        mkPlan(map[string]any{"subEnable": true, "subPort": 2096}),
+			wantRestart: 0,
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			var restarts int32
+			mu := sync.Mutex{}
+			server := make(map[string]any)
+			for k, v := range c.existing {
+				server[k] = v
+			}
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/login":
+					w.Write(okResponse(nil))
+					return
+				case "/panel/api/setting/all":
+					// GetSettings: return the current server settings (new-API surface;
+					// also satisfies the one-shot useSettingsAPI probe).
+					mu.Lock()
+					snapshot := make(map[string]any, len(server))
+					for k, v := range server {
+						snapshot[k] = v
+					}
+					mu.Unlock()
+					w.Write(okResponse(snapshot))
+					return
+				case "/panel/api/setting/update":
+					var in map[string]any
+					_ = json.NewDecoder(r.Body).Decode(&in)
+					mu.Lock()
+					for k, v := range in {
+						server[k] = v
+					}
+					mu.Unlock()
+					w.Write(okResponse(nil))
+					return
+				case "/panel/api/setting/restartPanel":
+					atomic.AddInt32(&restarts, 1)
+					w.Write(okResponse(nil))
+					return
+				default:
+					w.WriteHeader(http.StatusNotFound)
+					return
+				}
+			}))
+			defer srv.Close()
+
+			client := newTestClient(t, srv.URL)
+			// Pin the new-API surface so settingPath() resolves to /panel/api/setting/*
+			// without a probe round-trip (matches TestSendRestartFallsBackOn404).
+			client.settingsAPIMu.Lock()
+			v := true
+			client.settingsUnderAPI = &v
+			client.settingsAPIMu.Unlock()
+
+			r := &PanelSubscriptionResource{client: client}
+			var d diag.Diagnostics
+			r.applySubscription(context.Background(), &c.plan, &d)
+
+			if d.HasError() {
+				t.Fatalf("applySubscription returned errors: %v", d.Errors())
+			}
+			if got := atomic.LoadInt32(&restarts); got != c.wantRestart {
+				t.Fatalf("restartPanel calls = %d, want %d", got, c.wantRestart)
+			}
+		})
+	}
+}

--- a/provider/client.go
+++ b/provider/client.go
@@ -946,15 +946,29 @@ func (c *Client) WaitForReady(ctx context.Context) error {
 	const (
 		interval = 2 * time.Second
 		timeout  = 30 * time.Second
+		// 3x-ui restarts its web server asynchronously after /setting/restartPanel:
+		// the SIGHUP is delivered to a channel and the main loop does Stop()+Start()
+		// in a goroutine (see main.go), so the old socket can briefly still answer
+		// before being torn down. A single successful login is therefore racy — a
+		// caller can observe "ready" on the dying socket and then hit a connection
+		// reset a moment later. Require a few CONSECUTIVE successes so the restart
+		// has actually settled.
+		consecutiveRequired = 3
 	)
 	deadline := time.Now().Add(timeout)
+	streak := 0
 	for {
 		if time.Now().After(deadline) {
 			return errors.New("panel did not become ready after restart")
 		}
 		// Try to login — this also verifies the panel is reachable.
 		if err := c.Login(ctx); err == nil {
-			return nil
+			streak++
+			if streak >= consecutiveRequired {
+				return nil
+			}
+		} else {
+			streak = 0
 		}
 		select {
 		case <-ctx.Done():

--- a/provider/resource_settings_tabs.go
+++ b/provider/resource_settings_tabs.go
@@ -2102,16 +2102,23 @@ func (r *PanelSubscriptionResource) applySubscription(ctx context.Context, plan 
 	}
 
 	settingsMu.Lock()
-	defer settingsMu.Unlock()
 
 	// First apply.
 	existing, err := r.client.GetSettings(ctx)
 	if err != nil {
+		settingsMu.Unlock()
 		diags.AddError("Failed to get settings", err.Error())
 		return
 	}
+	// Detect whether a server-binding key changed (subEnable/subListen/subDomain/
+	// subPort/subPath/subCertFile/subKeyFile). The 3x-ui subscription server is only
+	// (re)initialised at panel startup (see 3x-ui/internal/sub/sub.go Start()+initRouter()),
+	// so without a panel restart the subscription port stays closed / the URL 404s
+	// until the panel is restarted by hand (#291).
+	needRestart := panelSettingsNeedRestart(existing, desired)
 	merged := mergeSettingsForUpdate(r.client, existing, desired)
 	if err := r.client.UpdateSettings(ctx, merged); err != nil {
+		settingsMu.Unlock()
 		diags.AddError("Failed to update settings", err.Error())
 		return
 	}
@@ -2120,15 +2127,32 @@ func (r *PanelSubscriptionResource) applySubscription(ctx context.Context, plan 
 	// Second apply (workaround for 3x-ui bug).
 	existing2, err := r.client.GetSettings(ctx)
 	if err != nil {
+		settingsMu.Unlock()
 		diags.AddError("Failed to get settings (second apply)", err.Error())
 		return
 	}
 	merged2 := mergeSettingsForUpdate(r.client, existing2, desired)
 	if err := r.client.UpdateSettings(ctx, merged2); err != nil {
+		settingsMu.Unlock()
 		diags.AddError("Failed to update settings (second apply)", err.Error())
 		return
 	}
 	r.client.rememberConfiguredSettingSecrets(desired)
+	settingsMu.Unlock()
+
+	// Restart the panel (outside the settings lock) so the subscription server
+	// rebinds with the new settings. Mirrors applyPanelGeneral. No base-path
+	// handling here — the subscription server does not share the panel's webBasePath.
+	if needRestart {
+		if err := r.client.SendRestart(ctx); err != nil {
+			diags.AddError("Failed to restart panel", err.Error())
+			return
+		}
+		if err := r.client.WaitForReady(ctx); err != nil {
+			diags.AddError("Panel did not become ready after restart", err.Error())
+			return
+		}
+	}
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #294. Actually fixes the bug behind #291 (which #292 did not).

## Problem

#292 claimed to fix #291 by adding the subscription server-binding keys (`subEnable`, `subListen`, `subDomain`, `subPort`, `subPath`, `subCertFile`, `subKeyFile`) to `panelSettingsNeedRestart`. But that change was **inert**:

- `panelSettingsNeedRestart` is only called from `applyPanelGeneral`, and `expandPanelGeneral` never emits `sub*` keys → the restart branch on the subscription path was never wired.
- `applySubscription` only did the double `UpdateSettings` (the `subJsonEnable` workaround) and never called `SendRestart`.

So changing the subscription server via `threexui_panel_subscription` updated the DB without a panel restart. The 3x-ui sub server only (re)binds at startup (`3x-ui/internal/sub/sub.go` `Start()`+`initRouter()`), so the subscription URL kept 404ing / serving the old path until a manual panel restart. **#291 was never actually fixed.**

Discovered while working #294 (the requested end-to-end acc test): the test failed against `main` with the pre-fix code.

## Fix (2 commits)

1. **`fix(settings): restart panel when subscription server settings change`** — wire the restart into `applySubscription`, mirroring `applyPanelGeneral`: gated by `panelSettingsNeedRestart`, then `SendRestart` + `WaitForReady` (outside the settings lock). Link-generation fields (`subURI`, `subTitle`, …) remain non-restarting.

2. **`fix(client): make WaitForReady ride out the async SIGHUP restart race`** — the first CI run exposed a flake. After `SendRestart`, 3x-ui restarts its web server asynchronously (SIGHUP → channel → main loop `Stop()`+`Start()` in `3x-ui/main.go`), so the OLD socket can briefly still answer before teardown. `WaitForReady` returned on the first successful login (dying socket), and the next operation hit "connection reset by peer" against `:2053`. Now it requires a few **consecutive** successful logins (3 × 2s) before declaring ready. The 30s overall timeout is unchanged; this adds ~4-6s of settle time per panel restart. **Bonus:** this also killed the pre-existing `TestAccPanelSecurityWriteOnlyUpdate` flake (also restart-induced).

## Tests (verified to FAIL without the fix)

- **`provider/apply_subscription_test.go`** — unit-level regression guard. An `httptest` stub records `/setting/restartPanel` calls and asserts `SendRestart` fires exactly once for each server-binding key change (enable/disable, port, path, listen, …) and zero times for link-generation keys. Confirmed red (5 restart cases → 0 calls) when the restart block is removed.
- **`provider/acc_panel_subscription_test.go`** — `TestAccPanelSubscription_RestartsPanel` end-to-end. Applies a **non-default** `sub_path` (`/sub2/`) with a real inbound client, then GETs `http://host:2096/sub2/<subId>` and asserts HTTP 200 (the sub server rebound under the new path). Uses `sub_path` rather than `sub_enable`/`sub_port` because 3x-ui v3.x ships `subEnable=true`/`subPort=2096`/`subPath="/sub/"` by default, so the server is already up on a fresh panel and only a path change forces a router re-registration (`initRouter`). A bounded poll (~60s) covers the panel-restart window. Confirmed red (404 after 60 attempts) when the restart block is removed.
- `docker-compose.yaml`: publish `2096` so the acc test can reach the sub server from the host.

## Local validation

`task test:acc` ×3 (full Docker lifecycle, canonical path per AGENTS.md): **all clean, 0 FAIL** — including `TestAccPanelSubscription_v328` (was flaky after the first commit, fixed by the `WaitForReady` change) and `TestAccPanelSecurityWriteOnlyUpdate` (pre-existing flake, also fixed).

## Docs

`AGENTS.md`: corrected the panel-settings restart note — the `sub*` keys restart via `panel_subscription` (not `panel_general`, which never emits them). This also makes the note added in #299 (`docs/resources/panel_subscription.md`) truthful.